### PR TITLE
Fix navigation lock in ResumeYatra

### DIFF
--- a/apps/resume-yatra/src/components/builder/BuilderMain.tsx
+++ b/apps/resume-yatra/src/components/builder/BuilderMain.tsx
@@ -7,6 +7,7 @@ import {
     Sparkles
 } from "lucide-react"
 import { useRouter } from "next/router"
+import { useEffect } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -34,10 +35,17 @@ export default function BuilderMain({ builder }: BuilderMainProps) {
         setShowResult
     } = builder
 
+    useEffect(() => {
+        // Ensure scroll is unlocked when leaving the builder
+        return () => {
+            document.body.style.overflow = "auto"
+        }
+    }, [])
+
     return (
-        <div className='min-h-screen bg-white'>
+        <div className='min-h-screen bg-white pt-20'>
             {/* Progress Bar */}
-            <div className='sticky top-0 z-40 bg-white/95 backdrop-blur-sm border-b border-gray-200 p-4 transition-all duration-300'>
+            <div className='sticky top-16 z-30 bg-white/95 backdrop-blur-sm border-b border-gray-200 p-4 transition-all duration-300'>
                 <div className='container mx-auto'>
                     <div className='flex items-center justify-between mb-2'>
                         <span className='text-sm font-medium text-gray-600'>
@@ -213,11 +221,10 @@ export default function BuilderMain({ builder }: BuilderMainProps) {
                                             />
                                             <label
                                                 htmlFor={item.id}
-                                                className={`text-sm font-medium cursor-pointer transition-all duration-200 ${
-                                                    item.checked
-                                                        ? "line-through text-gray-500"
-                                                        : "text-gray-900"
-                                                }`}>
+                                                className={`text-sm font-medium cursor-pointer transition-all duration-200 ${item.checked
+                                                    ? "line-through text-gray-500"
+                                                    : "text-gray-900"
+                                                    }`}>
                                                 {item.text}
                                             </label>
                                         </div>

--- a/apps/resume-yatra/src/components/builder/InitialChoice.tsx
+++ b/apps/resume-yatra/src/components/builder/InitialChoice.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle,FileText } from "lucide-react"
+import { CheckCircle, FileText } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -10,7 +10,7 @@ interface InitialChoiceProps {
 
 export default function InitialChoice({ builder }: InitialChoiceProps) {
     return (
-        <div className='min-h-screen bg-white flex items-center justify-center transition-all duration-500'>
+        <div className='min-h-screen bg-white flex items-center justify-center transition-all duration-500 pt-20'>
             <div className='container mx-auto px-6'>
                 <div className='max-w-2xl mx-auto text-center space-y-8 animate-fade-in'>
                     <h1 className='text-4xl font-bold text-gray-900'>

--- a/apps/resume-yatra/src/components/builder/ResultScreen.tsx
+++ b/apps/resume-yatra/src/components/builder/ResultScreen.tsx
@@ -1,4 +1,4 @@
-import { Copy, RotateCcw,Sparkles } from "lucide-react"
+import { Copy, RotateCcw, Sparkles } from "lucide-react"
 import { useRouter } from "next/router"
 import { useEffect } from "react"
 import { toast } from "sonner"
@@ -26,6 +26,13 @@ export default function ResultScreen({ builder }: ResultScreenProps) {
         return () => clearTimeout(timer)
     }, [setShowConfetti])
 
+    useEffect(() => {
+        // Ensure scroll is unlocked when leaving the result screen
+        return () => {
+            document.body.style.overflow = "auto"
+        }
+    }, [])
+
     const handleShareResult = () => {
         const url = window.location.href
         navigator.clipboard.writeText(url)
@@ -44,7 +51,7 @@ export default function ResultScreen({ builder }: ResultScreenProps) {
     }
 
     return (
-        <div className='min-h-screen bg-white'>
+        <div className='min-h-screen bg-white pt-20'>
             {/* Confetti Effect */}
             {showConfetti && (
                 <div className='fixed inset-0 pointer-events-none z-50'>

--- a/apps/resume-yatra/src/components/builder/TemplatePrompt.tsx
+++ b/apps/resume-yatra/src/components/builder/TemplatePrompt.tsx
@@ -9,7 +9,7 @@ interface TemplatePromptProps {
 
 export default function TemplatePrompt({ builder }: TemplatePromptProps) {
     return (
-        <div className='min-h-screen bg-white flex items-center justify-center'>
+        <div className='min-h-screen bg-white flex items-center justify-center pt-20'>
             <div className='container mx-auto px-6'>
                 <div className='max-w-2xl mx-auto text-center space-y-8 animate-fade-in'>
                     <h1 className='text-4xl font-bold text-gray-900'>

--- a/apps/resume-yatra/src/components/ui/badge.tsx
+++ b/apps/resume-yatra/src/components/ui/badge.tsx
@@ -25,7 +25,9 @@ const badgeVariants = cva(
 
 export interface BadgeProps
     extends React.HTMLAttributes<HTMLDivElement>,
-        VariantProps<typeof badgeVariants> {}
+    VariantProps<typeof badgeVariants> {
+    className?: string
+}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
     return (


### PR DESCRIPTION
Fixes #653

What was fixed

Scroll Unlock: Added useEffect cleanup in 
BuilderMain.tsx
 and 
ResultScreen.tsx
 to ensure overflow: auto is restored when the user leaves the page.
Layout Conflict: Fixed overlap between the fixed Navbar and sticky Progress Bar by adjusting z-index and adding top padding.
Visual Consistency: Added padding to all builder sub-screens to ensure they start below the header.

Testing
Ran npm run lint and tsc --noEmit (All passed).
Verified layout visually via npm run dev.
