### PR TITLE
fix(dsa): restore visible topic names on Sheets via API + hook contract alignment (Vibe Kanban)

### DIFF
--- a/apps/api/src/lib/database/queries/interview-prep.ts
+++ b/apps/api/src/lib/database/queries/interview-prep.ts
@@ -733,14 +733,17 @@ const getDSATopicSummariesFromDB =
         [...DSA_TOPICS].map((topicId, index) => [topicId, index]),
       );
 
-      const topics: DSATopicType[] = rows
-        .map((row) => row._id as DSATopicType)
+      const topics = rows
+        .map((row) => ({
+          topic: row._id as DSATopicType,
+          count: row.count,
+        }))
         .sort((a, b) => {
-          const ia = orderMap.get(a as string) ?? 999;
-          const ib = orderMap.get(b as string) ?? 999;
+          const ia = orderMap.get(a.topic as string) ?? 999;
+          const ib = orderMap.get(b.topic as string) ?? 999;
           if (ia !== ib) return ia - ib;
-          return a.localeCompare(b);
-        }) as DSATopicType[];
+          return (a.topic as string).localeCompare(b.topic as string);
+        });
 
       return { data: { topics } };
     } catch (error) {

--- a/apps/dsayatra/public/sitemap.xml
+++ b/apps/dsayatra/public/sitemap.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://dsayatra.theboringeducation.com</loc><lastmod>2026-03-21T20:06:06.543Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/auth/callback</loc><lastmod>2026-03-21T20:06:06.544Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/dashboard</loc><lastmod>2026-03-21T20:06:06.544Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/login</loc><lastmod>2026-03-21T20:06:06.544Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/revisions</loc><lastmod>2026-03-21T20:06:06.544Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/sheets</loc><lastmod>2026-03-21T20:06:06.544Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/topics</loc><lastmod>2026-03-21T20:06:06.544Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com</loc><lastmod>2026-03-25T06:12:12.372Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/auth/callback</loc><lastmod>2026-03-25T06:12:12.373Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/dashboard</loc><lastmod>2026-03-25T06:12:12.373Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/login</loc><lastmod>2026-03-25T06:12:12.373Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/revisions</loc><lastmod>2026-03-25T06:12:12.373Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/sheets</loc><lastmod>2026-03-25T06:12:12.373Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/topics</loc><lastmod>2026-03-25T06:12:12.373Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/apps/oncampus/public/sitemap.xml
+++ b/apps/oncampus/public/sitemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://oncampus.theboringeducation.com</loc><lastmod>2026-03-21T20:05:55.962Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
-<url><loc>https://oncampus.theboringeducation.com/auth/callback</loc><lastmod>2026-03-21T20:05:55.964Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://oncampus.theboringeducation.com/campus-prep</loc><lastmod>2026-03-21T20:05:55.964Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://oncampus.theboringeducation.com/dashboard</loc><lastmod>2026-03-21T20:05:55.964Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://oncampus.theboringeducation.com/login</loc><lastmod>2026-03-21T20:05:55.964Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+<url><loc>https://oncampus.theboringeducation.com</loc><lastmod>2026-03-25T06:11:54.705Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
+<url><loc>https://oncampus.theboringeducation.com/auth/callback</loc><lastmod>2026-03-25T06:11:54.707Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://oncampus.theboringeducation.com/campus-prep</loc><lastmod>2026-03-25T06:11:54.707Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://oncampus.theboringeducation.com/dashboard</loc><lastmod>2026-03-25T06:11:54.707Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://oncampus.theboringeducation.com/login</loc><lastmod>2026-03-25T06:11:54.707Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
 </urlset>

--- a/apps/prep-yatra/public/sitemap.xml
+++ b/apps/prep-yatra/public/sitemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://prepyatra.theboringeducation.com/</loc><lastmod>2026-03-21T20:06:05.940Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
-<url><loc>https://prepyatra.theboringeducation.com/auth/callback/</loc><lastmod>2026-03-21T20:06:05.941Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://prepyatra.theboringeducation.com/dashboard/</loc><lastmod>2026-03-21T20:06:05.941Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://prepyatra.theboringeducation.com/login/</loc><lastmod>2026-03-21T20:06:05.941Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
-<url><loc>https://prepyatra.theboringeducation.com/pricing/</loc><lastmod>2026-03-21T20:06:05.941Z</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+<url><loc>https://prepyatra.theboringeducation.com/</loc><lastmod>2026-03-25T06:12:09.049Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
+<url><loc>https://prepyatra.theboringeducation.com/auth/callback/</loc><lastmod>2026-03-25T06:12:09.050Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://prepyatra.theboringeducation.com/dashboard/</loc><lastmod>2026-03-25T06:12:09.050Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://prepyatra.theboringeducation.com/login/</loc><lastmod>2026-03-25T06:12:09.050Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+<url><loc>https://prepyatra.theboringeducation.com/pricing/</loc><lastmod>2026-03-25T06:12:09.050Z</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
 </urlset>

--- a/apps/quizes/public/sitemap.xml
+++ b/apps/quizes/public/sitemap.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://quiz.theboringeducation.com</loc><lastmod>2026-03-21T20:06:14.101Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
-<url><loc>https://quiz.theboringeducation.com/auth/callback</loc><lastmod>2026-03-21T20:06:14.101Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://quiz.theboringeducation.com/dashboard</loc><lastmod>2026-03-21T20:06:14.101Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://quiz.theboringeducation.com/leaderboard</loc><lastmod>2026-03-21T20:06:14.101Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
-<url><loc>https://quiz.theboringeducation.com/login</loc><lastmod>2026-03-21T20:06:14.101Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
-<url><loc>https://quiz.theboringeducation.com/performance</loc><lastmod>2026-03-21T20:06:14.101Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://quiz.theboringeducation.com</loc><lastmod>2026-03-25T06:12:17.159Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
+<url><loc>https://quiz.theboringeducation.com/auth/callback</loc><lastmod>2026-03-25T06:12:17.160Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://quiz.theboringeducation.com/dashboard</loc><lastmod>2026-03-25T06:12:17.160Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://quiz.theboringeducation.com/leaderboard</loc><lastmod>2026-03-25T06:12:17.160Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://quiz.theboringeducation.com/login</loc><lastmod>2026-03-25T06:12:17.160Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+<url><loc>https://quiz.theboringeducation.com/performance</loc><lastmod>2026-03-25T06:12:17.160Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/apps/resume-yatra/public/sitemap.xml
+++ b/apps/resume-yatra/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://resumeyatra.theboringeducation.com/</loc><lastmod>2026-03-21T20:06:02.194Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
-<url><loc>https://resumeyatra.theboringeducation.com/auth/callback/</loc><lastmod>2026-03-21T20:06:02.195Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://resumeyatra.theboringeducation.com/builder/</loc><lastmod>2026-03-21T20:06:02.195Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://resumeyatra.theboringeducation.com/login/</loc><lastmod>2026-03-21T20:06:02.195Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+<url><loc>https://resumeyatra.theboringeducation.com/</loc><lastmod>2026-03-25T06:12:05.385Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
+<url><loc>https://resumeyatra.theboringeducation.com/auth/callback/</loc><lastmod>2026-03-25T06:12:05.387Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://resumeyatra.theboringeducation.com/builder/</loc><lastmod>2026-03-25T06:12:05.387Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://resumeyatra.theboringeducation.com/login/</loc><lastmod>2026-03-25T06:12:05.387Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
 </urlset>

--- a/packages/constants/src/campusPrep.ts
+++ b/packages/constants/src/campusPrep.ts
@@ -89,9 +89,13 @@ export const TOPIC_LABELS: Record<string, string> = {
   DYNAMIC_PROGRAMMING: "Dynamic Programming",
   GREEDY: "Greedy",
   MATH: "Math",
+  RECURSION: "Recursion",
   BIT_MANIPULATION: "Bit Manipulation",
   TRIE: "Trie",
   HEAP: "Heap",
   UNION_FIND: "Union Find",
   PREFIX_SUM: "Prefix Sum",
+  SIMULATION: "Simulation",
+  DESIGN: "Design",
+  MONOTONIC_STACK: "Monotonic Stack",
 };

--- a/packages/hooks/src/useDsaTopicSummaries.ts
+++ b/packages/hooks/src/useDsaTopicSummaries.ts
@@ -20,10 +20,16 @@ export const useDsaTopicSummaries = () => {
         method: "GET",
       });
 
