### PR TITLE
make topic-wise progress cards navigable to filtered sheets

### DIFF
--- a/apps/dsayatra/src/pages/dashboard.tsx
+++ b/apps/dsayatra/src/pages/dashboard.tsx
@@ -596,23 +596,26 @@ const DsaClient = () => {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3.5">
             {topicProgress.length > 0 ? (
               topicProgress.map((topic) => (
-                <div
+                <Link
                   key={topic.key}
-                  className="bg-[#0f0f0f] border border-[#2a2a2a] p-4 rounded-lg text-center cursor-pointer hover:border-[#ff5757] transition-all group"
+                  href={`/sheets?topic=${topic.key}`}
+                  className="block"
                 >
-                  <p className="text-xs font-bold text-[#e0e0e0] uppercase">
-                    {topic.name}
-                  </p>
-                  <p className="text-[10px] text-[#a0a0a0] my-1.5">
-                    {topic.solved}/{topic.total}
-                  </p>
-                  <Progress
-                    value={
-                      topic.total > 0 ? (topic.solved / topic.total) * 100 : 0
-                    }
-                    className="h-1.5 bg-[#1a1a1a] rounded"
-                  />
-                </div>
+                  <div className="bg-[#0f0f0f] border border-[#2a2a2a] p-4 rounded-lg text-center cursor-pointer hover:border-[#ff5757] transition-all group">
+                    <p className="text-xs font-bold text-[#e0e0e0] uppercase">
+                      {topic.name}
+                    </p>
+                    <p className="text-[10px] text-[#a0a0a0] my-1.5">
+                      {topic.solved}/{topic.total}
+                    </p>
+                    <Progress
+                      value={
+                        topic.total > 0 ? (topic.solved / topic.total) * 100 : 0
+                      }
+                      className="h-1.5 bg-[#1a1a1a] rounded"
+                    />
+                  </div>
+                </Link>
               ))
             ) : (
               <div className="col-span-full text-center py-6">


### PR DESCRIPTION
feat(dsayatra): make topic-wise progress cards navigable to filtered sheets
Wrapped each topic card in the dashboard's Topic-wise Progress section
with a Next.js Link pointing to `/sheets?topic=<topicKey>`. Clicking a
topic now navigates directly to that topic's sheet without modifying the
existing card component definition (OCP).

<img width="1622" height="529" alt="image" src="https://github.com/user-attachments/assets/02fbe93d-334a-4363-8b53-294df18f809b" />
