### PR TITLE
Refresh sitemap lastmod timestamps across learner apps (Vibe Kanban)

### DIFF
--- a/apps/dsayatra/public/sitemap.xml
+++ b/apps/dsayatra/public/sitemap.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://dsayatra.theboringeducation.com</loc><lastmod>2026-03-18T07:36:01.962Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/auth/callback</loc><lastmod>2026-03-18T07:36:01.964Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/dashboard</loc><lastmod>2026-03-18T07:36:01.964Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/login</loc><lastmod>2026-03-18T07:36:01.964Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/revisions</loc><lastmod>2026-03-18T07:36:01.964Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/sheets</loc><lastmod>2026-03-18T07:36:01.964Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/topics</loc><lastmod>2026-03-18T07:36:01.964Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com</loc><lastmod>2026-03-19T15:38:57.622Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/auth/callback</loc><lastmod>2026-03-19T15:38:57.623Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/dashboard</loc><lastmod>2026-03-19T15:38:57.623Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/login</loc><lastmod>2026-03-19T15:38:57.623Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/revisions</loc><lastmod>2026-03-19T15:38:57.623Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/sheets</loc><lastmod>2026-03-19T15:38:57.623Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/topics</loc><lastmod>2026-03-19T15:38:57.623Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/apps/oncampus/public/sitemap.xml
+++ b/apps/oncampus/public/sitemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://oncampus.theboringeducation.com</loc><lastmod>2026-03-18T07:35:50.562Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
-<url><loc>https://oncampus.theboringeducation.com/auth/callback</loc><lastmod>2026-03-18T07:35:50.562Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://oncampus.theboringeducation.com/campus-prep</loc><lastmod>2026-03-18T07:35:50.562Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://oncampus.theboringeducation.com/dashboard</loc><lastmod>2026-03-18T07:35:50.562Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://oncampus.theboringeducation.com/login</loc><lastmod>2026-03-18T07:35:50.562Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+<url><loc>https://oncampus.theboringeducation.com</loc><lastmod>2026-03-19T15:38:36.737Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
+<url><loc>https://oncampus.theboringeducation.com/auth/callback</loc><lastmod>2026-03-19T15:38:36.738Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://oncampus.theboringeducation.com/campus-prep</loc><lastmod>2026-03-19T15:38:36.738Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://oncampus.theboringeducation.com/dashboard</loc><lastmod>2026-03-19T15:38:36.738Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://oncampus.theboringeducation.com/login</loc><lastmod>2026-03-19T15:38:36.738Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
 </urlset>

--- a/apps/prep-yatra/public/sitemap.xml
+++ b/apps/prep-yatra/public/sitemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://prepyatra.theboringeducation.com/</loc><lastmod>2026-03-18T08:16:44.495Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
-<url><loc>https://prepyatra.theboringeducation.com/auth/callback/</loc><lastmod>2026-03-18T08:16:44.496Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://prepyatra.theboringeducation.com/dashboard/</loc><lastmod>2026-03-18T08:16:44.496Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://prepyatra.theboringeducation.com/login/</loc><lastmod>2026-03-18T08:16:44.496Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
-<url><loc>https://prepyatra.theboringeducation.com/pricing/</loc><lastmod>2026-03-18T08:16:44.496Z</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+<url><loc>https://prepyatra.theboringeducation.com/</loc><lastmod>2026-03-19T15:38:55.924Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
+<url><loc>https://prepyatra.theboringeducation.com/auth/callback/</loc><lastmod>2026-03-19T15:38:55.926Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://prepyatra.theboringeducation.com/dashboard/</loc><lastmod>2026-03-19T15:38:55.926Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://prepyatra.theboringeducation.com/login/</loc><lastmod>2026-03-19T15:38:55.926Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+<url><loc>https://prepyatra.theboringeducation.com/pricing/</loc><lastmod>2026-03-19T15:38:55.926Z</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
 </urlset>

--- a/apps/quizes/public/sitemap.xml
+++ b/apps/quizes/public/sitemap.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://quiz.theboringeducation.com</loc><lastmod>2026-03-18T07:36:09.183Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
-<url><loc>https://quiz.theboringeducation.com/auth/callback</loc><lastmod>2026-03-18T07:36:09.183Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://quiz.theboringeducation.com/dashboard</loc><lastmod>2026-03-18T07:36:09.183Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://quiz.theboringeducation.com/leaderboard</loc><lastmod>2026-03-18T07:36:09.183Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
-<url><loc>https://quiz.theboringeducation.com/login</loc><lastmod>2026-03-18T07:36:09.183Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
-<url><loc>https://quiz.theboringeducation.com/performance</loc><lastmod>2026-03-18T07:36:09.183Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://quiz.theboringeducation.com</loc><lastmod>2026-03-19T15:39:03.511Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
+<url><loc>https://quiz.theboringeducation.com/auth/callback</loc><lastmod>2026-03-19T15:39:03.511Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://quiz.theboringeducation.com/dashboard</loc><lastmod>2026-03-19T15:39:03.511Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://quiz.theboringeducation.com/leaderboard</loc><lastmod>2026-03-19T15:39:03.511Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://quiz.theboringeducation.com/login</loc><lastmod>2026-03-19T15:39:03.511Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+<url><loc>https://quiz.theboringeducation.com/performance</loc><lastmod>2026-03-19T15:39:03.511Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/apps/resume-yatra/public/sitemap.xml
+++ b/apps/resume-yatra/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://resumeyatra.theboringeducation.com/</loc><lastmod>2026-03-18T07:35:57.626Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
-<url><loc>https://resumeyatra.theboringeducation.com/auth/callback/</loc><lastmod>2026-03-18T07:35:57.627Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://resumeyatra.theboringeducation.com/builder/</loc><lastmod>2026-03-18T07:35:57.627Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://resumeyatra.theboringeducation.com/login/</loc><lastmod>2026-03-18T07:35:57.627Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+<url><loc>https://resumeyatra.theboringeducation.com/</loc><lastmod>2026-03-19T15:38:53.267Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
+<url><loc>https://resumeyatra.theboringeducation.com/auth/callback/</loc><lastmod>2026-03-19T15:38:53.268Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://resumeyatra.theboringeducation.com/builder/</loc><lastmod>2026-03-19T15:38:53.268Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://resumeyatra.theboringeducation.com/login/</loc><lastmod>2026-03-19T15:38:53.268Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
 </urlset>


### PR DESCRIPTION
## What changes were made
- Updated static sitemap files in:
  - `apps/dsayatra/public/sitemap.xml`
  - `apps/oncampus/public/sitemap.xml`
  - `apps/prep-yatra/public/sitemap.xml`
  - `apps/quizes/public/sitemap.xml`
  - `apps/resume-yatra/public/sitemap.xml`
- Refreshed `<lastmod>` values for existing URLs in each sitemap.
- Kept all existing URL structure, `changefreq`, and `priority` values unchanged.

## Why these changes were made
- This branch is focused on a build/SEO freshness update, and the concrete branch diff is a sitemap metadata refresh.
- Updating `<lastmod>` timestamps helps search engines recrawl with up-to-date freshness signals across key learner-facing apps.
- Scope is intentionally narrow to keep risk low while maintaining crawl/index hygiene.

## Important implementation details
- Change type: static XML metadata update only.
- Runtime impact: none (no changes to app logic, APIs, routing, or data models).
- Diff size: 5 files changed, 27 insertions and 27 deletions.
- Operational risk: low; this is a deterministic sitemap timestamp update.

This PR was written using [Vibe Kanban](https://vibekanban.com)