### PR TITLE
Persist DSA Yatra question progress to MongoDB (Vibe Kanban)

### DIFF
--- a/apps/api/src/lib/constants/routes.ts
+++ b/apps/api/src/lib/constants/routes.ts
@@ -97,6 +97,7 @@ const routes = {
     markCourseChapterAsCompleted: "/user/shiksha/course",
     markProjectChapterAsCompleted: "/user/projects/project",
     markSheetQuestionAsCompleted: "/user/interview-prep/sheet",
+    dsaYatraProgress: "/user/dsayatra/progress",
     submitUserFeedback: "/feedback",
     createOrder: "/payment/create-order",
     checkStatus: "/payment/checkstatus",

--- a/apps/api/src/lib/database/models/User.ts
+++ b/apps/api/src/lib/database/models/User.ts
@@ -87,6 +87,21 @@ const DSAYatraSchema = new Schema({
     enum: DSA_TOPICS,
     default: [],
   },
+  progress: {
+    completedQuestionIds: {
+      type: [String],
+      default: [],
+    },
+    todayStats: {
+      date: {
+        type: String,
+      },
+      solvedCount: {
+        type: Number,
+        default: 0,
+      },
+    },
+  },
 });
 
 const UserSchema: Schema<UserModel> = new Schema(

--- a/apps/api/src/lib/database/queries/dsayatra.ts
+++ b/apps/api/src/lib/database/queries/dsayatra.ts
@@ -1,7 +1,32 @@
-import type { DatabaseQueryResponseType } from "@/lib/interfaces";
+import type {
+  DatabaseQueryResponseType,
+  DsaYatraProgressResponseProps,
+  DsaYatraTodayStatsPayload,
+} from "@/lib/interfaces";
 import { logger } from "@/lib/utils/logger";
 
 import { User } from "../models";
+
+const normalizeDsaQuestionId = (questionId: string | number): string =>
+  String(questionId);
+
+const todayDateString = (): string => new Date().toDateString();
+
+const buildProgressResponse = (
+  progress:
+    | {
+        completedQuestionIds?: string[];
+        todayStats?: { date?: string; solvedCount?: number };
+      }
+    | null
+    | undefined,
+): DsaYatraProgressResponseProps => {
+  const ids = (progress?.completedQuestionIds ?? []).map((id) => String(id));
+  const day = todayDateString();
+  const ts = progress?.todayStats;
+  const solvedToday = ts?.date === day ? Math.max(0, ts.solvedCount ?? 0) : 0;
+  return { completedQuestionIds: ids, solvedToday };
+};
 
 const getDYUserByIdFromDB = async (
   userId: string,
@@ -35,4 +60,153 @@ const updateDYUserByIdInDB = async (
   }
 };
 
-export { getDYUserByIdFromDB, updateDYUserByIdInDB };
+const getDsaYatraProgressFromDB = async (
+  userId: string,
+): Promise<DatabaseQueryResponseType> => {
+  try {
+    const user = await User.findById(userId).select("dsaYatra.progress").lean();
+    if (!user) {
+      return { error: "User not found" };
+    }
+    const data = buildProgressResponse(user.dsaYatra?.progress);
+    return { data };
+  } catch (error) {
+    logger.error("DB: getDsaYatraProgressFromDB failed", {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    return { error: "Failed to fetch DSA Yatra progress", details: error };
+  }
+};
+
+const patchDsaYatraQuestionCompletionInDB = async (
+  userId: string,
+  questionId: string | number,
+  isCompleted: boolean,
+): Promise<DatabaseQueryResponseType> => {
+  try {
+    const qid = normalizeDsaQuestionId(questionId);
+    const user = await User.findById(userId).select("dsaYatra.progress");
+    if (!user) {
+      return { error: "User not found" };
+    }
+
+    const prev = user.dsaYatra?.progress;
+    const idSet = new Set(
+      (prev?.completedQuestionIds ?? []).map((id) => String(id)),
+    );
+    const day = todayDateString();
+    let todayStats: DsaYatraTodayStatsPayload = {
+      date: day,
+      solvedCount: 0,
+    };
+    if (prev?.todayStats?.date === day) {
+      todayStats = {
+        date: day,
+        solvedCount: Math.max(0, prev.todayStats.solvedCount ?? 0),
+      };
+    }
+
+    const had = idSet.has(qid);
+    let didMutate = false;
+    if (isCompleted) {
+      if (!had) {
+        idSet.add(qid);
+        todayStats.solvedCount += 1;
+        didMutate = true;
+      }
+    } else if (had) {
+      idSet.delete(qid);
+      if (todayStats.solvedCount > 0) {
+        todayStats.solvedCount -= 1;
+      }
+      didMutate = true;
+    }
+
+    if (didMutate) {
+      await User.updateOne(
+        { _id: userId },
+        {
+          $set: {
+            "dsaYatra.progress.completedQuestionIds": [...idSet],
+            "dsaYatra.progress.todayStats": todayStats,
+          },
+        },
+      );
+    }
+
+    return getDsaYatraProgressFromDB(userId);
+  } catch (error) {
+    logger.error("DB: patchDsaYatraQuestionCompletionInDB failed", {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    return { error: "Failed to update DSA Yatra question", details: error };
+  }
+};
+
+const mergeDsaYatraProgressInDB = async (
+  userId: string,
+  addCompletedQuestionIds: string[],
+  clientToday?: DsaYatraTodayStatsPayload,
+): Promise<DatabaseQueryResponseType> => {
+  try {
+    const user = await User.findById(userId).select("dsaYatra.progress");
+    if (!user) {
+      return { error: "User not found" };
+    }
+
+    const prev = user.dsaYatra?.progress;
+    const idSet = new Set(
+      (prev?.completedQuestionIds ?? []).map((id) => String(id)),
+    );
+    for (const raw of addCompletedQuestionIds) {
+      idSet.add(String(raw));
+    }
+
+    const day = todayDateString();
+    let todayStats: DsaYatraTodayStatsPayload = {
+      date: day,
+      solvedCount: 0,
+    };
+    if (prev?.todayStats?.date === day) {
+      todayStats = {
+        date: day,
+        solvedCount: Math.max(0, prev.todayStats.solvedCount ?? 0),
+      };
+    }
+
+    if (clientToday?.date === day) {
+      todayStats.solvedCount = Math.max(
+        todayStats.solvedCount,
+        Math.max(0, clientToday.solvedCount ?? 0),
+      );
+    }
+
+    await User.updateOne(
+      { _id: userId },
+      {
+        $set: {
+          "dsaYatra.progress.completedQuestionIds": [...idSet],
+          "dsaYatra.progress.todayStats": todayStats,
+        },
+      },
+    );
+
+    return getDsaYatraProgressFromDB(userId);
+  } catch (error) {
+    logger.error("DB: mergeDsaYatraProgressInDB failed", {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    return { error: "Failed to merge DSA Yatra progress", details: error };
+  }
+};
+
+export {
+  getDsaYatraProgressFromDB,
+  getDYUserByIdFromDB,
+  mergeDsaYatraProgressInDB,
+  patchDsaYatraQuestionCompletionInDB,
+  updateDYUserByIdInDB,
+};

--- a/apps/api/src/lib/interfaces/api.ts
+++ b/apps/api/src/lib/interfaces/api.ts
@@ -202,6 +202,32 @@ export interface DSAYatraOnboardingPayload {
   targetTopics: DSATopicType[];
 }
 
+export interface DsaYatraTodayStatsPayload {
+  date: string;
+  solvedCount: number;
+}
+
+export interface DsaYatraProgressResponseProps {
+  completedQuestionIds: string[];
+  solvedToday: number;
+}
+
+export interface GetDsaYatraProgressQueryProps {
+  userId: string;
+}
+
+export interface PatchDsaYatraQuestionCompletionProps {
+  userId: string;
+  questionId: string;
+  isCompleted: boolean;
+}
+
+export interface PutDsaYatraProgressMergeProps {
+  userId: string;
+  addCompletedQuestionIds: string[];
+  todayStats?: DsaYatraTodayStatsPayload;
+}
+
 export interface UpdateCompanyTypePayload {
   questionIds: string[];
   companyTypes: CompanyType[];

--- a/apps/api/src/lib/interfaces/database.ts
+++ b/apps/api/src/lib/interfaces/database.ts
@@ -71,6 +71,13 @@ export interface UserModel {
     target?: string;
     preferredLanguage?: string;
     targetTopics?: DSATopicType[];
+    progress?: {
+      completedQuestionIds?: string[];
+      todayStats?: {
+        date?: string;
+        solvedCount?: number;
+      };
+    };
   };
 }
 

--- a/apps/api/src/pages/api/v1/user/dsayatra/progress.ts
+++ b/apps/api/src/pages/api/v1/user/dsayatra/progress.ts
@@ -1,0 +1,228 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { apiStatusCodes } from "@/lib/constants";
+import {
+  getDsaYatraProgressFromDB,
+  handleGamificationPoints,
+  mergeDsaYatraProgressInDB,
+  patchDsaYatraQuestionCompletionInDB,
+} from "@/lib/database";
+import type {
+  DsaYatraProgressResponseProps,
+  GetDsaYatraProgressQueryProps,
+  PatchDsaYatraQuestionCompletionProps,
+  PutDsaYatraProgressMergeProps,
+} from "@/lib/interfaces";
+import { sendAPIResponse } from "@/lib/utils";
+import { withApiHandler } from "@/middleware/requestLogger";
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const { method } = req;
+
+    switch (method) {
+      case "GET":
+        return handleGetProgress(req, res);
+      case "PATCH":
+        return handlePatchQuestion(req, res);
+      case "PUT":
+        return handleMergeProgress(req, res);
+      default:
+        return res.status(apiStatusCodes.BAD_REQUEST).json(
+          sendAPIResponse({
+            status: false,
+            message: `Method ${req.method} Not Allowed`,
+          }),
+        );
+    }
+  } catch (error) {
+    return res.status(apiStatusCodes.INTERNAL_SERVER_ERROR).json(
+      sendAPIResponse({
+        status: false,
+        message: "Something went wrong",
+        error,
+      }),
+    );
+  }
+};
+
+const handleGetProgress = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { userId } = req.query as unknown as GetDsaYatraProgressQueryProps;
+
+  if (!userId) {
+    return res.status(apiStatusCodes.BAD_REQUEST).json(
+      sendAPIResponse({
+        status: false,
+        message: "userId is required",
+      }),
+    );
+  }
+
+  try {
+    const { data, error } = await getDsaYatraProgressFromDB(userId);
+
+    if (error) {
+      const notFound = error === "User not found";
+      return res
+        .status(
+          notFound
+            ? apiStatusCodes.NOT_FOUND
+            : apiStatusCodes.INTERNAL_SERVER_ERROR,
+        )
+        .json(
+          sendAPIResponse({
+            status: false,
+            message:
+              typeof error === "string" ? error : "Failed to load progress",
+          }),
+        );
+    }
+
+    return res.status(apiStatusCodes.OKAY).json(
+      sendAPIResponse({
+        status: true,
+        data,
+        message: "DSA Yatra progress loaded",
+      }),
+    );
+  } catch (error) {
+    return res.status(apiStatusCodes.INTERNAL_SERVER_ERROR).json(
+      sendAPIResponse({
+        status: false,
+        message: "Failed to load progress",
+        error,
+      }),
+    );
+  }
+};
+
+const handlePatchQuestion = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+) => {
+  const { userId, questionId, isCompleted } =
+    req.body as PatchDsaYatraQuestionCompletionProps;
+
+  if (!userId || questionId === undefined || questionId === null) {
+    return res.status(apiStatusCodes.BAD_REQUEST).json(
+      sendAPIResponse({
+        status: false,
+        message: "userId and questionId are required",
+      }),
+    );
+  }
+
+  if (typeof isCompleted !== "boolean") {
+    return res.status(apiStatusCodes.BAD_REQUEST).json(
+      sendAPIResponse({
+        status: false,
+        message: "isCompleted must be a boolean",
+      }),
+    );
+  }
+
+  try {
+    const beforeResult = await getDsaYatraProgressFromDB(userId);
+    if (beforeResult.error || !beforeResult.data) {
+      return res.status(apiStatusCodes.NOT_FOUND).json(
+        sendAPIResponse({
+          status: false,
+          message: "User not found",
+        }),
+      );
+    }
+    const before = beforeResult.data as DsaYatraProgressResponseProps;
+    const qid = String(questionId);
+    const hadBefore = before.completedQuestionIds.some(
+      (id: string) => String(id) === qid,
+    );
+
+    const { data, error } = await patchDsaYatraQuestionCompletionInDB(
+      userId,
+      questionId,
+      isCompleted,
+    );
+
+    if (error) {
+      return res.status(apiStatusCodes.INTERNAL_SERVER_ERROR).json(
+        sendAPIResponse({
+          status: false,
+          message: "Failed to update question progress",
+        }),
+      );
+    }
+
+    const progressChanged = hadBefore !== isCompleted;
+    if (progressChanged) {
+      await handleGamificationPoints(isCompleted, userId, "COMPLETE_QUESTION");
+    }
+
+    return res.status(apiStatusCodes.OKAY).json(
+      sendAPIResponse({
+        status: true,
+        data,
+        message: "Question progress updated",
+      }),
+    );
+  } catch (error) {
+    return res.status(apiStatusCodes.INTERNAL_SERVER_ERROR).json(
+      sendAPIResponse({
+        status: false,
+        message: "Failed to update question progress",
+        error,
+      }),
+    );
+  }
+};
+
+const handleMergeProgress = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+) => {
+  const { userId, addCompletedQuestionIds, todayStats } =
+    req.body as PutDsaYatraProgressMergeProps;
+
+  if (!userId || !Array.isArray(addCompletedQuestionIds)) {
+    return res.status(apiStatusCodes.BAD_REQUEST).json(
+      sendAPIResponse({
+        status: false,
+        message: "userId and addCompletedQuestionIds (array) are required",
+      }),
+    );
+  }
+
+  try {
+    const { data, error } = await mergeDsaYatraProgressInDB(
+      userId,
+      addCompletedQuestionIds.map((id) => String(id)),
+      todayStats,
+    );
+
+    if (error) {
+      return res.status(apiStatusCodes.INTERNAL_SERVER_ERROR).json(
+        sendAPIResponse({
+          status: false,
+          message: "Failed to merge progress",
+        }),
+      );
+    }
+
+    return res.status(apiStatusCodes.OKAY).json(
+      sendAPIResponse({
+        status: true,
+        data,
+        message: "Progress merged",
+      }),
+    );
+  } catch (error) {
+    return res.status(apiStatusCodes.INTERNAL_SERVER_ERROR).json(
+      sendAPIResponse({
+        status: false,
+        message: "Failed to merge progress",
+        error,
+      }),
+    );
+  }
+};
+
+export default withApiHandler(handler);

--- a/apps/dsayatra/src/pages/dashboard.tsx
+++ b/apps/dsayatra/src/pages/dashboard.tsx
@@ -145,7 +145,7 @@ const DsaClient = () => {
     queryKey: "dashboard-dsa-sheet",
   });
   const { completedIds: completedQuestions, solvedToday } =
-    useDsaCompletedQuestions();
+    useDsaCompletedQuestions({ userId: user?.id });
 
   const [weeklyAssignments, setWeeklyAssignments] = useState<
     Record<number, string[]>

--- a/apps/dsayatra/src/pages/revisions.tsx
+++ b/apps/dsayatra/src/pages/revisions.tsx
@@ -17,7 +17,7 @@ import { Fragment, useEffect, useState } from "react";
 
 export default function RevisionsUI({ seoMeta }: PageProps) {
   const router = useRouter();
-  const { loading: userLoading, isAuth } = useUser();
+  const { loading: userLoading, isAuth, user } = useUser();
   const [selectedWeek, setSelectedWeek] = useState<number | null>(null);
   const [weeklyAssignments, setWeeklyAssignments] = useState<
     Record<number, string[]>
@@ -27,7 +27,7 @@ export default function RevisionsUI({ seoMeta }: PageProps) {
   );
 
   const { questions: dsaQuestions, loading: sheetsLoading } = useDsaQuestions();
-  const { completedIds } = useDsaCompletedQuestions();
+  const { completedIds } = useDsaCompletedQuestions({ userId: user?.id });
   const globalCompleted = completedIds.map(String);
 
   useEffect(() => {

--- a/apps/dsayatra/src/pages/sheets.tsx
+++ b/apps/dsayatra/src/pages/sheets.tsx
@@ -64,7 +64,9 @@ const SheetsPageClient = () => {
     [topicQuestionsCache],
   );
 
-  const { completedIds, toggleComplete } = useDsaCompletedQuestions();
+  const { completedIds, toggleComplete } = useDsaCompletedQuestions({
+    userId: user?.id,
+  });
   const { topicsCompletionMap } = useDsaTopics(
     questionsForCompletion,
     completedIds,

--- a/apps/dsayatra/src/pages/topics.tsx
+++ b/apps/dsayatra/src/pages/topics.tsx
@@ -1,3 +1,4 @@
+import { useAuth } from "@tbe/auth";
 import type { RoadmapStatItem } from "@tbe/components";
 import { InteractiveRoadmap, SEO } from "@tbe/components";
 import { PAGE_REFRESH_TIMEOUT, routes, TOPIC_LABELS } from "@tbe/constants";
@@ -55,8 +56,11 @@ const PREFERRED_ORDER = [
 
 function TopicsClient() {
   const router = useRouter();
+  const { user } = useAuth();
   const { questions: allQuestions } = useDsaQuestions();
-  const { completedIds: completedQuestions } = useDsaCompletedQuestions();
+  const { completedIds: completedQuestions } = useDsaCompletedQuestions({
+    userId: user?.id,
+  });
 
   const nodes: RoadmapNode[] = useMemo(() => {
     const topicMap = new Map<string, { total: number; solved: number }>();

--- a/apps/oncampus/src/pages/dashboard/dsa-prep/index.tsx
+++ b/apps/oncampus/src/pages/dashboard/dsa-prep/index.tsx
@@ -1,4 +1,4 @@
-﻿import {
+import {
   DsaPrepWorkspace,
   LearningEnvironmentLayout,
   LoadingSpinner,
@@ -17,7 +17,7 @@ import { useEffect, useMemo, useState } from "react";
 
 const DSAPrepPage = () => {
   const router = useRouter();
-  const { loading: userLoading, isAuth } = useUser();
+  const { loading: userLoading, isAuth, user } = useUser();
 
   const [selectedQuestion, setSelectedQuestion] = useState<DsaQuestion | null>(
     null,
@@ -38,7 +38,9 @@ const DSAPrepPage = () => {
   const { questions, loading: topicQuestionsLoading } =
     useDsaQuestionsForTopic(selectedTopic);
 
-  const { completedIds, toggleComplete } = useDsaCompletedQuestions();
+  const { completedIds, toggleComplete } = useDsaCompletedQuestions({
+    userId: user?.id,
+  });
 
   const topicsCompletionMap = useMemo(() => {
     return (topicRows ?? []).reduce(

--- a/apps/testing/src/unit/hooks/useDsaCompletedQuestions.test.ts
+++ b/apps/testing/src/unit/hooks/useDsaCompletedQuestions.test.ts
@@ -1,5 +1,6 @@
 import { useDsaCompletedQuestions } from "@tbe/hooks";
-import { act, renderHook } from "@testing-library/react";
+import { renderHookWithQuery } from "@test-utils/query-wrapper";
+import { act } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("useDsaCompletedQuestions", () => {
@@ -40,22 +41,23 @@ describe("useDsaCompletedQuestions", () => {
   });
 
   it("should return empty completedIds initially when no localStorage data", () => {
-    const { result } = renderHook(() => useDsaCompletedQuestions());
+    const { result } = renderHookWithQuery(() => useDsaCompletedQuestions());
 
     expect(result.current.completedIds).toEqual([]);
     expect(result.current.solvedToday).toBe(0);
+    expect(result.current.isProgressLoading).toBe(false);
   });
 
   it("should load completed IDs from localStorage", () => {
     store["dsayatra_completed_questions"] = JSON.stringify(["q1", "q2", "q3"]);
 
-    const { result } = renderHook(() => useDsaCompletedQuestions());
+    const { result } = renderHookWithQuery(() => useDsaCompletedQuestions());
 
     expect(result.current.completedIds).toEqual(["q1", "q2", "q3"]);
   });
 
   it("should toggle a question to completed", () => {
-    const { result } = renderHook(() => useDsaCompletedQuestions());
+    const { result } = renderHookWithQuery(() => useDsaCompletedQuestions());
 
     act(() => {
       result.current.toggleComplete("q1");
@@ -68,7 +70,7 @@ describe("useDsaCompletedQuestions", () => {
   it("should toggle a question to incomplete", () => {
     store["dsayatra_completed_questions"] = JSON.stringify(["q1", "q2"]);
 
-    const { result } = renderHook(() => useDsaCompletedQuestions());
+    const { result } = renderHookWithQuery(() => useDsaCompletedQuestions());
 
     act(() => {
       result.current.toggleComplete("q1");
@@ -79,7 +81,7 @@ describe("useDsaCompletedQuestions", () => {
   });
 
   it("should track solved today count", () => {
-    const { result } = renderHook(() => useDsaCompletedQuestions());
+    const { result } = renderHookWithQuery(() => useDsaCompletedQuestions());
 
     act(() => {
       result.current.toggleComplete("q1");
@@ -95,7 +97,7 @@ describe("useDsaCompletedQuestions", () => {
   });
 
   it("should decrement solved today when uncompleting", () => {
-    const { result } = renderHook(() => useDsaCompletedQuestions());
+    const { result } = renderHookWithQuery(() => useDsaCompletedQuestions());
 
     act(() => {
       result.current.toggleComplete("q1");
@@ -112,7 +114,7 @@ describe("useDsaCompletedQuestions", () => {
     const customKey = "custom_completed";
     const customTodayKey = "custom_today";
 
-    const { result } = renderHook(() =>
+    const { result } = renderHookWithQuery(() =>
       useDsaCompletedQuestions(customKey, customTodayKey),
     );
 
@@ -127,7 +129,7 @@ describe("useDsaCompletedQuestions", () => {
   it("should handle corrupted localStorage data gracefully", () => {
     store["dsayatra_completed_questions"] = "invalid json{{{";
 
-    const { result } = renderHook(() => useDsaCompletedQuestions());
+    const { result } = renderHookWithQuery(() => useDsaCompletedQuestions());
 
     expect(result.current.completedIds).toEqual([]);
   });
@@ -139,7 +141,7 @@ describe("useDsaCompletedQuestions", () => {
       solvedCount: 5,
     });
 
-    const { result } = renderHook(() => useDsaCompletedQuestions());
+    const { result } = renderHookWithQuery(() => useDsaCompletedQuestions());
 
     expect(result.current.solvedToday).toBe(5);
   });
@@ -150,7 +152,7 @@ describe("useDsaCompletedQuestions", () => {
       solvedCount: 5,
     });
 
-    const { result } = renderHook(() => useDsaCompletedQuestions());
+    const { result } = renderHookWithQuery(() => useDsaCompletedQuestions());
 
     expect(result.current.solvedToday).toBe(0);
   });

--- a/packages/constants/src/routes.ts
+++ b/packages/constants/src/routes.ts
@@ -149,6 +149,7 @@ const routes = {
     markCourseChapterAsCompleted: "/user/shiksha/course",
     markProjectChapterAsCompleted: "/user/projects/project",
     markSheetQuestionAsCompleted: "/user/interview-prep/sheet",
+    dsaYatraProgress: "/user/dsayatra/progress",
     submitUserFeedback: "/feedback",
     createOrder: "/payment/create-order",
     checkStatus: "/payment/checkstatus",

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -16,6 +16,7 @@ export * from "./use-toast";
 export { default as useChallenges } from "./useChallenges";
 export { useChallengeProgress } from "./useChallenges";
 export { useDailyPrepEncouragement } from "./useDailyPrepEncouragement";
+export type { UseDsaCompletedQuestionsOptions } from "./useDsaCompletedQuestions";
 export { default as useDsaCompletedQuestions } from "./useDsaCompletedQuestions";
 export { default as useDsaQuestions } from "./useDsaQuestions";
 export { useDsaQuestionsForTopic } from "./useDsaQuestionsForTopic";

--- a/packages/hooks/src/useDsaCompletedQuestions.ts
+++ b/packages/hooks/src/useDsaCompletedQuestions.ts
@@ -25,6 +25,8 @@ interface UseDsaCompletedQuestionsReturn {
   solvedToday: number;
   /** True while loading server progress for an authenticated user */
   isProgressLoading: boolean;
+  localNotes: Record<string, string>;
+  saveNote: (questionId: string | number, notes: string) => Promise<void>;
 }
 
 const DEFAULT_STORAGE_KEY = "dsayatra_completed_questions";
@@ -299,6 +301,8 @@ const useDsaCompletedQuestions = (
     toggleComplete,
     solvedToday,
     isProgressLoading,
+    localNotes: {},
+    saveNote: async () => {},
   };
 };
 

--- a/packages/hooks/src/useDsaCompletedQuestions.ts
+++ b/packages/hooks/src/useDsaCompletedQuestions.ts
@@ -1,33 +1,103 @@
-import { useCallback, useEffect, useState } from "react";
+import { routes } from "@tbe/constants";
+import { CACHE_TIMES, queryKeys, useQuery, useQueryClient } from "@tbe/query";
+import { sendRequest } from "@tbe/utils";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 interface TodayStats {
   date: string;
   solvedCount: number;
 }
 
+interface DsaProgressPayload {
+  completedQuestionIds: string[];
+  solvedToday: number;
+}
+
+export interface UseDsaCompletedQuestionsOptions {
+  userId?: string | null;
+  storageKey?: string;
+  todayStatsKey?: string;
+}
+
 interface UseDsaCompletedQuestionsReturn {
   completedIds: (string | number)[];
   toggleComplete: (questionId: string | number) => void;
   solvedToday: number;
+  /** True while loading server progress for an authenticated user */
+  isProgressLoading: boolean;
 }
 
 const DEFAULT_STORAGE_KEY = "dsayatra_completed_questions";
 const DEFAULT_TODAY_STATS_KEY = "dsayatra_today_stats";
 
+function resolveArgs(
+  optionsOrLegacyStorageKey?: UseDsaCompletedQuestionsOptions | string,
+  legacyTodayStatsKey?: string,
+): Required<Omit<UseDsaCompletedQuestionsOptions, "userId">> & {
+  userId?: string | null;
+} {
+  if (typeof optionsOrLegacyStorageKey === "string") {
+    return {
+      userId: undefined,
+      storageKey: optionsOrLegacyStorageKey,
+      todayStatsKey: legacyTodayStatsKey ?? DEFAULT_TODAY_STATS_KEY,
+    };
+  }
+  const o = optionsOrLegacyStorageKey ?? {};
+  return {
+    userId: o.userId,
+    storageKey: o.storageKey ?? DEFAULT_STORAGE_KEY,
+    todayStatsKey: o.todayStatsKey ?? DEFAULT_TODAY_STATS_KEY,
+  };
+}
+
 const useDsaCompletedQuestions = (
-  storageKey = DEFAULT_STORAGE_KEY,
-  todayStatsKey = DEFAULT_TODAY_STATS_KEY,
+  optionsOrLegacyStorageKey?: UseDsaCompletedQuestionsOptions | string,
+  legacyTodayStatsKey?: string,
 ): UseDsaCompletedQuestionsReturn => {
-  const [completedIds, setCompletedIds] = useState<(string | number)[]>([]);
-  const [solvedToday, setSolvedToday] = useState(0);
+  const { userId, storageKey, todayStatsKey } = resolveArgs(
+    optionsOrLegacyStorageKey,
+    legacyTodayStatsKey,
+  );
+
+  const queryClient = useQueryClient();
+
+  const [localCompletedIds, setLocalCompletedIds] = useState<
+    (string | number)[]
+  >([]);
+  const [localSolvedToday, setLocalSolvedToday] = useState(0);
+
+  const remoteQuery = useQuery({
+    queryKey: queryKeys.dsa.completedQuestions(userId ?? ""),
+    enabled: Boolean(userId),
+    queryFn: async () => {
+      const res = await sendRequest({
+        method: "GET",
+        url: `${routes.api.base}${routes.api.dsaYatraProgress}?userId=${encodeURIComponent(userId!)}`,
+      });
+      if (!res?.status) {
+        throw new Error(
+          typeof res?.message === "string"
+            ? res.message
+            : "Failed to load DSA Yatra progress",
+        );
+      }
+      return res.data as DsaProgressPayload;
+    },
+    ...CACHE_TIMES.STANDARD,
+  });
 
   useEffect(() => {
+    if (userId) {
+      return;
+    }
+
     const saved = localStorage.getItem(storageKey);
     if (saved) {
       try {
-        setCompletedIds(JSON.parse(saved));
+        setLocalCompletedIds(JSON.parse(saved));
       } catch {
-        /* corrupted data, start fresh */
+        /* corrupted data */
       }
     }
 
@@ -37,51 +107,199 @@ const useDsaCompletedQuestions = (
       try {
         const data: TodayStats = JSON.parse(statsStr);
         if (data.date === todayStr) {
-          setSolvedToday(data.solvedCount || 0);
+          setLocalSolvedToday(data.solvedCount || 0);
         }
       } catch {
-        /* corrupted data, start fresh */
+        /* corrupted data */
       }
     }
-  }, [storageKey, todayStatsKey]);
+  }, [storageKey, todayStatsKey, userId]);
+
+  useEffect(() => {
+    if (
+      !userId ||
+      !remoteQuery.isSuccess ||
+      !remoteQuery.data ||
+      typeof window === "undefined"
+    ) {
+      return;
+    }
+
+    let localIds: string[] = [];
+    let localToday: TodayStats | undefined;
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (raw) {
+        localIds = (JSON.parse(raw) as unknown[]).map((id) => String(id));
+      }
+      const t = localStorage.getItem(todayStatsKey);
+      if (t) {
+        localToday = JSON.parse(t) as TodayStats;
+      }
+    } catch {
+      return;
+    }
+
+    const serverIds = new Set(
+      remoteQuery.data.completedQuestionIds.map((id) => String(id)),
+    );
+    const extras = localIds.filter((id) => !serverIds.has(id));
+    if (extras.length === 0) {
+      return;
+    }
+
+    const run = async () => {
+      const res = await sendRequest({
+        method: "PUT",
+        url: `${routes.api.base}${routes.api.dsaYatraProgress}`,
+        body: {
+          userId,
+          addCompletedQuestionIds: extras,
+          todayStats: localToday,
+        },
+      });
+      if (res?.status && res.data) {
+        queryClient.setQueryData(
+          queryKeys.dsa.completedQuestions(userId),
+          res.data as DsaProgressPayload,
+        );
+        localStorage.removeItem(storageKey);
+        localStorage.removeItem(todayStatsKey);
+      }
+    };
+
+    void run();
+  }, [
+    userId,
+    remoteQuery.isSuccess,
+    remoteQuery.data,
+    storageKey,
+    todayStatsKey,
+    queryClient,
+  ]);
+
+  const completedIds = useMemo<(string | number)[]>(() => {
+    if (userId) {
+      if (!remoteQuery.data) {
+        return [];
+      }
+      return remoteQuery.data.completedQuestionIds;
+    }
+    return localCompletedIds;
+  }, [userId, remoteQuery.data, localCompletedIds]);
+
+  const solvedToday = useMemo(() => {
+    if (userId) {
+      return remoteQuery.data?.solvedToday ?? 0;
+    }
+    return localSolvedToday;
+  }, [userId, remoteQuery.data, localSolvedToday]);
+
+  const isProgressLoading = Boolean(userId && remoteQuery.isPending);
 
   const toggleComplete = useCallback(
     (questionId: string | number) => {
-      // Determine the next state based on the current completedIds from closure
-      const isCompletedNow = !completedIds.includes(questionId);
-      const next = isCompletedNow
-        ? [...completedIds, questionId]
-        : completedIds.filter((id) => id !== questionId);
+      const qid = String(questionId);
 
-      // 1. Update React state
-      setCompletedIds(next);
+      if (userId) {
+        const serverIds = new Set(
+          (remoteQuery.data?.completedQuestionIds ?? []).map((id) =>
+            String(id),
+          ),
+        );
+        const had = serverIds.has(qid);
+        const nextCompleted = !had;
 
-      // 2. Perform side effects (LocalStorage, etc.)
-      localStorage.setItem(storageKey, JSON.stringify(next));
+        const prevToday = remoteQuery.data?.solvedToday ?? 0;
+        let nextSolvedToday = prevToday;
+        if (nextCompleted && !had) {
+          nextSolvedToday = prevToday + 1;
+        } else if (!nextCompleted && had && prevToday > 0) {
+          nextSolvedToday = prevToday - 1;
+        }
 
-      const todayStr = new Date().toDateString();
-      const todayStatsStr = localStorage.getItem(todayStatsKey);
-      let todayStats: TodayStats = todayStatsStr
-        ? JSON.parse(todayStatsStr)
-        : { date: todayStr, solvedCount: 0 };
+        const optimistic: DsaProgressPayload = {
+          completedQuestionIds: nextCompleted
+            ? [...serverIds, qid]
+            : [...serverIds].filter((id) => id !== qid),
+          solvedToday: nextSolvedToday,
+        };
 
-      if (todayStats.date !== todayStr) {
-        todayStats = { date: todayStr, solvedCount: 0 };
+        queryClient.setQueryData(
+          queryKeys.dsa.completedQuestions(userId),
+          optimistic,
+        );
+
+        void (async () => {
+          try {
+            const res = await sendRequest({
+              method: "PATCH",
+              url: `${routes.api.base}${routes.api.dsaYatraProgress}`,
+              body: {
+                userId,
+                questionId: qid,
+                isCompleted: nextCompleted,
+              },
+            });
+            if (!res?.status) {
+              throw new Error("PATCH failed");
+            }
+            if (res.data) {
+              queryClient.setQueryData(
+                queryKeys.dsa.completedQuestions(userId),
+                res.data as DsaProgressPayload,
+              );
+            }
+          } catch {
+            await queryClient.invalidateQueries({
+              queryKey: queryKeys.dsa.completedQuestions(userId),
+            });
+          }
+        })();
+        return;
       }
 
-      if (isCompletedNow) {
-        todayStats.solvedCount += 1;
-      } else if (todayStats.solvedCount > 0) {
-        todayStats.solvedCount -= 1;
-      }
+      setLocalCompletedIds((completedIdsPrev) => {
+        const isCompletedNow = !completedIdsPrev.some(
+          (id) => String(id) === qid,
+        );
+        const next = isCompletedNow
+          ? [...completedIdsPrev, questionId]
+          : completedIdsPrev.filter((id) => String(id) !== qid);
 
-      localStorage.setItem(todayStatsKey, JSON.stringify(todayStats));
-      setSolvedToday(todayStats.solvedCount);
+        localStorage.setItem(storageKey, JSON.stringify(next));
+
+        const todayStr = new Date().toDateString();
+        const todayStatsStr = localStorage.getItem(todayStatsKey);
+        let todayStats: TodayStats = todayStatsStr
+          ? JSON.parse(todayStatsStr)
+          : { date: todayStr, solvedCount: 0 };
+
+        if (todayStats.date !== todayStr) {
+          todayStats = { date: todayStr, solvedCount: 0 };
+        }
+
+        if (isCompletedNow) {
+          todayStats.solvedCount += 1;
+        } else if (todayStats.solvedCount > 0) {
+          todayStats.solvedCount -= 1;
+        }
+
+        localStorage.setItem(todayStatsKey, JSON.stringify(todayStats));
+        setLocalSolvedToday(todayStats.solvedCount);
+
+        return next;
+      });
     },
-    [completedIds, storageKey, todayStatsKey],
+    [userId, remoteQuery.data, queryClient, storageKey, todayStatsKey],
   );
 
-  return { completedIds, toggleComplete, solvedToday };
+  return {
+    completedIds,
+    toggleComplete,
+    solvedToday,
+    isProgressLoading,
+  };
 };
 
 export default useDsaCompletedQuestions;


### PR DESCRIPTION
## Summary

DSA Yatra previously stored “solved” question ids only in **localStorage**, so progress did not follow the user across devices or browsers. This change **persists the same progress in MongoDB** on the `User` document, consistent with how we embed product-specific state elsewhere (e.g. Prep Yatra’s `prepYatra.prepLog`) and how Interview Prep / Shiksha track completion via APIs.

## What changed

- **User model** (`dsaYatra.progress`): `completedQuestionIds[]` plus `todayStats` (`date`, `solvedCount`) for the dashboard “solved today” metric.
- **API** (`GET` / `PATCH` / `PUT` on `/api/v1/user/dsayatra/progress`):
  - **GET** — load progress for `userId`.
  - **PATCH** — toggle a single question’s completion; triggers **`COMPLETE_QUESTION` gamification only when completion actually flips** (avoids double points on duplicate/no-op requests).
  - **PUT** — merge extra question ids (and optional local “today” stats) for **one-time migration** from localStorage after login.
- **Routes**: `routes.api.dsaYatraProgress` in shared constants and the API app’s route map.
- **`useDsaCompletedQuestions`**: When `userId` is passed, uses **React Query** + `sendRequest` for server state, optimistic `PATCH` with **invalidate on failure**; guests / no user still use **localStorage only**. Legacy call pattern (custom storage key strings) remains supported.
- **Apps**: DSAYatra pages (dashboard, sheets, revisions, topics) and OnCampus DSA prep pass `userId` into the hook; topics uses `useAuth` for id when the roadmap is shown.
- **Tests**: `useDsaCompletedQuestions` specs run with a **QueryClient** wrapper and assert `isProgressLoading` for the offline path.

## Why

- **Product**: Users expect learning progress to be **account-scoped**, not tied to one browser profile.
- **Consistency**: Matches established patterns (API + user-scoped persistence + shared hook) instead of ad hoc local-only state for a core learning loop.

## Implementation notes

- Progress lives on **`User.dsaYatra`** (no new collection) — appropriate for a single global DSA curriculum and a bounded id list.
- **Migration**: On first successful remote load, any ids present only in localStorage are **unioned** into the DB via `PUT`, then default local keys are cleared to avoid split brain.
- **Typecheck / tests**: API `tsc` and dsayatra `tsc` clean; unit tests for the hook updated and passing from `apps/testing`.

---

This PR was written using [Vibe Kanban](https://vibekanban.com).
