### PR TITLE
Add PR template for consistent review & testing standards (Vibe Kanban)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,12 +23,6 @@
 
 ## Screenshots / Recordings
 
-<!-- If this touches UI at all, paste screenshots or a short screen recording here. Before & after comparisons are gold. -->
-
-| Before | After |
-| ------ | ----- |
-|        |       |
-
 ---
 
 ## Testing

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,58 @@
+## What does this PR do?
+
+<!-- A brief summary. Keep it human-readable — imagine explaining this to a teammate over coffee. -->
+
+## Why?
+
+<!-- What problem does this solve? Link to the issue/ticket if there is one. -->
+
+---
+
+## Type of Change
+
+- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds functionality)
+- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] 🔧 Refactor / cleanup (no functional change)
+- [ ] 🎨 UI / styling change
+- [ ] 🔌 API change (new or modified endpoints, request/response shape changes)
+- [ ] 📦 Dependency update
+- [ ] 📝 Documentation only
+
+---
+
+## Screenshots / Recordings
+
+<!-- If this touches UI at all, paste screenshots or a short screen recording here. Before & after comparisons are gold. -->
+
+| Before | After |
+| ------ | ----- |
+|        |       |
+
+---
+
+## Testing
+
+### Does this PR include tests?
+
+- [ ] Yes — unit tests
+- [ ] Yes — integration / e2e tests
+- [ ] No — here's why: <!-- explain briefly -->
+
+### How to test manually
+
+<!-- Steps someone can follow to verify this works. Be specific. -->
+
+1.
+2.
+3.
+
+---
+
+## Checklist
+
+- [ ] I've tested this locally and it works as expected
+- [ ] I've checked for console errors / warnings
+- [ ] No unrelated changes snuck in
+- [ ] If UI change — tested on mobile viewport too
+- [ ] If API change — backward compatible or migration plan noted above


### PR DESCRIPTION
## What Changed

Added a **Pull Request template** (`.github/PULL_REQUEST_TEMPLATE.md`) that auto-fills the PR description whenever someone opens a new PR against this repo.

The template includes:
- **What & Why** — sections prompting the author to explain the change and its motivation
- **Type of Change** — checkboxes to quickly classify the PR (bug fix, feature, UI change, API change, refactor, etc.)
- **Screenshots / Recordings** — a before/after table for visual changes
- **Testing** — asks whether the PR includes unit or e2e tests, and if not, asks why. Also provides a numbered list for manual testing steps.
- **Final Checklist** — local testing, console errors, mobile viewport, backward compatibility

## Why

Right now PRs don't have a standardized format, which means reviewers have to guess context, testing status, and whether screenshots are needed. This leads to longer review cycles and things slipping through.

A lightweight template fixes that without adding friction — it's pre-filled, so authors just fill in the blanks instead of starting from scratch. It nudges the team toward better habits (testing, screenshots, explaining *why*) without being heavy-handed about it.

## Implementation Details

- Single file addition: `.github/PULL_REQUEST_TEMPLATE.md` (58 lines)
- No code changes, no build impact, no dependencies
- GitHub automatically picks this up — no configuration needed
- The template is intentionally kept short so people actually use it rather than deleting it

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*