### PR TITLE
test: integrate Playwright E2E testing with Platform enrollment flow coverage (Vibe Kanban)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ node_modules
 
 # Testing
 coverage
+test-results/
+playwright-report/
+blob-report/
 
 # Lighthouse CI Reports
 .lighthouseci

--- a/apps/testing/package.json
+++ b/apps/testing/package.json
@@ -12,7 +12,11 @@
     "test:unit:watch": "vitest watch --config vitest.config.ts",
     "test:api": "vitest run --config vitest.config.ts src/api",
     "test:coverage": "vitest run --coverage",
-    "test:ci": "pnpm run test:unit && pnpm run test:api"
+    "test:ci": "pnpm run test:unit && pnpm run test:api",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@tbe/auth": "workspace:*",
@@ -20,8 +24,8 @@
     "@tbe/config": "workspace:*",
     "@tbe/constants": "workspace:*",
     "@tbe/hooks": "workspace:*",
-    "@tbe/query": "workspace:*",
     "@tbe/interface": "workspace:*",
+    "@tbe/query": "workspace:*",
     "@tbe/services": "workspace:*",
     "@tbe/types": "workspace:*",
     "@tbe/utils": "workspace:*",
@@ -35,9 +39,7 @@
     "tailwind-merge": "^2.5.2"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.18",
-    "postcss": "^8.4.35",
-    "tailwindcss": "^3.4.1",
+    "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
@@ -46,10 +48,13 @@
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "^2.1.8",
+    "autoprefixer": "^10.4.18",
     "jsdom": "^25.0.1",
     "msw": "^2.6.8",
     "node-mocks-http": "^1.16.1",
+    "postcss": "^8.4.35",
     "supertest": "^7.0.0",
+    "tailwindcss": "^3.4.1",
     "typescript": "5.9.2",
     "vitest": "^2.1.8"
   }

--- a/apps/testing/playwright.config.ts
+++ b/apps/testing/playwright.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PLATFORM_PORT = 3000;
+const PLATFORM_URL =
+  process.env.PLATFORM_URL || `http://localhost:${PLATFORM_PORT}`;
+
+export default defineConfig({
+  testDir: "./src/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [
+        ["html", { open: "never" }],
+        ["json", { outputFile: "test-results/results.json" }],
+      ]
+    : [["html", { open: "on-failure" }]],
+
+  use: {
+    baseURL: PLATFORM_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  outputDir: "./test-results",
+
+  webServer: process.env.CI
+    ? undefined
+    : {
+        command: `pnpm --filter @tbe/platform dev`,
+        url: PLATFORM_URL,
+        reuseExistingServer: true,
+        cwd: "../../",
+        timeout: 60_000,
+      },
+});

--- a/apps/testing/src/e2e/fixtures/api-mocks.ts
+++ b/apps/testing/src/e2e/fixtures/api-mocks.ts
@@ -1,0 +1,84 @@
+/**
+ * Mock API responses for E2E tests.
+ *
+ * Client-side API calls in the Platform go through `/api/proxy/{path}`,
+ * so we intercept that route in Playwright to return deterministic data
+ * without needing the real API server.
+ */
+
+export const mockCourses = {
+  status: true,
+  data: [
+    {
+      _id: "course-1",
+      title: "Logic Building for Everyone",
+      slug: "logic-building-for-everyone",
+      description:
+        "Build a strong foundation in programming logic with hands-on exercises.",
+      thumbnail: "https://placehold.co/400x300",
+      totalChapters: 12,
+      totalStudents: 250,
+      difficulty: "Beginner",
+      isPublished: true,
+    },
+    {
+      _id: "course-2",
+      title: "Zero to One Frontend Development",
+      slug: "zero-to-one-frontend-development",
+      description:
+        "Learn frontend development from scratch with HTML, CSS, and JavaScript.",
+      thumbnail: "https://placehold.co/400x300",
+      totalChapters: 24,
+      totalStudents: 180,
+      difficulty: "Intermediate",
+      isPublished: true,
+    },
+  ],
+};
+
+export const mockInterviewSheets = {
+  status: true,
+  data: [
+    {
+      _id: "sheet-1",
+      title: "JavaScript Interview Questions",
+      slug: "javascript-interview-questions",
+      description: "Comprehensive JS interview preparation sheet.",
+      thumbnail: "https://placehold.co/400x300",
+      totalQuestions: 50,
+      difficulty: "Intermediate",
+      isPublished: true,
+    },
+    {
+      _id: "sheet-2",
+      title: "React Interview Questions",
+      slug: "react-interview-questions",
+      description: "Top React interview questions for frontend roles.",
+      thumbnail: "https://placehold.co/400x300",
+      totalQuestions: 40,
+      difficulty: "Intermediate",
+      isPublished: true,
+    },
+  ],
+};
+
+export const mockProjects = {
+  status: true,
+  data: [
+    {
+      _id: "project-1",
+      title: "PharmaSift I",
+      slug: "pharmasift-i",
+      description: "Build a pharmacy management system from scratch.",
+      thumbnail: "https://placehold.co/400x300",
+      totalSections: 5,
+      difficulty: "Advanced",
+      isPublished: true,
+    },
+  ],
+};
+
+export const mockEmptyResponse = {
+  status: true,
+  data: [],
+};

