### PR TITLE
DSA Yatra: Fix AI-sounding copy in Common Questions FAQ (Vibe Kanban)

### DIFF
--- a/apps/dsayatra/src/data/dsaData.ts
+++ b/apps/dsayatra/src/data/dsaData.ts
@@ -28,7 +28,7 @@ export const DSA_YATRA_FAQS = [
   {
     question: "Is DSA Yatra free?",
     answer:
-      "Yes. You get free access to structured content and practice. We also offer premium paths with tailored roadmaps, company-focused question sets, and deeper tracking—so you can start free and upgrade when you want more focus.",
+      "Yes. You get free access to structured content and practice. We also have premium paths with tailored roadmaps, company-focused question sets, and deeper tracking. Start free and upgrade when you want more focus.",
   },
   {
     question: "How is this different from solving random LeetCode problems?",


### PR DESCRIPTION
## What changed

- **DSA Yatra landing page — Common Questions:** Updated the answer for *"Is DSA Yatra free?"* so it reads more natural and less AI-generated.

## Why

- The previous copy used an em dash (—) and slightly formal phrasing (e.g. "We also offer … —so you can start free"), which felt templated and AI-written.
- This was flagged during the DSA Bug Bash as copy that needed to sound more human and on-brand.

## Implementation details

- **File:** `apps/dsayatra/src/data/dsaData.ts`
- **Edits:**
  - Removed the em dash and split the run-on into two sentences (e.g. "…deeper tracking. Start free and upgrade when you want more focus.").
  - Tweaked wording: "We also offer" → "We also have" for a more conversational tone.
- Message and value proposition are unchanged; only tone and punctuation were adjusted.

---

This PR was written using [Vibe Kanban](https://vibekanban.com).