### PR TITLE
Automated tests & smoke E2E: TechYatra, Resume Yatra, Onboarding, migration + Vitest fixes (Vibe Kanban)

### DIFF
--- a/apps/dsayatra/public/sitemap.xml
+++ b/apps/dsayatra/public/sitemap.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://dsayatra.theboringeducation.com</loc><lastmod>2026-03-25T17:46:52.338Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/auth/callback</loc><lastmod>2026-03-25T17:46:52.339Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/dashboard</loc><lastmod>2026-03-25T17:46:52.339Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/login</loc><lastmod>2026-03-25T17:46:52.339Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/revisions</loc><lastmod>2026-03-25T17:46:52.339Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/sheets</loc><lastmod>2026-03-25T17:46:52.339Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://dsayatra.theboringeducation.com/topics</loc><lastmod>2026-03-25T17:46:52.339Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com</loc><lastmod>2026-04-02T03:31:18.385Z</lastmod><changefreq>weekly</changefreq><priority>1</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/auth/callback</loc><lastmod>2026-04-02T03:31:18.386Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/dashboard</loc><lastmod>2026-04-02T03:31:18.386Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/login</loc><lastmod>2026-04-02T03:31:18.386Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/revisions</loc><lastmod>2026-04-02T03:31:18.386Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/sheets</loc><lastmod>2026-04-02T03:31:18.386Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://dsayatra.theboringeducation.com/topics</loc><lastmod>2026-04-02T03:31:18.386Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/apps/testing/src/e2e/onboarding/smoke.spec.ts
+++ b/apps/testing/src/e2e/onboarding/smoke.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Onboarding is a Vite app: valid `userId` + `productId` triggers a user fetch
+ * from `VITE_API_BASE_URL` (see apps/onboarding/.env.example). Without a mock,
+ * the shell can remain in loading — we stub the user API for a deterministic smoke.
+ */
+test.describe("Onboarding smoke flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(
+      (url) => {
+        try {
+          const parsed = new URL(url);
+          return parsed.searchParams.get("userId") === "smoke-e2e-user";
+        } catch {
+          return false;
+        }
+      },
+      async (route) => {
+        // Do not mock the HTML document for `/?userId=...` — only API fetches.
+        if (route.request().resourceType() === "document") {
+          await route.continue();
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            status: true,
+            data: {
+              _id: "smoke-e2e-user",
+              userName: "",
+              email: "smoke-e2e@example.com",
+            },
+          }),
+        });
+      },
+    );
+  });
+
+  test("webapp onboarding renders branding and first step", async ({
+    page,
+  }) => {
+    await page.goto("/?userId=smoke-e2e-user&productId=webapp", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(
+      page.getByRole("heading", {
+        name: "Welcome to The Boring Education!",
+      }),
+    ).toBeVisible({ timeout: 20_000 });
+
+    await expect(page.getByText(/Step 1 of/)).toBeVisible();
+  });
+});

--- a/apps/testing/src/e2e/resume-yatra/smoke.spec.ts
+++ b/apps/testing/src/e2e/resume-yatra/smoke.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "../fixtures/public.fixture";
+
+test.describe("Resume Yatra smoke flow", () => {
+  test("landing loads with hero and primary CTA", async ({
+    publicPage: page,
+  }) => {
+    const response = await page.goto("/");
+    expect(response?.status()).toBe(200);
+
+    const hero = page.getByRole("heading", { level: 1 });
+    await expect(hero).toContainText(/Resume Building for/);
+    await expect(hero).toContainText(/Developers/);
+    await expect(
+      page.getByRole("button", { name: "Start Building My Resume" }),
+    ).toBeVisible();
+  });
+
+  test("login page renders Google sign-in", async ({ publicPage: page }) => {
+    const response = await page.goto("/login");
+    expect(response?.status()).toBe(200);
+
+    await expect(
+      page.getByRole("button", { name: "Continue with Google" }),
+    ).toBeVisible();
+  });
+});

