### PR TITLE
revision icon colors and continue learning button

### DIFF
--- a/apps/dsayatra/src/pages/dashboard.tsx
+++ b/apps/dsayatra/src/pages/dashboard.tsx
@@ -364,9 +364,11 @@ const DsaClient = () => {
             </p>
           </div>
           <div className="flex gap-3">
-            <Button className="bg-[#ff6b6b] hover:bg-[#ff5252] text-white px-4 py-2 h-auto font-semibold text-xs rounded-md transition-all hover:scale-105">
-              Continue Learning
-            </Button>
+            <Link href="/sheets" tabIndex={-1}>
+              <Button className="bg-[#ff6b6b] hover:bg-[#ff5252] text-white px-4 py-2 h-auto font-semibold text-xs rounded-md transition-all hover:scale-105">
+                Continue Learning
+              </Button>
+            </Link>
             <Button
               onClick={() => setIsEditModalOpen(true)}
               className="bg-[#2a2a2a] border border-[#3a3a3a] text-[#e0e0e0] hover:bg-[#333] h-auto px-4 py-2 font-semibold text-xs rounded-md"

--- a/apps/dsayatra/src/pages/revisions.tsx
+++ b/apps/dsayatra/src/pages/revisions.tsx
@@ -605,7 +605,6 @@ export default function RevisionsUI({ seoMeta }: PageProps) {
                               href={q.resources.leetcodeURL}
                               target="_blank"
                               rel="noopener noreferrer"
-                              className="grayscale hover:grayscale-0 transition-all duration-300 opacity-50 hover:opacity-100"
                               title="Solve on LeetCode"
                               onClick={(e) => e.stopPropagation()}
                             >
@@ -617,7 +616,6 @@ export default function RevisionsUI({ seoMeta }: PageProps) {
                               href={q.resources.youtubeURL}
                               target="_blank"
                               rel="noopener noreferrer"
-                              className="grayscale hover:grayscale-0 transition-all duration-300 opacity-50 hover:opacity-100"
                               title="Watch explanation on YouTube"
                               onClick={(e) => e.stopPropagation()}
                             >


### PR DESCRIPTION
The changes I made earlier have been reverted, so implementing them again.
<img width="1608" height="84" alt="Screenshot 2026-03-26 204251" src="https://github.com/user-attachments/assets/4be5a6c0-cfc9-4b1b-b9a8-f0885fe4c88a" />
<img width="1359" height="411" alt="Screenshot 2026-03-26 204307" src="https://github.com/user-attachments/assets/3c10fdcc-b9ed-4d6b-95a6-54bcca8db62c" />
