### PR TITLE
added rate-limiting to APIs

### DIFF
--- a/src/middlewares/rateLimiter.ts
+++ b/src/middlewares/rateLimiter.ts
@@ -1,0 +1,49 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+const rateLimitMap = new Map<
+  string,
+  { count: number; lastRequestTime: number }
+>();
+
+const REQUEST_LIMIT = 3; // Maximum requests
+const WINDOW_SIZE_IN_MS = 60 * 1000; // 1 minute
+
+// Rate limiter middleware function that wraps a handler
+const rateLimiter = (
+  handler: (req: NextApiRequest, res: NextApiResponse) => void
+) => {
+  return (req: NextApiRequest, res: NextApiResponse) => {
+    const ip =
+      req.headers['x-forwarded-for']?.toString() ||
+      req.socket.remoteAddress ||
+      'unknown';
+
+    const currentTime = Date.now();
+
+    const ipData = rateLimitMap.get(ip) || {
+      count: 0,
+      lastRequestTime: currentTime,
+    };
+
+    if (currentTime - ipData.lastRequestTime < WINDOW_SIZE_IN_MS) {
+      if (ipData.count >= REQUEST_LIMIT) {
+        res
+          .status(429)
+          .json({ message: 'Too many requests, please try again later.' });
+        return;
+      }
+
+      ipData.count += 1;
+    } else {
+      ipData.count = 1;
+      ipData.lastRequestTime = currentTime;
+    }
+
+    rateLimitMap.set(ip, ipData);
+
+    // Calling the original handler
+    handler(req, res);
+  };
+};
+
+export default rateLimiter;


### PR DESCRIPTION
Implemented rate limiting for APIs to enhance performance and mitigate abuse.

**Key Changes:**

- Added a middleware function (`rateLimiter`) that tracks the number of requests per IP address.
- Set a limit of **3 requests per minute** per IP (configurable as needed).
- Utilized an in-memory map to store request counts and timestamps for each IP.
- Responds with a **429 Too Many Requests** status when the limit is exceeded, prompting users to wait before sending more requests.
- Improved client IP detection using the `x-forwarded-for` header and `req.socket.remoteAddress`.
