### PR TITLE
username at dsayatra dashboard fixed

### DIFF
--- a/apps/dsayatra/src/pages/dashboard.tsx
+++ b/apps/dsayatra/src/pages/dashboard.tsx
@@ -408,7 +408,7 @@ function DsaClient() {
               {user?.name || "Shivani Jha"}
             </h3>
             <p className="text-[#a0a0a0] text-xs mt-0.5">
-              @{user?.userName || "shivanijhavats"}
+              @{user?.email?.split("@")[0] || "shivanijhavats"}
             </p>
 
             <div className="flex gap-3 my-4">

--- a/packages/components/src/prepyatra/modals/EditDsaOnboardingModal.tsx
+++ b/packages/components/src/prepyatra/modals/EditDsaOnboardingModal.tsx
@@ -134,7 +134,7 @@ const EditDsaOnboardingModal: React.FC<EditDsaOnboardingModalProps> = ({
 
         <div className="space-y-2 mt-0.5 px-1.5 pb-3">
           {/* Basic Info */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <div className="">
             <div className="space-y-0.5">
               <label className="block text-[9px] font-black text-[#606060] uppercase tracking-[0.2em]">
                 Full Name
@@ -143,17 +143,6 @@ const EditDsaOnboardingModal: React.FC<EditDsaOnboardingModalProps> = ({
                 type="text"
                 value={formData.name}
                 onChange={(e) => handleInputChange("name", e.target.value)}
-                className="w-full px-2 py-1.5 rounded-lg bg-[#0a0a0a] border border-[#2a2a2a] text-[#e0e0e0] text-xs font-bold focus:border-[#ff5757] outline-none transition-all"
-              />
-            </div>
-            <div className="space-y-0.5">
-              <label className="block text-[9px] font-black text-[#606060] uppercase tracking-[0.2em]">
-                Username
-              </label>
-              <input
-                type="text"
-                value={formData.username}
-                onChange={(e) => handleInputChange("username", e.target.value)}
                 className="w-full px-2 py-1.5 rounded-lg bg-[#0a0a0a] border border-[#2a2a2a] text-[#e0e0e0] text-xs font-bold focus:border-[#ff5757] outline-none transition-all"
               />
             </div>


### PR DESCRIPTION
* Fixed username not showing correctly on the main dashboard of DSA Yatra
* Removed the username change section
* Username is now automatically set based on the user’s email (for consistency with most apps)
<img width="1530" height="528" alt="Screenshot 2026-03-24 162709" src="https://github.com/user-attachments/assets/9e0b2a8d-de81-4770-9b1c-c350cb2e563d" />