-      const rows = result.data?.topics as DsaTopicSummaryRow[] | undefined;
-      if (!Array.isArray(rows)) {
+      const raw = result.data?.topics;
+      if (!Array.isArray(raw)) {
         throw new Error(result.message || "Failed to fetch DSA topics");
       }
+      // API may return legacy string[]; sheet UI expects { topic, count }.
+      const rows: DsaTopicSummaryRow[] = raw.map((item: unknown) =>
+        typeof item === "string"
+          ? { topic: item, count: 0 }
+          : (item as DsaTopicSummaryRow),
+      );
       return rows;
     },
     ...CACHE_TIMES.STABLE,


### PR DESCRIPTION
## Summary

DSA Yatra **Sheets** (`/sheets`) showed folder icons with **no topic titles** even though `GET /interview-prep/dsa-sheet?query=topics` returned data. This change fixes the **response shape mismatch** between the API and the client, and fills gaps in `TOPIC_LABELS` for enums that exist in the backend topic list.

## What changed

### API — `getDSATopicSummariesFromDB` (`apps/api/src/lib/database/queries/interview-prep.ts`)
- **Before:** `topics` was a **string array** of primary topic ids (aggregation counts were computed then discarded).
- **After:** `topics` is an array of **`{ topic, count }`** objects, still sorted using the canonical `DSA_TOPICS` order.

### Client — `useDsaTopicSummaries` (`packages/hooks/src/useDsaTopicSummaries.ts`)
- Normalizes the payload: if `topics` is still a **legacy `string[]`**, each entry is mapped to ``{ topic, count: 0 }`` so the Sheets UI never treats a string like an object again.

### Constants — `TOPIC_LABELS` (`packages/constants/src/campusPrep.ts`)
- Added display names for **`RECURSION`**, **`SIMULATION`**, **`DESIGN`**, and **`MONOTONIC_STACK`** so they stay consistent with `DSA_TOPICS` in the API when those topics appear in summaries.

### Sitemaps (incidental)
- **`lastmod`** timestamps were refreshed in several apps’ `public/sitemap.xml` files (dsayatra, oncampus, prep-yatra, quizes, resume-yatra) as part of the same commit—no URL structure changes.

## Why

The UI builds rows with `t.topic` and `TOPIC_LABELS[t.topic]`. When each list item was a **plain string**, `t.topic` was `undefined`, so **labels rendered empty** while icons still showed—matching the reported bug. The issue was **not** primarily “enums need prettier strings”; `TOPIC_LABELS` already covered most ids once the **correct key** was passed through.

## Testing / verification

- Manually: open DSA Yatra **Sheets** with a profile that passes the sheet gate; topic sidebar should list **Array**, **String**, **Linked List**, etc., with stable ordering.
- Optional: call `GET .../dsa-sheet?query=topics` and confirm `data.topics` entries are objects with `topic` and `count`.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)