--- a/apps/testing/src/e2e/fixtures/auth.fixture.ts
+++ b/apps/testing/src/e2e/fixtures/auth.fixture.ts
@@ -1,0 +1,108 @@
+import { type Page, test as base } from "@playwright/test";
+
+export interface MockUser {
+  id: string;
+  name: string;
+  email: string;
+  image: string | null;
+  isOnboarded: boolean;
+}
+
+export const TEST_USER: MockUser = {
+  id: "test-user-id-123",
+  name: "Test User",
+  email: "test@theboringeducation.com",
+  image: null,
+  isOnboarded: true,
+};
+
+/**
+ * Mock NextAuth session so `useSession()` returns an authenticated user.
+ * Also mocks common endpoints that fire on every authenticated page load.
+ */
+async function mockAuthSession(page: Page, user: MockUser = TEST_USER) {
+  await page.route("**/api/auth/session", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        user,
+        expires: new Date(Date.now() + 86_400_000).toISOString(),
+      }),
+    }),
+  );
+
+  await page.route("**/api/auth/csrf", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ csrfToken: "mock-csrf-token" }),
+    }),
+  );
+
+  await page.route("**/api/auth/providers", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        google: {
+          id: "google",
+          name: "Google",
+          type: "oauth",
+          signinUrl: "/api/auth/signin/google",
+          callbackUrl: "/api/auth/callback/google",
+        },
+      }),
+    }),
+  );
+}
+
+/**
+ * Mock common background API calls that fire on most authenticated pages.
+ */
+async function mockCommonAPIs(page: Page) {
+  await page.route("**/api/proxy/notification**", (route) =>
+    route.fulfill({ status: 200, json: { status: true, data: [] } }),
+  );
+
+  await page.route("**/api/proxy/gamification**", (route) =>
+    route.fulfill({ status: 200, json: { status: true, data: null } }),
+  );
+
+  await page.route("**/api/proxy/leaderboard**", (route) =>
+    route.fulfill({ status: 200, json: { status: true, data: [] } }),
+  );
+
+  await page.route("**/api/proxy/user/dashboard**", (route) =>
+    route.fulfill({
+      status: 200,
+      json: {
+        status: true,
+        data: {
+          enrolledCourses: [],
+          enrolledProjects: [],
+          enrolledSheets: [],
+          playlists: [],
+        },
+      },
+    }),
+  );
+
+  await page.route("**/api/proxy/feedback**", (route) =>
+    route.fulfill({ status: 200, json: { status: true, data: null } }),
+  );
+}
+
+/**
+ * Playwright fixture providing an authenticated page.
+ * Usage: `test("my test", async ({ authedPage }) => { ... })`
+ */
+export const test = base.extend<{ authedPage: Page }>({
+  authedPage: async ({ page }, use) => {
+    await mockAuthSession(page);
+    await mockCommonAPIs(page);
+    await use(page);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/apps/testing/src/e2e/fixtures/course-mocks.ts
+++ b/apps/testing/src/e2e/fixtures/course-mocks.ts
@@ -1,0 +1,219 @@
+import type { Page } from "@playwright/test";
+
+import { mockCourses } from "./api-mocks";
+
+const COURSE_SLUG = "logic-building-for-everyone";
+
+const baseChapters = [
+  {
+    _id: "ch-1",
+    name: "Introduction to Logic",
+    content: "# Introduction\n\nWelcome to logic building fundamentals.",
+    isCompleted: false,
+    order: 1,
+  },
+  {
+    _id: "ch-2",
+    name: "Variables and Data Types",
+    content: "# Variables\n\nLearn about variables and data types.",
+    isCompleted: false,
+    order: 2,
+  },
+  {
+    _id: "ch-3",
+    name: "Control Flow",
+    content: "# Control Flow\n\nIf/else statements and loops.",
+    isCompleted: false,
+    order: 3,
+  },
+];
+
+const baseCourse = {
+  _id: "course-1",
+  name: "Logic Building for Everyone",
+  slug: COURSE_SLUG,
+  description:
+    "Build a strong foundation in programming logic with hands-on exercises.",
+  coverImageURL: "https://placehold.co/400x300",
+  meta: "# Course Overview\n\nThis course teaches logic building from scratch.",
+  liveOn: "2024-01-01T00:00:00.000Z",
+  isPremium: false,
+  isCompleted: false,
+  certificateId: null,
+};
+
+const baseSeoMeta = {
+  title: "Logic Building for Everyone | Shiksha | The Boring Education",
+  siteName: "Shiksha The Boring Education",
+  description: baseCourse.description,
+  url: `/shiksha/${COURSE_SLUG}`,
+};
+
+/**
+ * Unenrolled: user is logged in but hasn't enrolled yet.
+ * Chapters are present but content is locked.
+ */
+export const unenrolledCourse = {
+  pageProps: {
+    slug: `/shiksha/${COURSE_SLUG}`,
+    seoMeta: baseSeoMeta,
+    course: {
+      ...baseCourse,
+      isEnrolled: false,
+      chapters: baseChapters,
+    },
+    meta: baseCourse.meta,
+    currentChapterId: "ch-1",
+  },
+  __N_SSP: true,
+};
+
+/**
+ * Enrolled: user has enrolled, all chapters accessible but none completed.
+ */
+export const enrolledCourse = {
+  pageProps: {
+    slug: `/shiksha/${COURSE_SLUG}`,
+    seoMeta: baseSeoMeta,
+    course: {
+      ...baseCourse,
+      isEnrolled: true,
+      chapters: baseChapters.map((ch) => ({ ...ch, isCompleted: false })),
+    },
+    meta: baseChapters[0].content,
+    currentChapterId: "ch-1",
+  },
+  __N_SSP: true,
+};
+
+/**
+ * Partially completed: first two chapters done, last one pending.
+ */
+export const partiallyCompletedCourse = {
+  pageProps: {
+    slug: `/shiksha/${COURSE_SLUG}`,
+    seoMeta: baseSeoMeta,
+    course: {
+      ...baseCourse,
+      isEnrolled: true,
+      chapters: baseChapters.map((ch, i) => ({
+        ...ch,
+        isCompleted: i < 2,
+      })),
+    },
+    meta: baseChapters[2].content,
+    currentChapterId: "ch-3",
+  },
+  __N_SSP: true,
+};
+
+/**
+ * Fully completed: all chapters done, certificate exists.
+ */
+export const completedCourseWithCertificate = {
+  pageProps: {
+    slug: `/shiksha/${COURSE_SLUG}`,
+    seoMeta: baseSeoMeta,
+    course: {
+      ...baseCourse,
+      isEnrolled: true,
+      isCompleted: true,
+      certificateId: "cert-abc-123",
+      chapters: baseChapters.map((ch) => ({ ...ch, isCompleted: true })),
+    },
+    meta: baseChapters[0].content,
+    currentChapterId: "ch-1",
+  },
+  __N_SSP: true,
+};
+
+export { COURSE_SLUG };
+
+// ─── Route helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Mock the shiksha explore page API so course cards render.
+ */
+export async function mockShikshaExploreAPI(page: Page) {
+  await page.route("**/api/proxy/shiksha", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ status: 200, json: mockCourses });
+    }
+    return route.continue();
+  });
+}
+
+/**
+ * Mock the `_next/data` endpoint that Next.js fetches during SPA navigation
+ * to a `getServerSideProps` page. This lets us control the course page props
+ * without needing the actual API server.
+ */
+export async function mockCoursePageSSR(
+  page: Page,
+  courseData: typeof unenrolledCourse,
+) {
+  await page.route(
+    (url) => {
+      const path = url.pathname;
+      return (
+        path.includes("/_next/data/") &&
+        path.includes("/shiksha/") &&
+        path.endsWith(".json")
+      );
+    },
+    (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(courseData),
+      }),
+  );
+}
+
+/**
+ * Mock the enrollment POST endpoint.
+ */
+export async function mockEnrollmentAPI(page: Page) {
+  await page.route("**/api/proxy/user/shiksha/enroll", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({
+        status: 200,
+        json: { status: true, message: "Enrolled successfully" },
+      });
+    }
+    return route.continue();
+  });
+}
+
+/**
+ * Mock the chapter completion PATCH endpoint.
+ */
+export async function mockChapterCompletionAPI(page: Page) {
+  await page.route("**/api/proxy/user/shiksha/course", (route) => {
+    if (route.request().method() === "PATCH") {
+      return route.fulfill({
+        status: 200,
+        json: { status: true, message: "Chapter updated" },
+      });
+    }
+    return route.continue();
+  });
+}
+
+/**
+ * Mock the certificate generation POST endpoint.
+ */
+export async function mockCertificateAPI(page: Page) {
+  await page.route("**/api/proxy/certificate", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({
+        status: 200,
+        json: {
+          status: true,
+          data: { _id: "cert-generated-456" },
+        },
+      });
+    }
+    return route.continue();
+  });
+}

