### PR TITLE
fix: handle getStaticProps error in dsayatra to resolve 500 error

### DIFF
--- a/apps/dsayatra/src/pages/dashboard.tsx
+++ b/apps/dsayatra/src/pages/dashboard.tsx
@@ -127,9 +127,19 @@ const Dashboard = ({ seoMeta }: PageProps) => {
     );
 }
 
-export const getStaticProps = async () => ({
-    ...(await getPreFetchProps({ slug: routes.dsayatra.home, appId: "dsayatra" })),
-    revalidate: PAGE_REFRESH_TIMEOUT.veryVeryLong,
-});
+export const getStaticProps = async () => {
+    try {
+        return {
+            ...(await getPreFetchProps({ slug: routes.dsayatra.home, appId: "dsayatra" })),
+            revalidate: PAGE_REFRESH_TIMEOUT.veryVeryLong,
+        };
+    } catch (error) {
+        console.error("getStaticProps failed:", error);
+        return {
+            props: { seoMeta: {} },
+            revalidate: PAGE_REFRESH_TIMEOUT.veryVeryLong,
+        };
+    }
+};
 
 export default Dashboard;

--- a/apps/dsayatra/src/pages/index.tsx
+++ b/apps/dsayatra/src/pages/index.tsx
@@ -134,9 +134,19 @@ const LandingPage = ({ seoMeta }: PageProps) => {
   );
 };
 
-export const getStaticProps = async () => ({
-  ...(await getPreFetchProps({ slug: "/", appId: "dsayatra" })),
-  revalidate: PAGE_REFRESH_TIMEOUT.veryVeryLong,
-});
+export const getStaticProps = async () => {
+    try {
+        return {
+            ...(await getPreFetchProps({ slug: routes.dsayatra.home, appId: "dsayatra" })),
+            revalidate: PAGE_REFRESH_TIMEOUT.veryVeryLong,
+        };
+    } catch (error) {
+        console.error("getStaticProps failed:", error);
+        return {
+            props: { seoMeta: {} },
+            revalidate: PAGE_REFRESH_TIMEOUT.veryVeryLong,
+        };
+    }
+};
 
 export default LandingPage;


### PR DESCRIPTION
## Problem
Clicking "Start Your Journey" on DSA Yatra was throwing a 500 internal server error.

## Root Cause
getStaticProps in dashboard.tsx and index.tsx was crashing when 
getPreFetchProps failed with no error handling.

## Fix
Wrapped getStaticProps in try/catch so the page loads gracefully 
even if the prefetch API call fails.

Closes #739 