### PR TITLE
feat: display webinar type as "Free" or "Paid" based on isFree prop

### DIFF
--- a/src/pages/webinar/[webinarSlug]/index.tsx
+++ b/src/pages/webinar/[webinarSlug]/index.tsx
@@ -19,6 +19,7 @@ import { isProgramActive } from '@/utils';
 const WebinarPage = ({
   seoMeta,
   name,
+  isFree,
   description,
   slug,
   host,
@@ -197,7 +198,7 @@ const WebinarPage = ({
               level='span'
               className='bg-yellow-500 text-sm md:text-md lg:text-lg font-semibold p-1 px-3 mb-2 rounded-1'
             >
-              Free Webinar
+              {isFree ? "Free" : "Paid"} Webinar
             </Text>
 
             <Text


### PR DESCRIPTION
This pull request includes updates to the `WebinarPage` component in `src/pages/webinar/[webinarSlug]/index.tsx` to enhance its functionality and improve user experience. The most important changes include adding a new prop to determine if a webinar is free and updating the display text accordingly.

Enhancements to `WebinarPage` component:

* `src/pages/webinar/[webinarSlug]/index.tsx`: Added a new prop `isFree` to the `WebinarPage` component to indicate whether the webinar is free or paid. ([src/pages/webinar/[webinarSlug]/index.tsxR22](diffhunk://#diff-7968a24aa67c0c9f80428ac23643a9cbcd61936558128d0294e2d6f660633255R22))
* `src/pages/webinar/[webinarSlug]/index.tsx`: Updated the display text to show "Free" or "Paid" based on the `isFree` prop value. ([src/pages/webinar/[webinarSlug]/index.tsxL200-R201](diffhunk://#diff-7968a24aa67c0c9f80428ac23643a9cbcd61936558128d0294e2d6f660633255L200-R201))

For Paid :
![image](https://github.com/user-attachments/assets/0e739121-c100-4dfe-9ba0-b5e7ce92305d)

For Free :
![image](https://github.com/user-attachments/assets/7d944129-b69b-40e8-9722-cd8b76378bbf)
