### PR TITLE
refactor: change findByIdAndUpdate to findOneAndUpdate for webinar en…

### DIFF
--- a/src/database/query/webinar.ts
+++ b/src/database/query/webinar.ts
@@ -32,8 +32,8 @@ const updateEnrolledUsersInWebinarDB = async (
   users: WebinarEnrolledUsersProps[]
 ) => {
   try {
-    const updatedWebinar = await Webinar.findByIdAndUpdate(
-      slug,
+    const updatedWebinar = await Webinar.findOneAndUpdate(
+      {slug},
       { $push: { enrolledUsersList: { $each: users } } },
       { new: true }
     );


### PR DESCRIPTION
This pull request includes a change to the `updateEnrolledUsersInWebinarDB` function in the `src/database/query/webinar.ts` file. The change modifies the method used to update the webinar data in the database.

Database update method change:

* [`src/database/query/webinar.ts`](diffhunk://#diff-7935d03ea295472bbbbcd3310da781330191283bc360b6e200ddb17a3f8e4b85L35-R36): Changed the method from `findByIdAndUpdate` to `findOneAndUpdate` for updating the webinar data based on the `slug` property enrollment and fixed : the PATCH request for handleUpdateEnrolledUsers