### PR TITLE
Fixed Footer Alignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.8.0",
     "react-query": "^3.39.3",
-    "tbe-webapp": "file:",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.8.0",
     "react-query": "^3.39.3",
+    "tbe-webapp": "file:",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/src/components/layout/Page.tsx
+++ b/src/components/layout/Page.tsx
@@ -20,9 +20,9 @@ const PageLayout = ({ children }: PageLayoutProps) => {
   }, [router.events]);
 
   return (
-    <main className='bg-lightBG'>
+    <main className='bg-lightBG flex flex-col min-h-screen'>
       <Navbar />
-      {children}
+      <div className="flex-1">{children}</div>
       <Footer />
     </main>
   );


### PR DESCRIPTION
### **Description**

This PR resolves an alignment issue in the Explore Projects section where the footer was positioned directly under the navigation bar while the projects were still loading. 

#### **Before the Fix**
- The footer appeared immediately after the navigation bar when project content was not yet loaded (e.g., during API calls or slow network).
- This led to an awkward layout where the footer overlapped or didn't maintain its intended bottom alignment.

#### **After the Fix**
- The footer is now correctly positioned at the bottom of the page, regardless of the loading state of the projects.
- The layout remains consistent and visually appealing even during content loading.

---

### **Changes Made**
- Updated the layout structure using **Tailwind CSS** to ensure the footer stays at the bottom of the viewport when content is loading or insufficient to fill the screen.
- Adjusted the parent container with `min-h-screen`, `flex`, and `flex-col` utilities to maintain consistent alignment across all states.

---

### **Testing Steps**
1. Navigate to the Explore Projects section.
2. Observe the footer alignment while the projects are loading.
3. Verify the footer remains at the bottom of the page once the content is fully loaded.

---

### **Screenshots**
#### Before:

![Screenshot 2024-12-19 132840](https://github.com/user-attachments/assets/567468bc-e80e-4152-8269-cb8b7c60ce43)

#### After:
![Screenshot 2024-12-19 134607](https://github.com/user-attachments/assets/e58c51ce-07dd-4e06-a7ef-b36efabffdb3)

---

### **Linked Issue**
- Closes #133

---

### **Additional Notes**
- This fix improves user experience by ensuring consistent footer placement.
- No breaking changes were introduced.