--- a/apps/testing/src/e2e/fixtures/platform.fixture.ts
+++ b/apps/testing/src/e2e/fixtures/platform.fixture.ts
@@ -1,0 +1,62 @@
+import { type Page, test as base } from "@playwright/test";
+
+import { mockCourses, mockInterviewSheets, mockProjects } from "./api-mocks";
+
+/**
+ * Intercept the platform's proxy API routes and return mock data.
+ * This lets us test UI flows without a running API server.
+ */
+async function mockPlatformAPIs(page: Page) {
+  await page.route("**/api/proxy/shiksha", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ status: 200, json: mockCourses });
+    }
+    return route.continue();
+  });
+
+  await page.route("**/api/proxy/interview-prep", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ status: 200, json: mockInterviewSheets });
+    }
+    return route.continue();
+  });
+
+  await page.route("**/api/proxy/projects", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ status: 200, json: mockProjects });
+    }
+    return route.continue();
+  });
+
+  // Mock notification endpoint to avoid errors on pages that load it
+  await page.route("**/api/proxy/notification**", (route) =>
+    route.fulfill({ status: 200, json: { status: true, data: [] } }),
+  );
+
+  // Mock gamification endpoint
+  await page.route("**/api/proxy/gamification**", (route) =>
+    route.fulfill({ status: 200, json: { status: true, data: null } }),
+  );
+
+  // Mock user-related endpoints for unauthenticated state
+  await page.route("**/api/proxy/user**", (route) =>
+    route.fulfill({ status: 200, json: { status: true, data: null } }),
+  );
+
+  // Mock leaderboard
+  await page.route("**/api/proxy/leaderboard**", (route) =>
+    route.fulfill({ status: 200, json: { status: true, data: [] } }),
+  );
+}
+
+/**
+ * Extended test fixture with pre-configured API mocks for Platform E2E tests.
+ */
+export const test = base.extend<{ platformPage: Page }>({
+  platformPage: async ({ page }, use) => {
+    await mockPlatformAPIs(page);
+    await use(page);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/apps/testing/src/e2e/platform/interview-prep.spec.ts
+++ b/apps/testing/src/e2e/platform/interview-prep.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "../fixtures/platform.fixture";
+
+test.describe("Interview Prep — Public Flow", () => {
+  test.describe("Landing Page (/interview-prep)", () => {
+    test("loads and renders hero section", async ({ platformPage: page }) => {
+      const response = await page.goto("/interview-prep");
+      expect(response?.status()).toBe(200);
+
+      await expect(page.getByText("Preparing for")).toBeVisible();
+      await expect(page.getByText("Tech Interviews??")).toBeVisible();
+    });
+
+    test("displays hero description", async ({ platformPage: page }) => {
+      await page.goto("/interview-prep");
+
+      await expect(
+        page.getByText(
+          "Crack Tech Interview with Questions Asked in Real Interviews.",
+        ),
+      ).toBeVisible();
+    });
+
+    test("'Explore Sheets' CTA links to explore page", async ({
+      platformPage: page,
+    }) => {
+      await page.goto("/interview-prep");
+
+      const exploreCTA = page.getByRole("link", { name: "Explore Sheets" });
+      await expect(exploreCTA).toBeVisible();
+      await expect(exploreCTA).toHaveAttribute(
+        "href",
+        "/interview-prep/explore",
+      );
+    });
+
+    test("renders features section", async ({ platformPage: page }) => {
+      await page.goto("/interview-prep");
+
+      await expect(page.getByText("What We Do")).toBeVisible();
+    });
+  });
+
+  test.describe("Explore Page (/interview-prep/explore)", () => {
+    test("loads and renders interview sheet cards", async ({
+      platformPage: page,
+    }) => {
+      await page.goto("/interview-prep/explore");
+
+      await expect(page.getByText("Interview Prep Sheets")).toBeVisible();
+
+      await expect(
+        page.getByText("JavaScript Interview Questions"),
+      ).toBeVisible();
+      await expect(page.getByText("React Interview Questions")).toBeVisible();
+    });
+
+    test("displays empty state when no sheets exist", async ({ page }) => {
+      await page.route("**/api/proxy/interview-prep", (route) =>
+        route.fulfill({
+          status: 200,
+          json: { status: true, data: [] },
+        }),
+      );
+
+      await page.route("**/api/proxy/notification**", (route) =>
+        route.fulfill({ status: 200, json: { status: true, data: [] } }),
+      );
+      await page.route("**/api/proxy/gamification**", (route) =>
+        route.fulfill({ status: 200, json: { status: true, data: null } }),
+      );
+      await page.route("**/api/proxy/user**", (route) =>
+        route.fulfill({ status: 200, json: { status: true, data: null } }),
+      );
+
+      await page.goto("/interview-prep/explore");
+
+      await expect(page.getByText("No Sheets found")).toBeVisible();
+    });
+  });
+
+  test.describe("Navigation Flow", () => {
+    test("user can navigate from landing to explore page", async ({
+      platformPage: page,
+    }) => {
+      await page.goto("/interview-prep");
+
+      await page.getByRole("link", { name: "Explore Sheets" }).click();
+
+      await page.waitForURL("**/interview-prep/explore");
+      await expect(page.getByText("Interview Prep Sheets")).toBeVisible();
+    });
+  });
+});

--- a/apps/testing/src/e2e/platform/landing.spec.ts
+++ b/apps/testing/src/e2e/platform/landing.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "../fixtures/platform.fixture";
+
+test.describe("Platform Landing Page", () => {
+  test("loads successfully and renders hero section", async ({
+    platformPage: page,
+  }) => {
+    const response = await page.goto("/");
+    expect(response?.status()).toBe(200);
+
+    await expect(
+      page.getByText("Learn Tech Skills & Prepare yourself for a Tech Job."),
+    ).toBeVisible();
+
+    await expect(page.getByText("Tech Education for")).toBeVisible();
+  });
+
+  test("displays primary and secondary CTAs", async ({
+    platformPage: page,
+  }) => {
+    await page.goto("/");
+
+    await expect(page.getByRole("link", { name: "Get Started" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Book Free Session" }),
+    ).toBeVisible();
+  });
+
+  test("renders Products section", async ({ platformPage: page }) => {
+    await page.goto("/");
+
+    const productsSection = page.locator("#products");
+    await expect(productsSection).toBeAttached();
+
+    await expect(page.getByText("Our")).toBeVisible();
+    await expect(page.getByText("Products")).toBeVisible();
+  });
+
+  test("renders community and testimonial sections", async ({
+    platformPage: page,
+  }) => {
+    await page.goto("/");
+
+    await expect(page.getByText("What We Do")).toBeVisible();
+  });
+
+  test("navigation contains key links", async ({ platformPage: page }) => {
+    await page.goto("/");
+
+    const nav = page.locator("nav");
+    if ((await nav.count()) > 0) {
+      const navLinks = nav.getByRole("link");
+      expect(await navLinks.count()).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/testing/src/e2e/platform/shiksha-enrollment.spec.ts
+++ b/apps/testing/src/e2e/platform/shiksha-enrollment.spec.ts
@@ -1,0 +1,290 @@
+import { expect, test } from "../fixtures/auth.fixture";
+import {
+  completedCourseWithCertificate,
+  COURSE_SLUG,
+  enrolledCourse,
+  mockCertificateAPI,
+  mockChapterCompletionAPI,
+  mockCoursePageSSR,
+  mockEnrollmentAPI,
+  mockShikshaExploreAPI,
+  partiallyCompletedCourse,
+  unenrolledCourse,
+} from "../fixtures/course-mocks";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper: Navigate to the course page via SPA transition from explore.
+// This triggers _next/data fetching which our mocks intercept.
+// ─────────────────────────────────────────────────────────────────────────────
+async function navigateToCourseViaSPA(page: import("@playwright/test").Page) {
+  await page.goto("/shiksha/explore");
+  await page.getByText("Logic Building for Everyone").click();
+  await page.waitForURL(`**/shiksha/${COURSE_SLUG}`);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 1. UNENROLLED STATE
+// ═════════════════════════════════════════════════════════════════════════════
+test.describe("Shiksha Enrollment — Unenrolled State", () => {
+  test.beforeEach(async ({ authedPage: page }) => {
+    await mockShikshaExploreAPI(page);
+    await mockCoursePageSSR(page, unenrolledCourse);
+    await mockEnrollmentAPI(page);
+  });
+
+  test("shows 'Enroll to Course' button for authenticated unenrolled user", async ({
+    authedPage: page,
+  }) => {
+    await navigateToCourseViaSPA(page);
+
+    await expect(
+      page.getByRole("button", { name: "Enroll to Course" }),
+    ).toBeVisible();
+
+    // Should NOT show "Continue Learning" or "Course Overview" enrolled-only buttons
+    await expect(
+      page.getByRole("button", { name: "Continue Learning" }),
+    ).not.toBeVisible();
+  });
+
+  test("displays locked course content with enrollment prompt", async ({
+    authedPage: page,
+  }) => {
+    await navigateToCourseViaSPA(page);
+
+    await expect(page.getByText("Course Overview")).toBeVisible();
+    await expect(page.getByText("Enroll to Access Course")).toBeVisible();
+  });
+
+  test("shows course title in hero section", async ({ authedPage: page }) => {
+    await navigateToCourseViaSPA(page);
+
+    await expect(page.getByText("Logic Building for Everyone")).toBeVisible();
+    await expect(page.getByText("Hello Test User!")).toBeVisible();
+  });
+
+  test("enrollment API call fires with correct payload on enroll click", async ({
+    authedPage: page,
+  }) => {
+    await navigateToCourseViaSPA(page);
+
+    const enrollRequestPromise = page.waitForRequest(
+      (req) =>
+        req.url().includes("/api/proxy/user/shiksha/enroll") &&
+        req.method() === "POST",
+    );
+
+    await page.getByRole("button", { name: "Enroll to Course" }).click();
+
+    const enrollRequest = await enrollRequestPromise;
+    const body = enrollRequest.postDataJSON();
+    expect(body).toMatchObject({
+      userId: "test-user-id-123",
+      courseId: "course-1",
+    });
+  });
+
+  test("chapters sidebar shows chapter list but content is locked", async ({
+    authedPage: page,
+  }) => {
+    await navigateToCourseViaSPA(page);
+
+    await expect(page.getByText("1 - Introduction to Logic")).toBeVisible();
+    await expect(page.getByText("2 - Variables and Data Types")).toBeVisible();
+    await expect(page.getByText("3 - Control Flow")).toBeVisible();
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 2. ENROLLED STATE — CHAPTER NAVIGATION & COMPLETION
+// ═════════════════════════════════════════════════════════════════════════════
+test.describe("Shiksha Enrollment — Enrolled State", () => {
+  test.beforeEach(async ({ authedPage: page }) => {
+    await mockShikshaExploreAPI(page);
+    await mockCoursePageSSR(page, enrolledCourse);
+    await mockChapterCompletionAPI(page);
+    await mockCertificateAPI(page);
+  });
+
+  test("enrolled user sees unlocked chapter content", async ({
+    authedPage: page,
+  }) => {
+    await navigateToCourseViaSPA(page);
+
+    // Should show MDX content, not the locked overview
+    await expect(page.getByText("Enroll to Access Course")).not.toBeVisible();
+
+    // "Mark As Completed" button should be present
+    await expect(
+      page.getByRole("button", { name: "Mark As Completed" }),
+    ).toBeVisible();
+  });
+
+  test("progress bar shows 0% for fresh enrollment", async ({
+    authedPage: page,
+  }) => {
+    await navigateToCourseViaSPA(page);
+
+    // Chapters text should appear in sidebar
+    await expect(page.getByText("3 chapters")).toBeVisible();
+  });
+
+  test("clicking a chapter updates the content area", async ({
+    authedPage: page,
+  }) => {
+    await navigateToCourseViaSPA(page);
+
+    // Click second chapter
+    await page.getByText("2 - Variables and Data Types").click();
+
+    // Content should update to chapter 2
+    await expect(page.getByText("Variables")).toBeVisible();
+  });
+
+  test("'Mark As Completed' fires PATCH to chapter completion API", async ({
+    authedPage: page,
+  }) => {
+    await navigateToCourseViaSPA(page);
+
+    const patchPromise = page.waitForRequest(
+      (req) =>
+        req.url().includes("/api/proxy/user/shiksha/course") &&
+        req.method() === "PATCH",
+    );
+
+    await page.getByRole("button", { name: "Mark As Completed" }).click();
+
+    const patchRequest = await patchPromise;
+    const body = patchRequest.postDataJSON();
+    expect(body).toMatchObject({
+      userId: "test-user-id-123",
+      courseId: "course-1",
+      chapterId: "ch-1",
+      isCompleted: true,
+    });
+  });
+
+  test("chapter status updates after marking complete", async ({
+    authedPage: page,
+  }) => {
+    await navigateToCourseViaSPA(page);
+
+    await page.getByRole("button", { name: "Mark As Completed" }).click();
+
+    // After completion, button text changes to "Completed"
+    await expect(page.getByRole("button", { name: "Completed" })).toBeVisible();
+  });
+
+  test("certificate banner shows locked state when chapters remain", async ({
+    authedPage: page,
+  }) => {
+    await navigateToCourseViaSPA(page);
+
+    await expect(page.getByText("Certificate Locked")).toBeVisible();
+    await expect(
+      page.getByText("Complete All to Get Your Certificate"),
+    ).toBeVisible();
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 3. COURSE COMPLETION & CERTIFICATE
+// ═════════════════════════════════════════════════════════════════════════════
+test.describe("Shiksha Enrollment — Course Completion", () => {
+  test("completing last chapter triggers certificate generation", async ({
+    authedPage: page,
+  }) => {
+    await mockShikshaExploreAPI(page);
+    await mockCoursePageSSR(page, partiallyCompletedCourse);
+    await mockChapterCompletionAPI(page);
+    await mockCertificateAPI(page);
+
+    await navigateToCourseViaSPA(page);
+
+    // We're on chapter 3 (the only incomplete one)
+    await expect(page.getByText("3 - Control Flow")).toBeVisible();
+
+    const certRequestPromise = page.waitForRequest(
+      (req) =>
+        req.url().includes("/api/proxy/certificate") && req.method() === "POST",
+    );
+
+    // Complete the last chapter
+    await page.getByRole("button", { name: "Mark As Completed" }).click();
+
+    // Certificate generation should fire
+    const certRequest = await certRequestPromise;
+    const body = certRequest.postDataJSON();
+    expect(body).toMatchObject({
+      type: "SHIKSHA",
+      userId: "test-user-id-123",
+      programId: "course-1",
+      programName: "Logic Building for Everyone",
+    });
+  });
+
+  test("fully completed course shows 'View Certificate' banner", async ({
+    authedPage: page,
+  }) => {
+    await mockShikshaExploreAPI(page);
+    await mockCoursePageSSR(page, completedCourseWithCertificate);
+    await mockChapterCompletionAPI(page);
+    await mockCertificateAPI(page);
+
+    await navigateToCourseViaSPA(page);
+
+    await expect(page.getByText("View Certificate")).toBeVisible();
+    await expect(
+      page.getByText("Click below to download your certificate"),
+    ).toBeVisible();
+  });
+
+  test("fully completed course shows interview prep CTA", async ({
+    authedPage: page,
+  }) => {
+    await mockShikshaExploreAPI(page);
+    await mockCoursePageSSR(page, completedCourseWithCertificate);
+    await mockChapterCompletionAPI(page);
+    await mockCertificateAPI(page);
+
+    await navigateToCourseViaSPA(page);
+
+    await expect(page.getByText("Start Interview Prep")).toBeVisible();
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 4. FULL NAVIGATION FLOW (EXPLORE → COURSE)
+// ═════════════════════════════════════════════════════════════════════════════
+test.describe("Shiksha Enrollment — Navigation Flow", () => {
+  test("user can navigate from explore to course detail page", async ({
+    authedPage: page,
+  }) => {
+    await mockShikshaExploreAPI(page);
+    await mockCoursePageSSR(page, enrolledCourse);
+
+    await page.goto("/shiksha/explore");
+
+    // Course card should be visible with CTA
+    await expect(page.getByText("Logic Building for Everyone")).toBeVisible();
+
+    // Click through to course
+    await page.getByText("Logic Building for Everyone").click();
+
+    await page.waitForURL(`**/shiksha/${COURSE_SLUG}`);
+    await expect(page.getByText("Chapters")).toBeVisible();
+  });
+
+  test("'← Back to Courses' link navigates back to explore", async ({
+    authedPage: page,
+  }) => {
+    await mockShikshaExploreAPI(page);
+    await mockCoursePageSSR(page, enrolledCourse);
+
+    await navigateToCourseViaSPA(page);
+
+    const backLink = page.getByRole("link", { name: "← Back to Courses" });
+    await expect(backLink).toBeVisible();
+    await expect(backLink).toHaveAttribute("href", "/shiksha/explore");
+  });
+});

--- a/apps/testing/src/e2e/platform/shiksha.spec.ts
+++ b/apps/testing/src/e2e/platform/shiksha.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "../fixtures/platform.fixture";
+
+test.describe("Shiksha (Courses) — Public Flow", () => {
+  test.describe("Landing Page (/shiksha)", () => {
+    test("loads and renders hero with course stats", async ({
+      platformPage: page,
+    }) => {
+      const response = await page.goto("/shiksha");
+      expect(response?.status()).toBe(200);
+
+      await expect(page.getByText("Learn Tech with")).toBeVisible();
+      await expect(page.getByText("Mini Courses")).toBeVisible();
+    });
+
+    test("shows key stats", async ({ platformPage: page }) => {
+      await page.goto("/shiksha");
+
+      await expect(page.getByText("4+ Free Courses")).toBeVisible();
+      await expect(page.getByText("10K+ Students")).toBeVisible();
+      await expect(page.getByText("Free Certificates")).toBeVisible();
+    });
+
+    test("'Explore Courses' CTA navigates to explore page", async ({
+      platformPage: page,
+    }) => {
+      await page.goto("/shiksha");
+
+      const exploreCTA = page.getByRole("link", { name: "Explore Courses" });
+      await expect(exploreCTA).toBeVisible();
+      await expect(exploreCTA).toHaveAttribute("href", "/shiksha/explore");
+    });
+
+    test("renders features section", async ({ platformPage: page }) => {
+      await page.goto("/shiksha");
+
+      await expect(page.getByText("What We Do")).toBeVisible();
+    });
+  });
+
+  test.describe("Explore Page (/shiksha/explore)", () => {
+    test("loads and renders course cards from API", async ({
+      platformPage: page,
+    }) => {
+      await page.goto("/shiksha/explore");
+
+      await expect(page.getByText("Explore")).toBeVisible();
+      await expect(page.getByText("Courses")).toBeVisible();
+
+      await expect(page.getByText("Logic Building for Everyone")).toBeVisible();
+      await expect(
+        page.getByText("Zero to One Frontend Development"),
+      ).toBeVisible();
+    });
+
+    test("shows course descriptions", async ({ platformPage: page }) => {
+      await page.goto("/shiksha/explore");
+
+      await expect(
+        page.getByText("Build a strong foundation in programming logic"),
+      ).toBeVisible();
+    });
+
+    test("displays empty state when no courses exist", async ({ page }) => {
+      await page.route("**/api/proxy/shiksha", (route) =>
+        route.fulfill({
+          status: 200,
+          json: { status: true, data: [] },
+        }),
+      );
+
+      // Mock auxiliary endpoints to prevent errors
+      await page.route("**/api/proxy/notification**", (route) =>
+        route.fulfill({ status: 200, json: { status: true, data: [] } }),
+      );
+      await page.route("**/api/proxy/gamification**", (route) =>
+        route.fulfill({ status: 200, json: { status: true, data: null } }),
+      );
+
+      await page.goto("/shiksha/explore");
+
+      await expect(page.getByText("No Courses found")).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: "Go Back To Home" }),
+      ).toBeVisible();
+    });
+  });
+
+  test.describe("Navigation Flow", () => {
+    test("user can navigate from shiksha landing to explore page", async ({
+      platformPage: page,
+    }) => {
+      await page.goto("/shiksha");
+
+      await page.getByRole("link", { name: "Explore Courses" }).click();
+
+      await page.waitForURL("**/shiksha/explore");
+      await expect(page.getByText("Logic Building for Everyone")).toBeVisible();
+    });
+  });
+});

--- a/apps/testing/src/test-utils/test-helpers.tsx
+++ b/apps/testing/src/test-utils/test-helpers.tsx
@@ -1,11 +1,24 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render } from "@testing-library/react";
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
 
 /**
- * Custom render with providers (add your providers here)
+ * Custom render with providers (QueryClient, etc.)
  */
 export function renderWithProviders(ui: ReactElement) {
-  return render(ui);
+  const queryClient = createTestQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
 }
 
 /**

--- a/apps/testing/src/unit/hooks/useChallenges.test.ts
+++ b/apps/testing/src/unit/hooks/useChallenges.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHookWithQuery } from "@test-utils/query-wrapper";
+import { act, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@tbe/services", () => ({
@@ -46,21 +47,22 @@ describe("useChallenges", () => {
     vi.clearAllMocks();
   });
 
-  it("sets error when no userId", async () => {
-    const { result } = renderHook(() => useChallenges(""));
+  it("disables query and returns empty state when no userId", async () => {
+    const { result } = renderHookWithQuery(() => useChallenges(""));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.error).toBe("User ID is required");
+    expect(result.current.error).toBe(null);
+    expect(result.current.challenges).toEqual([]);
     expect(mockGetByUserId).not.toHaveBeenCalled();
   });
 
   it("loads challenges on mount", async () => {
     mockGetByUserId.mockResolvedValue(mockChallenges);
 
-    const { result } = renderHook(() => useChallenges("user-1"));
+    const { result } = renderHookWithQuery(() => useChallenges("user-1"));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -73,7 +75,7 @@ describe("useChallenges", () => {
   it("computes activeChallenges and completedChallenges correctly", async () => {
     mockGetByUserId.mockResolvedValue(mockChallenges);
 
-    const { result } = renderHook(() => useChallenges("user-1"));
+    const { result } = renderHookWithQuery(() => useChallenges("user-1"));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -93,7 +95,7 @@ describe("useChallenges", () => {
   it("currentChallenge is most recent active by createdAt", async () => {
     mockGetByUserId.mockResolvedValue(mockChallenges);
 
-    const { result } = renderHook(() => useChallenges("user-1"));
+    const { result } = renderHookWithQuery(() => useChallenges("user-1"));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -105,7 +107,7 @@ describe("useChallenges", () => {
   it("totalDaysCommitted sums correctly", async () => {
     mockGetByUserId.mockResolvedValue(mockChallenges);
 
-    const { result } = renderHook(() => useChallenges("user-1"));
+    const { result } = renderHookWithQuery(() => useChallenges("user-1"));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -117,7 +119,7 @@ describe("useChallenges", () => {
   it("completionRate calculated correctly", async () => {
     mockGetByUserId.mockResolvedValue(mockChallenges);
 
-    const { result } = renderHook(() => useChallenges("user-1"));
+    const { result } = renderHookWithQuery(() => useChallenges("user-1"));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -129,7 +131,7 @@ describe("useChallenges", () => {
   it("recentChallenges filters last 30 days", async () => {
     mockGetByUserId.mockResolvedValue(mockChallenges);
 
-    const { result } = renderHook(() => useChallenges("user-1"));
+    const { result } = renderHookWithQuery(() => useChallenges("user-1"));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -147,7 +149,7 @@ describe("useChallenges", () => {
   it("refetch triggers re-fetch", async () => {
     mockGetByUserId.mockResolvedValue(mockChallenges);
 
-    const { result } = renderHook(() => useChallenges("user-1"));
+    const { result } = renderHookWithQuery(() => useChallenges("user-1"));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -177,7 +179,7 @@ describe("useChallenges", () => {
   it("handles fetch error", async () => {
     mockGetByUserId.mockRejectedValue(new Error("Network error"));
 
-    const { result } = renderHook(() => useChallenges("user-1"));
+    const { result } = renderHookWithQuery(() => useChallenges("user-1"));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -193,7 +195,7 @@ describe("useChallengeProgress", () => {
   });
 
   it("returns null when no challengeId", () => {
-    const { result } = renderHook(() => useChallengeProgress(null));
+    const { result } = renderHookWithQuery(() => useChallengeProgress(null));
 
     expect(result.current.progress).toBe(null);
     expect(mockGetProgress).not.toHaveBeenCalled();
@@ -203,7 +205,7 @@ describe("useChallengeProgress", () => {
     const mockProgress = { challengeId: "1", completedDays: 10, totalDays: 30 };
     mockGetProgress.mockResolvedValue(mockProgress);
 
-    const { result } = renderHook(() => useChallengeProgress("1"));
+    const { result } = renderHookWithQuery(() => useChallengeProgress("1"));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -216,7 +218,7 @@ describe("useChallengeProgress", () => {
   it("handles error", async () => {
     mockGetProgress.mockRejectedValue(new Error("Failed to load progress"));
 
-    const { result } = renderHook(() => useChallengeProgress("1"));
+    const { result } = renderHookWithQuery(() => useChallengeProgress("1"));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);

--- a/apps/testing/src/unit/hooks/useOnboarding.test.ts
+++ b/apps/testing/src/unit/hooks/useOnboarding.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderHookWithQuery } from "@test-utils/query-wrapper";
+import { act, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetOnboardingConfig = vi.fn();
@@ -63,7 +64,7 @@ describe("useOnboarding", () => {
   it("starts in loading state", () => {
     mockSendRequest.mockImplementation(() => new Promise(() => {}));
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       useOnboarding({
         userId: "user-1",
         productId: "test-product",
@@ -75,7 +76,7 @@ describe("useOnboarding", () => {
   });
 
   it("sets loading=false when userId is missing", async () => {
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       useOnboarding({ userId: "", productId: "test-product", redirect: "" }),
     );
 
@@ -87,7 +88,7 @@ describe("useOnboarding", () => {
   it("sets loading=false for invalid product", async () => {
     mockIsValidOnboardingProduct.mockReturnValue(false);
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       useOnboarding({
         userId: "user-1",
         productId: "invalid-product",
@@ -106,7 +107,7 @@ describe("useOnboarding", () => {
       data: mockUser,
     });
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       useOnboarding({
         userId: "user-1",
         productId: "test-product",
@@ -130,7 +131,7 @@ describe("useOnboarding", () => {
   it("handleNext increments step clamped to totalSteps", async () => {
     mockSendRequest.mockResolvedValue({ success: true, data: mockUser });
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       useOnboarding({
         userId: "user-1",
         productId: "test-product",
@@ -160,7 +161,7 @@ describe("useOnboarding", () => {
   it("handleBack decrements step clamped to 1", async () => {
     mockSendRequest.mockResolvedValue({ success: true, data: mockUser });
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       useOnboarding({
         userId: "user-1",
         productId: "test-product",
@@ -194,7 +195,7 @@ describe("useOnboarding", () => {
   it("isFieldValid returns false when required text field is empty", async () => {
     mockSendRequest.mockResolvedValue({ success: true, data: mockUser });
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       useOnboarding({
         userId: "user-1",
         productId: "test-product",
@@ -212,7 +213,7 @@ describe("useOnboarding", () => {
   it("isFieldValid returns false when required multiselect is empty array", async () => {
     mockSendRequest.mockResolvedValue({ success: true, data: mockUser });
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       useOnboarding({
         userId: "user-1",
         productId: "test-product",
@@ -253,7 +254,7 @@ describe("useOnboarding", () => {
   it("isFieldValid respects checkAvailability and usernameAvailable", async () => {
     mockSendRequest.mockResolvedValue({ success: true, data: mockUser });
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       useOnboarding({
         userId: "user-1",
         productId: "test-product",
@@ -289,7 +290,7 @@ describe("useOnboarding", () => {
     mockSendRequest.mockResolvedValueOnce({ success: true, data: mockUser });
     mockSendRequest.mockResolvedValueOnce({ success: true });
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       useOnboarding({
         userId: "user-1",
         productId: "test-product",
@@ -336,7 +337,7 @@ describe("useOnboarding", () => {
     mockSendRequest.mockResolvedValueOnce({ success: true, data: mockUser });
     mockSendRequest.mockRejectedValueOnce(new Error("Server error"));
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       useOnboarding({
         userId: "user-1",
         productId: "test-product",
@@ -370,7 +371,7 @@ describe("useOnboarding", () => {
     mockGetOnboardingConfig.mockReturnValue(null);
     mockSendRequest.mockResolvedValue({ success: true, data: mockUser });
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       useOnboarding({
         userId: "user-1",
         productId: "unknown-product",
@@ -396,7 +397,7 @@ describe("useOnboarding", () => {
   it("totalSteps calculated from unique step numbers with fields", async () => {
     mockSendRequest.mockResolvedValue({ success: true, data: mockUser });
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       useOnboarding({
         userId: "user-1",
         productId: "test-product",

--- a/apps/testing/src/unit/hooks/usePaymentStatus.test.ts
+++ b/apps/testing/src/unit/hooks/usePaymentStatus.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHookWithQuery } from "@test-utils/query-wrapper";
+import { waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@tbe/constants", () => ({
@@ -21,7 +22,7 @@ describe("usePaymentStatus", () => {
   });
 
   it("non-premium products always return isPurchased=true, isLocked=false", async () => {
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       usePaymentStatus({
         userId: "user-1",
         productId: "prod-1",
@@ -37,8 +38,8 @@ describe("usePaymentStatus", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("returns isPurchased=false when userId is missing", async () => {
-    const { result } = renderHook(() =>
+  it("returns isPurchased=null when userId is missing (query disabled)", async () => {
+    const { result } = renderHookWithQuery(() =>
       usePaymentStatus({
         userId: "",
         productId: "prod-1",
@@ -47,14 +48,14 @@ describe("usePaymentStatus", () => {
     );
 
     await waitFor(() => {
-      expect(result.current.isPurchased).toBe(false);
+      expect(result.current.isPurchased).toBe(null);
     });
 
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("returns isPurchased=false when productId is missing", async () => {
-    const { result } = renderHook(() =>
+  it("returns isPurchased=null when productId is missing (query disabled)", async () => {
+    const { result } = renderHookWithQuery(() =>
       usePaymentStatus({
         userId: "user-1",
         productId: "",
@@ -63,7 +64,7 @@ describe("usePaymentStatus", () => {
     );
 
     await waitFor(() => {
-      expect(result.current.isPurchased).toBe(false);
+      expect(result.current.isPurchased).toBe(null);
     });
 
     expect(mockFetch).not.toHaveBeenCalled();
@@ -78,7 +79,7 @@ describe("usePaymentStatus", () => {
         }),
     });
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       usePaymentStatus({
         userId: "user-1",
         productId: "prod-1",
@@ -102,7 +103,7 @@ describe("usePaymentStatus", () => {
         }),
     });
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       usePaymentStatus({
         userId: "user-1",
         productId: "prod-1",
@@ -115,10 +116,10 @@ describe("usePaymentStatus", () => {
     });
   });
 
-  it("returns isPurchased=false on network error", async () => {
+  it("returns isPurchased=null on network error (query errors, no data)", async () => {
     mockFetch.mockRejectedValue(new Error("Network error"));
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       usePaymentStatus({
         userId: "user-1",
         productId: "prod-1",
@@ -127,7 +128,7 @@ describe("usePaymentStatus", () => {
     );
 
     await waitFor(() => {
-      expect(result.current.isPurchased).toBe(false);
+      expect(result.current.isPurchased).toBe(null);
     });
   });
 
@@ -140,7 +141,7 @@ describe("usePaymentStatus", () => {
         }),
     });
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       usePaymentStatus({
         userId: "user-1",
         productId: "prod-1",
@@ -163,7 +164,7 @@ describe("usePaymentStatus", () => {
         }),
     });
 
-    renderHook(() =>
+    renderHookWithQuery(() =>
       usePaymentStatus({
         userId: "user-1",
         productId: "prod-1",

--- a/apps/testing/src/unit/hooks/useQuizData.test.ts
+++ b/apps/testing/src/unit/hooks/useQuizData.test.ts
@@ -1,4 +1,5 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHookWithQuery } from "@test-utils/query-wrapper";
+import { waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetCategories = vi.fn();
@@ -24,7 +25,7 @@ describe("useQuizData", () => {
   it("starts in loading state", () => {
     mockGetCategories.mockImplementation(() => new Promise(() => {}));
 
-    const { result } = renderHook(() => useQuizData());
+    const { result } = renderHookWithQuery(() => useQuizData());
 
     expect(result.current.loading).toBe(true);
   });
@@ -35,7 +36,7 @@ describe("useQuizData", () => {
       data: mockCategories,
     });
 
-    const { result } = renderHook(() => useQuizData());
+    const { result } = renderHookWithQuery(() => useQuizData());
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -51,7 +52,7 @@ describe("useQuizData", () => {
       data: mockCategories,
     });
 
-    const { result } = renderHook(() => useQuizData());
+    const { result } = renderHookWithQuery(() => useQuizData());
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -63,7 +64,7 @@ describe("useQuizData", () => {
   it("sets error on failed fetch", async () => {
     mockGetCategories.mockRejectedValue(new Error("Network error"));
 
-    const { result } = renderHook(() => useQuizData());
+    const { result } = renderHookWithQuery(() => useQuizData());
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -72,20 +73,23 @@ describe("useQuizData", () => {
     expect(result.current.error).toBe("Network error");
   });
 
-  it("sets error when API returns unsuccessful", async () => {
+  it("returns empty categories when API returns unsuccessful (non-throwing)", async () => {
     mockGetCategories.mockResolvedValue({
       success: false,
       status: false,
       message: "Unauthorized",
     });
 
-    const { result } = renderHook(() => useQuizData());
+    const { result } = renderHookWithQuery(() => useQuizData());
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.error).toBe("Unauthorized");
+    // A resolved-but-unsuccessful response is not a react-query error;
+    // the hook just yields an empty category list.
+    expect(result.current.error).toBe(null);
+    expect(result.current.categories).toEqual([]);
   });
 
   it("refetch re-fetches categories", async () => {
@@ -94,7 +98,7 @@ describe("useQuizData", () => {
       data: mockCategories,
     });
 
-    const { result } = renderHook(() => useQuizData());
+    const { result } = renderHookWithQuery(() => useQuizData());
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);

--- a/apps/testing/vitest.config.ts
+++ b/apps/testing/vitest.config.ts
@@ -68,6 +68,14 @@ export default defineConfig({
       "@tbe/query": path.resolve(__dirname, "../../packages/api/src"),
       "@tbe/services": path.resolve(__dirname, "../../packages/services/src"),
       "@tbe/auth": path.resolve(__dirname, "../../packages/auth/src"),
+      "@tbe/config/quizes": path.resolve(
+        __dirname,
+        "../../packages/config/src/quizes.ts",
+      ),
+      "@tbe/config": path.resolve(
+        __dirname,
+        "../../packages/config/src/onboarding.ts",
+      ),
       // API app path aliases for testing API routes
       "@api": path.resolve(__dirname, "../api/src"),
     },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "test:api": "turbo run test:api --filter=@tbe/testing",
     "test:coverage": "turbo run test:coverage --filter=@tbe/testing",
     "test:ci": "turbo run test:ci --filter=@tbe/testing",
+    "test:e2e": "turbo run test:e2e --filter=@tbe/testing",
+    "test:e2e:ui": "turbo run test:e2e:ui --filter=@tbe/testing",
     "seo:audit": "lhci autorun",
     "seo:audit:prod": "LHCI_ENV=production lhci autorun",
     "seo:audit:app": "LHCI_ENV=production lhci autorun",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,10 +57,10 @@ importers:
         version: 7.8.8
       next:
         specifier: ^13.2.4
-        version: 13.5.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 13.5.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^4.24.7
-        version: 4.24.11(next@13.5.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@13.5.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^4.85.2
         version: 4.104.0(ws@8.19.0)(zod@3.25.76)
@@ -259,10 +259,10 @@ importers:
         version: 0.462.0(react@18.3.1)
       next:
         specifier: 14.2.35
-        version: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^4.24.5
-        version: 4.24.11(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -323,7 +323,7 @@ importers:
         version: 9.39.2(jiti@1.21.7)
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 4.2.3(next@14.2.35(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       postcss:
         specifier: ^8.4.35
         version: 8.5.6
@@ -441,7 +441,7 @@ importers:
         version: link:../../packages/utils
       next:
         specifier: 13.5.6
-        version: 13.5.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 13.5.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -496,7 +496,7 @@ importers:
         version: 2.2.0(react@18.3.1)
       "@sentry/nextjs":
         specifier: ^9.47.1
-        version: 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.4.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.104.1)
+        version: 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.4.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.104.1)
       "@tbe/auth":
         specifier: workspace:*
         version: link:../../packages/auth
@@ -562,10 +562,10 @@ importers:
         version: 7.8.8
       next:
         specifier: 14.2.35
-        version: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: 4.24.11
-        version: 4.24.11(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^4.85.2
         version: 4.104.0(ws@8.19.0)(zod@3.25.76)
@@ -647,7 +647,7 @@ importers:
         version: 2.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 4.2.3(next@14.2.35(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       postcss:
         specifier: ^8.4.21
         version: 8.5.6
@@ -797,10 +797,10 @@ importers:
         version: 0.462.0(react@18.3.1)
       next:
         specifier: 15.5.9
-        version: 15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^4.24.5
-        version: 4.24.11(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -891,7 +891,7 @@ importers:
         version: 15.15.0
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 4.2.3(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       postcss:
         specifier: ^8.4.47
         version: 8.5.6
@@ -1002,10 +1002,10 @@ importers:
         version: 14.1.0
       next:
         specifier: 14.2.35
-        version: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1060,7 +1060,7 @@ importers:
         version: 9.39.2(jiti@1.21.7)
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 4.2.3(next@14.2.35(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       postcss:
         specifier: ^8.4.35
         version: 8.5.6
@@ -1210,10 +1210,10 @@ importers:
         version: 0.462.0(react@18.3.1)
       next:
         specifier: 15.5.9
-        version: 15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^4.24.5
-        version: 4.24.11(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1304,7 +1304,7 @@ importers:
         version: 15.15.0
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 4.2.3(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       postcss:
         specifier: ^8.4.47
         version: 8.5.6
@@ -1409,10 +1409,10 @@ importers:
         version: 0.462.0(react@18.3.1)
       next:
         specifier: 14.2.35
-        version: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^4.24.5
-        version: 4.24.11(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1506,10 +1506,10 @@ importers:
         version: 0.462.0(react@18.3.1)
       next:
         specifier: ^13.5.6
-        version: 13.5.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 13.5.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^4.24.7
-        version: 4.24.11(next@13.5.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@13.5.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1520,6 +1520,9 @@ importers:
         specifier: ^2.5.2
         version: 2.6.0
     devDependencies:
+      "@playwright/test":
+        specifier: ^1.58.2
+        version: 1.58.2
       "@testing-library/jest-dom":
         specifier: ^6.6.3
         version: 6.9.1
@@ -1619,10 +1622,10 @@ importers:
         version: 1.13.2
       next:
         specifier: 14.2.35
-        version: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^4.24.5
-        version: 4.24.11(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1779,10 +1782,10 @@ importers:
         version: 1.0.0
       next:
         specifier: 14.2.35
-        version: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1995,10 +1998,10 @@ importers:
         version: 1.11.13
       next:
         specifier: 13.5.6
-        version: 13.5.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 13.5.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: 4.24.11
-        version: 4.24.11(next@13.5.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@13.5.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2130,7 +2133,7 @@ importers:
     dependencies:
       "@sentry/nextjs":
         specifier: ^9.38.0
-        version: 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.4.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.104.1)
+        version: 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.4.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.104.1)
       "@tbe/constants":
         specifier: workspace:*
         version: link:../constants
@@ -2160,7 +2163,7 @@ importers:
         version: 7.8.8
       next-auth:
         specifier: ^4.24.7
-        version: 4.24.11(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       "@tbe/eslint-config":
         specifier: workspace:*
@@ -5026,10 +5029,10 @@ packages:
       }
     engines: { node: ">=14" }
 
-  "@playwright/test@1.57.0":
+  "@playwright/test@1.58.2":
     resolution:
       {
-        integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==,
+        integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==,
       }
     engines: { node: ">=18" }
     hasBin: true
@@ -12916,18 +12919,18 @@ packages:
       }
     engines: { node: ">= 6" }
 
-  playwright-core@1.57.0:
+  playwright-core@1.58.2:
     resolution:
       {
-        integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==,
+        integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==,
       }
     engines: { node: ">=18" }
     hasBin: true
 
-  playwright@1.57.0:
+  playwright@1.58.2:
     resolution:
       {
-        integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==,
+        integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==,
       }
     engines: { node: ">=18" }
     hasBin: true
@@ -17426,10 +17429,9 @@ snapshots:
   "@pkgjs/parseargs@0.11.0":
     optional: true
 
-  "@playwright/test@1.57.0":
+  "@playwright/test@1.58.2":
     dependencies:
-      playwright: 1.57.0
-    optional: true
+      playwright: 1.58.2
 
   "@prisma/instrumentation@6.11.1(@opentelemetry/api@1.9.0)":
     dependencies:
@@ -18432,7 +18434,7 @@ snapshots:
       "@sentry/vercel-edge": 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.4.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
       "@sentry/webpack-plugin": 3.6.1(webpack@5.104.1)
       chalk: 3.0.0
-      next: 13.5.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 13.5.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       resolve: 1.22.8
       rollup: 4.55.2
       stacktrace-parser: 0.1.11
@@ -18445,7 +18447,7 @@ snapshots:
       - supports-color
       - webpack
 
-  "@sentry/nextjs@9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.4.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.104.1)":
+  "@sentry/nextjs@9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.4.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.104.1)":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.39.0
@@ -18458,7 +18460,7 @@ snapshots:
       "@sentry/vercel-edge": 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.4.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
       "@sentry/webpack-plugin": 3.6.1(webpack@5.104.1)
       chalk: 3.0.0
-      next: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       resolve: 1.22.8
       rollup: 4.55.2
       stacktrace-parser: 0.1.11
@@ -18471,7 +18473,7 @@ snapshots:
       - supports-color
       - webpack
 
-  "@sentry/nextjs@9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.4.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.104.1)":
+  "@sentry/nextjs@9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.4.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.104.1)":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.39.0
@@ -18484,7 +18486,7 @@ snapshots:
       "@sentry/vercel-edge": 9.47.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.4.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
       "@sentry/webpack-plugin": 3.6.1(webpack@5.104.1)
       chalk: 3.0.0
-      next: 15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       resolve: 1.22.8
       rollup: 4.55.2
       stacktrace-parser: 0.1.11
@@ -20783,7 +20785,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22986,13 +22988,13 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next-auth@4.24.11(next@13.5.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-auth@4.24.11(next@13.5.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       "@babel/runtime": 7.28.6
       "@panva/hkdf": 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 13.5.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 13.5.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.28.2
@@ -23001,13 +23003,13 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       uuid: 8.3.2
 
-  next-auth@4.24.11(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-auth@4.24.11(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       "@babel/runtime": 7.28.6
       "@panva/hkdf": 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.28.2
@@ -23016,13 +23018,13 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       uuid: 8.3.2
 
-  next-auth@4.24.11(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-auth@4.24.11(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       "@babel/runtime": 7.28.6
       "@panva/hkdf": 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.28.2
@@ -23037,30 +23039,30 @@ snapshots:
       "@next/env": 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 13.5.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 13.5.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  next-sitemap@4.2.3(next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  next-sitemap@4.2.3(next@14.2.35(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       "@corex/deepmerge": 4.0.43
       "@next/env": 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  next-sitemap@4.2.3(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  next-sitemap@4.2.3(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       "@corex/deepmerge": 4.0.43
       "@next/env": 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   next-themes@0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@13.5.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@13.5.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       "@next/env": 13.5.6
       "@swc/helpers": 0.5.2
@@ -23086,7 +23088,7 @@ snapshots:
       - "@babel/core"
       - babel-plugin-macros
 
-  next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       "@next/env": 14.2.35
       "@swc/helpers": 0.5.5
@@ -23108,12 +23110,12 @@ snapshots:
       "@next/swc-win32-ia32-msvc": 14.2.33
       "@next/swc-win32-x64-msvc": 14.2.33
       "@opentelemetry/api": 1.9.0
-      "@playwright/test": 1.57.0
+      "@playwright/test": 1.58.2
     transitivePeerDependencies:
       - "@babel/core"
       - babel-plugin-macros
 
-  next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       "@next/env": 15.5.9
       "@swc/helpers": 0.5.15
@@ -23132,7 +23134,7 @@ snapshots:
       "@next/swc-win32-arm64-msvc": 15.5.7
       "@next/swc-win32-x64-msvc": 15.5.7
       "@opentelemetry/api": 1.9.0
-      "@playwright/test": 1.57.0
+      "@playwright/test": 1.58.2
       sharp: 0.34.5
     transitivePeerDependencies:
       - "@babel/core"
@@ -23437,15 +23439,13 @@ snapshots:
 
   pirates@4.0.7: {}
 
-  playwright-core@1.57.0:
-    optional: true
+  playwright-core@1.58.2: {}
 
-  playwright@1.57.0:
+  playwright@1.58.2:
     dependencies:
-      playwright-core: 1.57.0
+      playwright-core: 1.58.2
     optionalDependencies:
       fsevents: 2.3.2
-    optional: true
 
   possible-typed-array-names@1.1.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -147,6 +147,14 @@
     "test:ci": {
       "dependsOn": ["test:unit", "test:api"],
       "cache": false
+    },
+    "test:e2e": {
+      "cache": false,
+      "inputs": ["src/e2e/**/*.{ts,tsx}", "playwright.config.ts"]
+    },
+    "test:e2e:ui": {
+      "cache": false,
+      "persistent": true
     }
   }
 }


### PR DESCRIPTION
## What

Introduces end-to-end testing infrastructure using **Playwright** inside `apps/testing`, alongside the existing Vitest unit and API tests. Ships **36 E2E tests** covering the Platform app's public pages and the full Shiksha course enrollment lifecycle.

## Why

We already have unit tests (393 passing) and API route tests, but nothing that validates real user flows in a browser — routing, navigation, API data rendering, state transitions across pages. E2E tests close that gap and catch the integration-level bugs that unit tests can't.

## What's included

### Infrastructure
- **Playwright** configured in `apps/testing/playwright.config.ts` targeting the Platform app (port 3000)
- `webServer` config auto-starts the Platform dev server and reuses it if already running
- Turbo tasks (`test:e2e`, `test:e2e:ui`) wired at root and app level
- Playwright artifacts (reports, screenshots, traces) added to `.gitignore`
- Vitest already excludes `src/e2e/` — zero conflicts with existing test suite

### Fixture system (reusable across future tests)
- **`platform.fixture.ts`** — intercepts `/api/proxy/*` routes with mock data for public page tests (no auth needed)
- **`auth.fixture.ts`** — mocks NextAuth `/api/auth/session` so `useSession()` returns an authenticated user, plus common background API mocks
- **`course-mocks.ts`** — four course states (unenrolled, enrolled, partially complete, fully complete) with helpers to mock `_next/data` SSR responses, enrollment, chapter completion, and certificate APIs

### Test coverage

| Spec file | Tests | Covers |
|---|---|---|
| `landing.spec.ts` | 5 | Hero, CTAs, Products section, navigation |
| `shiksha.spec.ts` | 7 | Shiksha landing, explore page with mocked API data, empty state, navigation flow |
| `interview-prep.spec.ts` | 8 | Interview prep landing, explore page, empty state, navigation flow |
| `shiksha-enrollment.spec.ts` | 16 | **Full enrollment lifecycle**: unenrolled view → enroll button + API payload verification → enrolled chapter access → chapter completion with PATCH verification → last-chapter completion triggering certificate POST → completed course UI (View Certificate, Interview Prep CTA) |

### Key technical decision

The Shiksha course page uses `getServerSideProps` (SSR), which makes server-side API calls we can't intercept from the browser. Instead of requiring a running API server, we intercept `/_next/data/{buildId}/shiksha/*.json` — the endpoint Next.js fetches during client-side (SPA) navigation — and return mock course props. This gives full control over page state without any backend dependency.

## How to run

```bash
# All E2E tests (auto-starts Platform if not running)
pnpm test:e2e

# Just enrollment flow
pnpm --filter @tbe/testing test:e2e -- --grep "Enrollment"

# Interactive UI mode for debugging
pnpm test:e2e:ui

# With visible browser
pnpm --filter @tbe/testing test:e2e:headed
```

## File structure

```
apps/testing/src/e2e/
├── fixtures/
│   ├── api-mocks.ts              # Shared mock API responses
│   ├── auth.fixture.ts           # Authenticated page fixture
│   ├── course-mocks.ts           # Course states + route helpers
│   └── platform.fixture.ts       # Public page fixture
└── platform/
    ├── landing.spec.ts           # Platform landing page
    ├── shiksha.spec.ts           # Shiksha public flow
    ├── shiksha-enrollment.spec.ts # Full enrollment lifecycle
    └── interview-prep.spec.ts    # Interview prep public flow
```

## What's next (not in this PR)

- **Tier 2**: Dashboard, onboarding form flow, auth redirect tests (auth fixture is ready)
- **Tier 4**: Projects and Interview Prep enrollment flows (same pattern as Shiksha)
- **Tier 5**: Cross-app navigation tests (Platform ↔ Quiz ↔ Prep-yatra)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)