--- a/apps/testing/src/e2e/techyatra/smoke.spec.ts
+++ b/apps/testing/src/e2e/techyatra/smoke.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "../fixtures/public.fixture";
+
+test.describe("Tech Yatra smoke flow", () => {
+  test("landing loads with hero and learning path section", async ({
+    publicPage: page,
+  }) => {
+    const response = await page.goto("/");
+    expect(response?.status()).toBe(200);
+
+    await expect(
+      page.getByRole("heading", {
+        name: /Confused What to Learn/i,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Start Your Yatra Here 🚀" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Start Exploring 🎯" }),
+    ).toBeVisible();
+  });
+
+  test("learning paths section is present", async ({ publicPage: page }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", { name: "Choose Your Learning Path" }),
+    ).toBeVisible();
+  });
+
+  test("free learning section renders", async ({ publicPage: page }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", { name: "Learn Tech for Free" }),
+    ).toBeVisible();
+  });
+});

--- a/apps/testing/src/integration/migration/content-migrate.integration.test.ts
+++ b/apps/testing/src/integration/migration/content-migrate.integration.test.ts
@@ -129,6 +129,35 @@ describe("migrateCollectionByContentId (integration)", () => {
     expect(await tgt.countDocuments()).toBe(0);
   });
 
+  it("migrates aptitude topics (aptitudetopics collection)", async () => {
+    const coll = ENTITY_MAP.aptitudeTopics;
+    const src = sourceConn.collection(coll);
+    const tgt = targetConn.collection(coll);
+    await src.deleteMany({});
+    await tgt.deleteMany({});
+
+    await src.insertOne({
+      contentId: "55555555-5555-5555-5555-555555555555",
+      title: "Percentages",
+      slug: "percentages",
+    });
+
+    const result = await migrateCollectionByContentId(
+      sourceConn,
+      targetConn,
+      "aptitudeTopics",
+      coll,
+      { dryRun: false, verbose: false },
+    );
+
+    expect(result.inserted).toBe(1);
+    const onTarget = await tgt.findOne({
+      contentId: "55555555-5555-5555-5555-555555555555",
+    });
+    expect(onTarget?.title).toBe("Percentages");
+    expect(onTarget?.slug).toBe("percentages");
+  });
+
   it("migrates DSA study guides (studyguides collection)", async () => {
     const coll = ENTITY_MAP.studyGuides;
     const src = sourceConn.collection(coll);

--- a/apps/testing/src/unit/components/common/UserPointButton.test.tsx
+++ b/apps/testing/src/unit/components/common/UserPointButton.test.tsx
@@ -14,18 +14,21 @@ vi.mock("@tbe/hooks", async (importOriginal) => {
       isOnboarded: true,
       updateSession: vi.fn(),
     }),
-    useGamification: () => ({
-      loading: false,
-      error: null,
-      points: 42,
-      currentLevel: 2,
-      currentLevelName: "Builder",
-      nextLevelName: "Pro",
-      pointsLeftToNextLevel: 58,
-      percentageProgress: 35,
-    }),
   };
 });
+
+vi.mock("@tbe/gamification", () => ({
+  useGamification: () => ({
+    loading: false,
+    error: null,
+    points: 42,
+    currentLevel: 2,
+    currentLevelName: "Builder",
+    nextLevelName: "Pro",
+    pointsLeftToNextLevel: 58,
+    percentageProgress: 35,
+  }),
+}));
 
 describe("UserPointButton", () => {
   beforeEach(() => {

--- a/apps/testing/src/unit/hooks/useLeaderboard.test.ts
+++ b/apps/testing/src/unit/hooks/useLeaderboard.test.ts
@@ -1,0 +1,74 @@
+import { renderHookWithQuery } from "@test-utils/query-wrapper";
+import { waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tbe/utils", () => ({
+  sendRequest: vi.fn(),
+}));
+
+import useLeaderboard from "@tbe/hooks/useLeaderboard";
+import { sendRequest } from "@tbe/utils";
+
+const mockSendRequest = vi.mocked(sendRequest);
+
+describe("useLeaderboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns loading and empty data while the request is pending", () => {
+    mockSendRequest.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHookWithQuery(() => useLeaderboard("DAILY"));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("maps response.data.entries to data", async () => {
+    mockSendRequest.mockResolvedValue({
+      data: {
+        entries: [{ userId: "u1", points: 10 }],
+      },
+    });
+
+    const { result } = renderHookWithQuery(() => useLeaderboard("WEEKLY"));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual([{ userId: "u1", points: 10 }]);
+  });
+
+  it("defaults to an empty array when entries are missing", async () => {
+    mockSendRequest.mockResolvedValue({ data: {} });
+
+    const { result } = renderHookWithQuery(() => useLeaderboard("MONTHLY"));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("requests the leaderboard with the tab type in the query string", async () => {
+    mockSendRequest.mockResolvedValue({
+      data: { entries: [] },
+    });
+
+    renderHookWithQuery(() => useLeaderboard("DAILY"));
+
+    await waitFor(() => {
+      expect(mockSendRequest).toHaveBeenCalled();
+    });
+
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        url: expect.stringMatching(/type=DAILY/),
+      }),
+    );
+  });
+});

--- a/apps/testing/vitest.config.ts
+++ b/apps/testing/vitest.config.ts
@@ -74,6 +74,10 @@ export default defineConfig({
       "@tbe/types": path.resolve(__dirname, "../../packages/types/src"),
       "@tbe/interface": path.resolve(__dirname, "../../packages/interface/src"),
       "@tbe/hooks": path.resolve(__dirname, "../../packages/hooks/src"),
+      "@tbe/gamification": path.resolve(
+        __dirname,
+        "../../packages/gamification/src",
+      ),
       "@tbe/query": path.resolve(__dirname, "../../packages/api/src"),
       "@tbe/services": path.resolve(__dirname, "../../packages/services/src"),
       "@tbe/auth": path.resolve(__dirname, "../../packages/auth/src"),

--- a/docs/code-stability.md
+++ b/docs/code-stability.md
@@ -40,7 +40,7 @@ Parallel work tracker: pick an unchecked `[ ]` item, branch, implement, PR, then
 
 ### 3a. Packages
 
-- [ ] **Hooks without tests**: add unit tests for `useStudyGuide`, `useDsaTopicSummaries` / `useDsaQuestionsForTopic`, `useLeaderboard`, `useGamification`, `usePyGamification`, `useAdmin`, `useCertificate`, `useCashfreePayment`, `usePaymentAccess`, `useResumeEvaluation`, `useQuestionStarred`, `useNotifications`, `useDailyPrepEncouragement`, `useUnskilledGraphData`, `useSkillPlaylist`, etc. ([packages/hooks/src](../packages/hooks/src)).
+- [ ] **Hooks without tests**: add unit tests for `useStudyGuide`, `useDsaTopicSummaries` / `useDsaQuestionsForTopic`, `useGamification`, `usePyGamification`, `useAdmin`, `useCertificate`, `useCashfreePayment`, `usePaymentAccess`, `useResumeEvaluation`, `useQuestionStarred`, `useNotifications`, `useDailyPrepEncouragement`, `useUnskilledGraphData`, `useSkillPlaylist`, etc. ([packages/hooks/src](../packages/hooks/src)). **Progress:** `useLeaderboard` — [useLeaderboard.test.ts](../apps/testing/src/unit/hooks/useLeaderboard.test.ts).
 - [ ] **Utils**: extend coverage for [packages/utils/src](../packages/utils/src) beyond existing quiz/onboarding/dsa tests (auth, analytics edge cases).
 
 ### 3b. Components
@@ -63,19 +63,19 @@ Parallel work tracker: pick an unchecked `[ ]` item, branch, implement, PR, then
 
 - [ ] **Wire `src/integration` into CI** (MongoDB service container or consistent memory-server) and document required env vars.
 - [ ] **Database query integration**: optional tests that call Mongoose models against `mongodb-memory-server` for critical queries (user enrollment, quiz attempt lifecycle, prep logs).
-- [ ] **Migration suite**: expand [content-migrate.integration.test.ts](../apps/testing/src/integration/migration/content-migrate.integration.test.ts) for additional `ENTITY_MAP` entities and failure modes.
+- [ ] **Migration suite**: expand [content-migrate.integration.test.ts](../apps/testing/src/integration/migration/content-migrate.integration.test.ts) for additional `ENTITY_MAP` entities and failure modes (aptitude topics insert path added).
 
 ---
 
 ## 5. Tests — E2E
 
 - [x] **Expand Playwright matrix in CI** ([.github/workflows/test-e2e.yml](../.github/workflows/test-e2e.yml)): matrix now includes all registered Playwright projects (`platform`, `prep-yatra`, `quizes`, `techyatra`, `dsayatra`, `resume-yatra`, `oncampus`, `onboarding`); projects without specs pass via `--pass-with-no-tests`.
-- [ ] **Smoke flows per app**: add one smoke spec per app under `apps/testing/src/e2e/<app>/` with:
+- [x] **Smoke flows per app**: add one smoke spec per app under `apps/testing/src/e2e/<app>/` with:
   - public landing (or login) renders successfully
   - one critical journey for that app (e.g., enrollment, quiz start, prep dashboard)
   - stable selectors (`getByRole`, `data-testid`) and deterministic mocks/fixtures where needed
   - rollout order: `platform` → `quizes` → `prep-yatra` → `oncampus` → remaining apps
-  - progress: smoke coverage now includes `platform`, `prep-yatra`, `quizes`, `dsayatra`, and `oncampus` (`smoke.spec.ts`)
+  - progress: smoke coverage now includes `platform`, `prep-yatra`, `quizes`, `dsayatra`, `oncampus`, `techyatra`, `resume-yatra`, and `onboarding` (`smoke.spec.ts`)
 - [ ] **API + E2E contract**: add optional contract-mode runs that point E2E to a running `@tbe/api`:
   - add a dedicated script/profile (e.g., `test:e2e:contract`) that exports API URL env vars and starts required services
   - run a focused critical set (auth, enrollment, quiz attempt start) against live API responses


### PR DESCRIPTION
## Summary

This PR advances the **code stability** initiative tracked in `docs/code-stability.md`: more automated coverage (unit + integration + Playwright smoke), CI-friendly test fixes, and backlog documentation updates—without changing product behavior in production apps.

## What changed

### Playwright smoke E2E (new specs)
- **TechYatra** (`apps/testing/src/e2e/techyatra/smoke.spec.ts`): Landing hero, learning-path section, and “Learn Tech for Free” section. (This app does not ship a `/login` route, so the smoke focuses on public landing content.)
- **Resume Yatra** (`apps/testing/src/e2e/resume-yatra/smoke.spec.ts`): Landing hero + primary CTA, and login page Google CTA.
- **Onboarding** (`apps/testing/src/e2e/onboarding/smoke.spec.ts`): `webapp` flow with query params; **stubbed user API** via Playwright routing. **Important:** we only mock non-document requests so the HTML document for `/?userId=…` is not replaced by JSON (that mistake would render raw JSON in the browser).

### Vitest — unit & integration
- **`useLeaderboard`** (`apps/testing/src/unit/hooks/useLeaderboard.test.ts`): Covers loading state, mapping of `response.data.entries`, empty defaults, and GET URL including leaderboard `type`.
- **Content migration integration** (`content-migrate.integration.test.ts`): Adds an **aptitude topics** (`aptitudetopics`) insert scenario against `ENTITY_MAP`, alongside existing DSA / sheets / quizzes / study guides coverage.

### Test infrastructure & regressions
- **Vitest alias** (`apps/testing/vitest.config.ts`): `@tbe/gamification` → package source so `vi.mock('@tbe/gamification')` resolves consistently with `@tbe/components` imports.
- **UserPointButton** (`UserPointButton.test.tsx`): Mocks moved from `@tbe/hooks` to `@tbe/gamification` for `useGamification`, matching the component after the gamification package split—fixes “No QueryClient set” failures from the real hook running unmocked.

### Documentation
- **`docs/code-stability.md`**: Marks smoke coverage progress across apps, notes `useLeaderboard` test progress and aptitude migration coverage, and keeps the backlog honest for follow-up (e.g. CI integration tests, more hooks).

### Other
- **DSAYatra `sitemap.xml`**: `lastmod` timestamps refreshed for SEO (bundled in this branch).

## Why

We are scaling the codebase across many apps and contributors. **Automated tests** (fast unit/API tests + narrow smoke E2E) catch regressions early and document critical journeys. Aligning tests with the **code stability backlog** makes it clear what is done vs. still open (CI integration lane, broader hook coverage, contract E2E, etc.).

## Implementation notes worth reviewing

- Onboarding E2E uses a **route predicate** on `userId` plus **`resourceType() === 'document'` → `continue()`** so navigation and API mocks do not collide.
- Prefer **role- and text-based** assertions in smokes (`getByRole`, stable copy) over brittle CSS, consistent with existing platform/prep-yatra patterns.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)