### PR TITLE
feat(payments): server-side pricing, unified checkout, and payment docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ yarn-error.log*
 .env.development
 .env.production
 apps/testing/playwright-report/
+
+# Local subscription plan pricing (copy from subscription-plans.example.json — never commit real amounts)
+apps/api/scripts/subscription-plans.local.json

--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log*
 .env.*.local
 .env.development
 .env.production
+
+# Local subscription pricing seed (see scripts/subscription-plans.example.json)
+scripts/subscription-plans.local.json

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,8 @@
     "deploy": "./deploy.sh",
     "seed:study-guide": "tsx src/scripts/seed-study-guide.ts",
     "backfill": "tsx scripts/backfill-content-ids.ts",
-    "migrate": "tsx scripts/migrate-content.ts"
+    "migrate": "tsx scripts/migrate-content.ts",
+    "seed:subscription-plans": "tsx scripts/seed-subscription-plans.ts"
   },
   "dependencies": {
     "@sentry/nextjs": "^9.38.0",

--- a/apps/api/scripts/seed-subscription-plans.ts
+++ b/apps/api/scripts/seed-subscription-plans.ts
@@ -1,0 +1,78 @@
+/**
+ * One-time / occasional seed of subscription SKU prices into MongoDB.
+ *
+ * 1. Copy subscription-plans.example.json → subscription-plans.local.json (gitignored).
+ * 2. Fill real INR amounts (amountInr).
+ * 3. Ensure API is running (or use deployed API URL).
+ * 4. Set ADMIN_SECRET in env (same as the API).
+ * 5. Run: pnpm seed:subscription-plans (from apps/api)
+ *
+ * Uses POST /api/v1/admin/subscription-plans with x-admin-secret — never commit secrets or local JSON.
+ */
+import dotenv from "dotenv";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.join(__dirname, "../.env.local") });
+dotenv.config({ path: path.join(__dirname, "../.env") });
+
+const LOCAL_FILE = path.join(__dirname, "subscription-plans.local.json");
+const EXAMPLE_FILE = path.join(__dirname, "subscription-plans.example.json");
+
+async function main() {
+  if (!fs.existsSync(LOCAL_FILE)) {
+    console.error(
+      `[seed-subscription-plans] Missing ${LOCAL_FILE}\n` +
+        `Copy ${EXAMPLE_FILE} to subscription-plans.local.json and set amountInr values.`,
+    );
+    process.exit(1);
+  }
+
+  const secret = process.env.ADMIN_SECRET;
+  if (!secret) {
+    console.error(
+      "[seed-subscription-plans] ADMIN_SECRET is required in environment.",
+    );
+    process.exit(1);
+  }
+
+  const raw = fs.readFileSync(LOCAL_FILE, "utf-8");
+  const parsed = JSON.parse(raw) as { plans?: unknown[] };
+  if (!parsed.plans || !Array.isArray(parsed.plans) || parsed.plans.length === 0) {
+    console.error("[seed-subscription-plans] JSON must contain a non-empty plans array.");
+    process.exit(1);
+  }
+
+  const apiBase = (
+    process.env.SEED_API_URL ||
+    process.env.API_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    "http://localhost:3004/api/v1"
+  ).replace(/\/$/, "");
+
+  const url = `${apiBase}/admin/subscription-plans`;
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-admin-secret": secret,
+    },
+    body: JSON.stringify({ plans: parsed.plans }),
+  });
+
+  const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+
+  if (!res.ok) {
+    console.error("[seed-subscription-plans] Request failed", res.status, body);
+    process.exit(1);
+  }
+
+  console.log("[seed-subscription-plans] OK", res.status, JSON.stringify(body, null, 2));
+}
+
+void main();

--- a/apps/api/scripts/subscription-plans.example.json
+++ b/apps/api/scripts/subscription-plans.example.json
@@ -1,0 +1,54 @@
+{
+  "plans": [
+    {
+      "productType": "DSA_YATRA",
+      "planKey": "lifetime",
+      "amountInr": 0
+    },
+    {
+      "productType": "PREPYATRA",
+      "planKey": "1months",
+      "amountInr": 0
+    },
+    {
+      "productType": "PREPYATRA",
+      "planKey": "3months",
+      "amountInr": 0
+    },
+    {
+      "productType": "PREPYATRA",
+      "planKey": "6months",
+      "amountInr": 0
+    },
+    {
+      "productType": "PREPYATRA",
+      "planKey": "12months",
+      "amountInr": 0
+    },
+    {
+      "productType": "PREPYATRA",
+      "planKey": "lifetime",
+      "amountInr": 0
+    },
+    {
+      "productType": "ONCAMPUS",
+      "planKey": "1months",
+      "amountInr": 0
+    },
+    {
+      "productType": "ONCAMPUS",
+      "planKey": "3months",
+      "amountInr": 0
+    },
+    {
+      "productType": "ONCAMPUS",
+      "planKey": "6months",
+      "amountInr": 0
+    },
+    {
+      "productType": "ONCAMPUS",
+      "planKey": "12months",
+      "amountInr": 0
+    }
+  ]
+}

--- a/apps/api/src/lib/constants/api.ts
+++ b/apps/api/src/lib/constants/api.ts
@@ -2639,6 +2639,8 @@ const planTypeMap = {
   "1months": { type: "3Months" as const, duration: 1 },
   "3months": { type: "5Months" as const, duration: 3 },
   "6months": { type: "5Months" as const, duration: 6 },
+  /** 1 year — duration in months for subscription expiry */
+  "12months": { type: "5Months" as const, duration: 12 },
   lifetime: { type: "Lifetime" as const, duration: 999 },
 };
 

--- a/apps/api/src/lib/constants/database.ts
+++ b/apps/api/src/lib/constants/database.ts
@@ -36,6 +36,8 @@ const DATABASE_MODELS = {
   DSA_QUESTION: "DSAQuestion",
   APTITUDE_TOPIC: "AptitudeTopic",
   STUDY_GUIDE: "StudyGuide",
+  /** Admin-configured INR prices for subscription SKUs (productType + planKey) */
+  SUBSCRIPTION_PLAN: "SubscriptionPlan",
 };
 
 export const FEEDBACK_TYPES = [

--- a/apps/api/src/lib/database/models/SubscriptionPlan.ts
+++ b/apps/api/src/lib/database/models/SubscriptionPlan.ts
@@ -1,0 +1,48 @@
+import { type Model, model, models, Schema } from "mongoose";
+
+import { DATABASE_MODELS, PRODUCT_TYPE } from "@/lib/constants";
+import type { SubscriptionPlanModel } from "@/lib/interfaces";
+
+const SubscriptionPlanSchema = new Schema<SubscriptionPlanModel>(
+  {
+    productType: {
+      type: String,
+      enum: PRODUCT_TYPE,
+      required: true,
+    },
+    planKey: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+    },
+    amountInr: {
+      type: Number,
+      required: true,
+      min: 0,
+    },
+    currency: {
+      type: String,
+      default: "INR",
+    },
+    isActive: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  { timestamps: true },
+);
+
+SubscriptionPlanSchema.index(
+  { productType: 1, planKey: 1 },
+  { unique: true },
+);
+
+const SubscriptionPlan: Model<SubscriptionPlanModel> =
+  models?.SubscriptionPlan ||
+  model<SubscriptionPlanModel>(
+    DATABASE_MODELS.SUBSCRIPTION_PLAN,
+    SubscriptionPlanSchema,
+  );
+
+export default SubscriptionPlan;

--- a/apps/api/src/lib/database/models/index.ts
+++ b/apps/api/src/lib/database/models/index.ts
@@ -6,6 +6,7 @@ export { default as Gamification } from "./Gamification";
 export { default as Leaderboard } from "./Leaderboard";
 export { default as Notification } from "./Notification";
 export { default as Payment } from "./Payment";
+export { default as SubscriptionPlan } from "./SubscriptionPlan";
 export { default as User } from "./User";
 export { default as UserInterest } from "./UserInterest";
 export { default as Webinar } from "./Webinar";

--- a/apps/api/src/lib/database/queries/index.ts
+++ b/apps/api/src/lib/database/queries/index.ts
@@ -15,6 +15,7 @@ export * from "./prepyatra";
 export * from "./project";
 export * from "./quiz";
 export * from "./shiksha";
+export * from "./subscription-plan";
 export * from "./unskilled";
 export * from "./user";
 export * from "./user-aptitude-topic";

--- a/apps/api/src/lib/database/queries/subscription-plan.ts
+++ b/apps/api/src/lib/database/queries/subscription-plan.ts
@@ -1,0 +1,101 @@
+import type { ProductType } from "@/lib/constants/database";
+import type { DatabaseQueryResponseType } from "@/lib/interfaces";
+import { logger } from "@/lib/utils/logger";
+
+import SubscriptionPlan from "../models/SubscriptionPlan";
+
+export interface SubscriptionPlanInput {
+  productType: ProductType;
+  planKey: string;
+  amountInr: number;
+  isActive?: boolean;
+}
+
+const normalizePlanKey = (key: string) => key.trim().toLowerCase();
+
+/**
+ * Authoritative INR price for a subscription SKU. Returns null if missing or inactive.
+ */
+export const getSubscriptionPlanPriceFromDB = async (
+  productType: ProductType,
+  planKey: string,
+): Promise<number | null> => {
+  try {
+    const key = normalizePlanKey(planKey);
+    const doc = await SubscriptionPlan.findOne({
+      productType,
+      planKey: key,
+      isActive: true,
+    }).lean();
+
+    if (!doc || typeof doc.amountInr !== "number") {
+      return null;
+    }
+    return doc.amountInr;
+  } catch (error) {
+    logger.error("DB: getSubscriptionPlanPriceFromDB failed", {
+      error: error instanceof Error ? error.message : String(error),
+      productType,
+      planKey,
+    });
+    return null;
+  }
+};
+
+export const listSubscriptionPlansFromDB =
+  async (): Promise<DatabaseQueryResponseType> => {
+    try {
+      const rows = await SubscriptionPlan.find({})
+        .sort({ productType: 1, planKey: 1 })
+        .lean();
+      return { data: rows };
+    } catch (error) {
+      logger.error("DB: listSubscriptionPlansFromDB failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { error: "Failed to list subscription plans" };
+    }
+  };
+
+export const upsertSubscriptionPlansInDB = async (
+  plans: SubscriptionPlanInput[],
+): Promise<DatabaseQueryResponseType> => {
+  try {
+    if (!plans.length) {
+      return { error: "No plans provided" };
+    }
+
+    const bulk = plans.map((p) => {
+      const planKey = normalizePlanKey(p.planKey);
+      return {
+        updateOne: {
+          filter: { productType: p.productType, planKey },
+          update: {
+            $set: {
+              productType: p.productType,
+              planKey,
+              amountInr: p.amountInr,
+              isActive: p.isActive ?? true,
+              currency: "INR",
+            },
+          },
+          upsert: true,
+        },
+      };
+    });
+
+    const result = await SubscriptionPlan.bulkWrite(bulk, { ordered: false });
+    return {
+      data: {
+        matched: result.matchedCount,
+        modified: result.modifiedCount,
+        upserted: result.upsertedCount,
+      },
+    };
+  } catch (error) {
+    logger.error("DB: upsertSubscriptionPlansInDB failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { error: "Failed to upsert subscription plans" };
+  }
+};

--- a/apps/api/src/lib/interfaces/database.ts
+++ b/apps/api/src/lib/interfaces/database.ts
@@ -403,6 +403,19 @@ export interface PaymentModel extends Document {
   updatedAt?: Date;
 }
 
+/** One row per (productType, planKey) subscription SKU; amounts are authoritative for checkout. */
+export interface SubscriptionPlanModel extends Document {
+  productType: ProductType;
+  /** Normalized to lowercase in DB (e.g. lifetime, 3months). */
+  planKey: string;
+  /** INR, matches Cashfree order_amount units. */
+  amountInr: number;
+  currency: string;
+  isActive: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
 export interface WebhookEvent {
   order_id: string;
   payment_id?: string;

--- a/apps/api/src/lib/services/payment/index.ts
+++ b/apps/api/src/lib/services/payment/index.ts
@@ -11,7 +11,5 @@ export {
 export { getProductConfig, PRODUCT_REGISTRY } from "@/lib/constants/products";
 
 export { resolveAuthoritativeOrderAmount } from "./resolveOrderAmount";
-export {
-  getSubscriptionPlanPrice,
-  SUBSCRIPTION_PLAN_PRICES,
-} from "./subscriptionPlanCatalog";
+export { getSubscriptionPlanPrice } from "./subscriptionPlanCatalog";
+export { getSubscriptionPlanPriceFromDB } from "@/lib/database/queries/subscription-plan";

--- a/apps/api/src/lib/services/payment/index.ts
+++ b/apps/api/src/lib/services/payment/index.ts
@@ -9,3 +9,9 @@ export {
 
 // Export product configuration
 export { getProductConfig, PRODUCT_REGISTRY } from "@/lib/constants/products";
+
+export { resolveAuthoritativeOrderAmount } from "./resolveOrderAmount";
+export {
+  getSubscriptionPlanPrice,
+  SUBSCRIPTION_PLAN_PRICES,
+} from "./subscriptionPlanCatalog";

--- a/apps/api/src/lib/services/payment/resolveOrderAmount.ts
+++ b/apps/api/src/lib/services/payment/resolveOrderAmount.ts
@@ -1,3 +1,5 @@
+import { calculatePriceBreakdown } from "@tbe/utils";
+
 import type { ProductType } from "@/lib/constants/database";
 import {
   getACourseFromDBById,
@@ -6,7 +8,8 @@ import {
   validateCouponForProductFromDB,
 } from "@/lib/database";
 import type { CouponModel, InterviewSheetModel } from "@/lib/interfaces";
-import { calculatePriceBreakdown } from "@tbe/utils";
+
+type InterviewSheetForPricing = Parameters<typeof calculatePriceBreakdown>[0];
 
 export interface ResolveOrderAmountParams {
   productType: ProductType;
@@ -56,22 +59,26 @@ export const resolveAuthoritativeOrderAmount = async ({
   productId,
   couponCode,
   userId,
-}: ResolveOrderAmountParams): Promise<{
-  ok: true;
-  data: ResolvedOrderAmount;
-} | { ok: false; error: string }> => {
+}: ResolveOrderAmountParams): Promise<
+  | {
+      ok: true;
+      data: ResolvedOrderAmount;
+    }
+  | { ok: false; error: string }
+> => {
   try {
     let baseAmount = 0;
 
     switch (productType) {
       case "INTERVIEW_SHEET": {
-        const { data: sheet, error } = await getInterviewSheetByIDFromDB(
-          productId,
-        );
+        const { data: sheet, error } =
+          await getInterviewSheetByIDFromDB(productId);
         if (error || !sheet) {
           return { ok: false, error: error || "Interview sheet not found" };
         }
         const sheetModel = sheet as unknown as InterviewSheetModel;
+        const sheetForPricing =
+          sheetModel as unknown as InterviewSheetForPricing;
         baseAmount = sheetModel.price ?? 0;
         if (!baseAmount || baseAmount <= 0) {
           return { ok: false, error: "Invalid sheet price" };
@@ -89,7 +96,10 @@ export const resolveAuthoritativeOrderAmount = async ({
             return { ok: false, error: cErr || "Invalid coupon" };
           }
           const couponModel = toCouponModel(coupon as CouponModel);
-          const breakdown = calculatePriceBreakdown(sheetModel, couponModel);
+          const breakdown = calculatePriceBreakdown(
+            sheetForPricing,
+            couponModel,
+          );
           return {
             ok: true,
             data: {
@@ -101,7 +111,7 @@ export const resolveAuthoritativeOrderAmount = async ({
           };
         }
 
-        const breakdown = calculatePriceBreakdown(sheetModel);
+        const breakdown = calculatePriceBreakdown(sheetForPricing);
         return {
           ok: true,
           data: {
@@ -155,7 +165,10 @@ export const resolveAuthoritativeOrderAmount = async ({
 
       case "PREPYATRA":
       case "DSA_YATRA":
-      case "ONCAMPUS": {
+      case "ONCAMPUS":
+      case "PROJECTS":
+      case "WEBINAR":
+      case "GENERAL": {
         const price = await getSubscriptionPlanPriceFromDB(
           productType,
           productId,
@@ -198,14 +211,6 @@ export const resolveAuthoritativeOrderAmount = async ({
 
         return { ok: true, data: { baseAmount, finalAmount: baseAmount } };
       }
-
-      case "PROJECTS":
-      case "WEBINAR":
-      case "GENERAL":
-        return {
-          ok: false,
-          error: `Price resolution for ${productType} is not implemented — add catalog or DB fields`,
-        };
 
       default:
         return { ok: false, error: "Unsupported product type" };

--- a/apps/api/src/lib/services/payment/resolveOrderAmount.ts
+++ b/apps/api/src/lib/services/payment/resolveOrderAmount.ts
@@ -1,0 +1,217 @@
+import type { ProductType } from "@/lib/constants/database";
+import {
+  getACourseFromDBById,
+  getInterviewSheetByIDFromDB,
+  validateCouponForProductFromDB,
+} from "@/lib/database";
+import type { CouponModel, InterviewSheetModel } from "@/lib/interfaces";
+import { calculatePriceBreakdown } from "@tbe/utils";
+
+import { getSubscriptionPlanPrice } from "./subscriptionPlanCatalog";
+
+export interface ResolveOrderAmountParams {
+  productType: ProductType;
+  productId: string;
+  couponCode?: string | null;
+  userId?: string;
+}
+
+export interface ResolvedOrderAmount {
+  baseAmount: number;
+  finalAmount: number;
+  appliedCoupon?: string;
+  couponCode?: string;
+}
+
+const toCouponModel = (doc: CouponModel): CouponModel => {
+  const o =
+    typeof (doc as { toObject?: (opts?: object) => CouponModel }).toObject ===
+    "function"
+      ? (doc as { toObject: (opts?: object) => CouponModel }).toObject({
+          virtuals: true,
+        })
+      : doc;
+  return { ...o, isValid: true } as CouponModel;
+};
+
+const applyCouponToFlatPrice = (
+  baseAmount: number,
+  productId: string,
+  coupon: CouponModel,
+): number => {
+  const applicable =
+    !coupon.applicableProducts?.length ||
+    coupon.applicableProducts.includes(productId);
+  if (!applicable || baseAmount < (coupon.minimumAmount ?? 0)) {
+    return baseAmount;
+  }
+  const discount = (baseAmount * (coupon.discountPercentage ?? 0)) / 100;
+  return Math.max(0, Math.round((baseAmount - discount) * 100) / 100);
+};
+
+/**
+ * Server-side price resolution for Cashfree orders. Never trust client-supplied amounts.
+ */
+export const resolveAuthoritativeOrderAmount = async ({
+  productType,
+  productId,
+  couponCode,
+  userId,
+}: ResolveOrderAmountParams): Promise<{
+  ok: true;
+  data: ResolvedOrderAmount;
+} | { ok: false; error: string }> => {
+  try {
+    let baseAmount = 0;
+
+    switch (productType) {
+      case "INTERVIEW_SHEET": {
+        const { data: sheet, error } = await getInterviewSheetByIDFromDB(
+          productId,
+        );
+        if (error || !sheet) {
+          return { ok: false, error: error || "Interview sheet not found" };
+        }
+        const sheetModel = sheet as unknown as InterviewSheetModel;
+        baseAmount = sheetModel.price ?? 0;
+        if (!baseAmount || baseAmount <= 0) {
+          return { ok: false, error: "Invalid sheet price" };
+        }
+
+        if (couponCode) {
+          const { data: coupon, error: cErr } =
+            await validateCouponForProductFromDB(
+              couponCode,
+              productId,
+              productType,
+              userId,
+            );
+          if (cErr || !coupon) {
+            return { ok: false, error: cErr || "Invalid coupon" };
+          }
+          const couponModel = toCouponModel(coupon as CouponModel);
+          const breakdown = calculatePriceBreakdown(sheetModel, couponModel);
+          return {
+            ok: true,
+            data: {
+              baseAmount,
+              finalAmount: breakdown.finalPrice,
+              appliedCoupon: coupon._id.toString(),
+              couponCode: coupon.code,
+            },
+          };
+        }
+
+        const breakdown = calculatePriceBreakdown(sheetModel);
+        return {
+          ok: true,
+          data: {
+            baseAmount,
+            finalAmount: breakdown.finalPrice,
+          },
+        };
+      }
+
+      case "SHIKSHA": {
+        const { data: course, error } = await getACourseFromDBById(productId);
+        if (error || !course) {
+          return { ok: false, error: error || "Course not found" };
+        }
+        const price = (course as { price?: number }).price ?? 0;
+        if (!price || price <= 0) {
+          return { ok: false, error: "Invalid course price" };
+        }
+        baseAmount = price;
+
+        if (couponCode) {
+          const { data: coupon, error: cErr } =
+            await validateCouponForProductFromDB(
+              couponCode,
+              productId,
+              productType,
+              userId,
+            );
+          if (cErr || !coupon) {
+            return { ok: false, error: cErr || "Invalid coupon" };
+          }
+          const couponModel = toCouponModel(coupon as CouponModel);
+          const finalAmount = applyCouponToFlatPrice(
+            baseAmount,
+            productId,
+            couponModel,
+          );
+          return {
+            ok: true,
+            data: {
+              baseAmount,
+              finalAmount,
+              appliedCoupon: coupon._id.toString(),
+              couponCode: coupon.code,
+            },
+          };
+        }
+
+        return { ok: true, data: { baseAmount, finalAmount: baseAmount } };
+      }
+
+      case "PREPYATRA":
+      case "DSA_YATRA":
+      case "ONCAMPUS": {
+        const price = getSubscriptionPlanPrice(productType, productId);
+        if (price === null || price <= 0) {
+          return {
+            ok: false,
+            error: `Unknown or invalid plan for ${productType}: ${productId}`,
+          };
+        }
+        baseAmount = price;
+
+        if (couponCode) {
+          const { data: coupon, error: cErr } =
+            await validateCouponForProductFromDB(
+              couponCode,
+              productId,
+              productType,
+              userId,
+            );
+          if (cErr || !coupon) {
+            return { ok: false, error: cErr || "Invalid coupon" };
+          }
+          const couponModel = toCouponModel(coupon as CouponModel);
+          const finalAmount = applyCouponToFlatPrice(
+            baseAmount,
+            productId,
+            couponModel,
+          );
+          return {
+            ok: true,
+            data: {
+              baseAmount,
+              finalAmount,
+              appliedCoupon: coupon._id.toString(),
+              couponCode: coupon.code,
+            },
+          };
+        }
+
+        return { ok: true, data: { baseAmount, finalAmount: baseAmount } };
+      }
+
+      case "PROJECTS":
+      case "WEBINAR":
+      case "GENERAL":
+        return {
+          ok: false,
+          error: `Price resolution for ${productType} is not implemented — add catalog or DB fields`,
+        };
+
+      default:
+        return { ok: false, error: "Unsupported product type" };
+    }
+  } catch (e) {
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : "Failed to resolve order amount",
+    };
+  }
+};

--- a/apps/api/src/lib/services/payment/resolveOrderAmount.ts
+++ b/apps/api/src/lib/services/payment/resolveOrderAmount.ts
@@ -2,12 +2,11 @@ import type { ProductType } from "@/lib/constants/database";
 import {
   getACourseFromDBById,
   getInterviewSheetByIDFromDB,
+  getSubscriptionPlanPriceFromDB,
   validateCouponForProductFromDB,
 } from "@/lib/database";
 import type { CouponModel, InterviewSheetModel } from "@/lib/interfaces";
 import { calculatePriceBreakdown } from "@tbe/utils";
-
-import { getSubscriptionPlanPrice } from "./subscriptionPlanCatalog";
 
 export interface ResolveOrderAmountParams {
   productType: ProductType;
@@ -157,11 +156,14 @@ export const resolveAuthoritativeOrderAmount = async ({
       case "PREPYATRA":
       case "DSA_YATRA":
       case "ONCAMPUS": {
-        const price = getSubscriptionPlanPrice(productType, productId);
+        const price = await getSubscriptionPlanPriceFromDB(
+          productType,
+          productId,
+        );
         if (price === null || price <= 0) {
           return {
             ok: false,
-            error: `Unknown or invalid plan for ${productType}: ${productId}`,
+            error: `Plan pricing not configured or inactive for ${productType} / ${productId}. Ask an admin to seed subscription plans.`,
           };
         }
         baseAmount = price;

--- a/apps/api/src/lib/services/payment/subscriptionPlanCatalog.ts
+++ b/apps/api/src/lib/services/payment/subscriptionPlanCatalog.ts
@@ -1,0 +1,39 @@
+import type { ProductType } from "@/lib/constants/database";
+
+/**
+ * Authoritative INR prices for subscription products (Cashfree order_amount is in INR).
+ * Keys must match `productId` passed to create-order (plan id, e.g. "3months", "lifetime").
+ * Tune per product line; keep in sync with public marketing pages and admin coupons.
+ */
+export const SUBSCRIPTION_PLAN_PRICES: Partial<
+  Record<ProductType, Record<string, number>>
+> = {
+  PREPYATRA: {
+    "1months": 199,
+    "3months": 499,
+    "6months": 999,
+    "12months": 1799,
+    lifetime: 1999,
+  },
+  /** DSA Yatra: single lifetime SKU (productId = "lifetime"). */
+  DSA_YATRA: {
+    lifetime: 2999,
+  },
+  /** On Campus: duration plans + optional separate coupon rules in DB. */
+  ONCAMPUS: {
+    "1months": 199,
+    "3months": 499,
+    "6months": 999,
+    "12months": 1799,
+  },
+};
+
+export const getSubscriptionPlanPrice = (
+  productType: ProductType,
+  planKey: string,
+): number | null => {
+  const catalog = SUBSCRIPTION_PLAN_PRICES[productType];
+  if (!catalog) return null;
+  const key = planKey.toLowerCase();
+  return catalog[key] ?? null;
+};

--- a/apps/api/src/lib/services/payment/subscriptionPlanCatalog.ts
+++ b/apps/api/src/lib/services/payment/subscriptionPlanCatalog.ts
@@ -1,39 +1,11 @@
-import type { ProductType } from "@/lib/constants/database";
-
 /**
- * Authoritative INR prices for subscription products (Cashfree order_amount is in INR).
- * Keys must match `productId` passed to create-order (plan id, e.g. "3months", "lifetime").
- * Tune per product line; keep in sync with public marketing pages and admin coupons.
+ * Subscription list prices live in MongoDB (`SubscriptionPlan` collection), not in source code.
+ *
+ * - Resolve at runtime: `getSubscriptionPlanPriceFromDB` in `@/lib/database/queries/subscription-plan`
+ * - Admin writes: `POST /api/v1/admin/subscription-plans` with header `x-admin-secret: <ADMIN_SECRET>`
+ * - One-off local seed: `pnpm seed:subscription-plans` (reads gitignored `scripts/subscription-plans.local.json`)
+ *
+ * @see docs/payment.md
  */
-export const SUBSCRIPTION_PLAN_PRICES: Partial<
-  Record<ProductType, Record<string, number>>
-> = {
-  PREPYATRA: {
-    "1months": 199,
-    "3months": 499,
-    "6months": 999,
-    "12months": 1799,
-    lifetime: 1999,
-  },
-  /** DSA Yatra: single lifetime SKU (productId = "lifetime"). */
-  DSA_YATRA: {
-    lifetime: 2999,
-  },
-  /** On Campus: duration plans + optional separate coupon rules in DB. */
-  ONCAMPUS: {
-    "1months": 199,
-    "3months": 499,
-    "6months": 999,
-    "12months": 1799,
-  },
-};
 
-export const getSubscriptionPlanPrice = (
-  productType: ProductType,
-  planKey: string,
-): number | null => {
-  const catalog = SUBSCRIPTION_PLAN_PRICES[productType];
-  if (!catalog) return null;
-  const key = planKey.toLowerCase();
-  return catalog[key] ?? null;
-};
+export { getSubscriptionPlanPriceFromDB as getSubscriptionPlanPrice } from "@/lib/database/queries/subscription-plan";

--- a/apps/api/src/pages/api/v1/admin/subscription-plans/index.ts
+++ b/apps/api/src/pages/api/v1/admin/subscription-plans/index.ts
@@ -1,0 +1,135 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { apiStatusCodes } from "@/lib/constants";
+import type { ProductType } from "@/lib/constants/database";
+import { isValidProductType } from "@/lib/constants/products";
+import {
+  listSubscriptionPlansFromDB,
+  upsertSubscriptionPlansInDB,
+} from "@/lib/database";
+import type { APIResponseType } from "@/lib/interfaces";
+import { sendAPIResponse } from "@/lib/utils";
+import { logger } from "@/lib/utils/logger";
+import { adminMiddleware } from "@/middleware/api";
+import { withApiHandler } from "@/middleware/requestLogger";
+
+interface SeedBody {
+  plans: Array<{
+    productType: string;
+    planKey: string;
+    amountInr: number;
+    isActive?: boolean;
+  }>;
+}
+
+const handler = async (req: NextApiRequest, res: NextApiResponse<APIResponseType>) => {
+  const adminCheck = await adminMiddleware(req, res);
+  if (!adminCheck) return;
+
+  try {
+    switch (req.method) {
+      case "GET":
+        return handleGet(res);
+      case "POST":
+        return handlePost(req, res);
+      default:
+        return res.status(apiStatusCodes.METHOD_NOT_ALLOWED).json(
+          sendAPIResponse({
+            status: false,
+            message: `Method ${req.method} Not Allowed`,
+          }),
+        );
+    }
+  } catch (error) {
+    logger.error("admin subscription-plans handler error", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return res.status(apiStatusCodes.INTERNAL_SERVER_ERROR).json(
+      sendAPIResponse({
+        status: false,
+        message: "Internal Server Error",
+      }),
+    );
+  }
+};
+
+const handleGet = async (res: NextApiResponse<APIResponseType>) => {
+  const { data, error } = await listSubscriptionPlansFromDB();
+  if (error) {
+    return res.status(apiStatusCodes.INTERNAL_SERVER_ERROR).json(
+      sendAPIResponse({
+        status: false,
+        message: error,
+      }),
+    );
+  }
+  return res.status(apiStatusCodes.OKAY).json(
+    sendAPIResponse({
+      status: true,
+      message: "OK",
+      data,
+    }),
+  );
+};
+
+const handlePost = async (
+  req: NextApiRequest,
+  res: NextApiResponse<APIResponseType>,
+) => {
+  const body = req.body as SeedBody;
+  if (!body?.plans || !Array.isArray(body.plans)) {
+    return res.status(apiStatusCodes.BAD_REQUEST).json(
+      sendAPIResponse({
+        status: false,
+        message: "Body must include plans: [...]",
+      }),
+    );
+  }
+
+  for (const p of body.plans) {
+    if (!p.productType || !p.planKey || typeof p.amountInr !== "number") {
+      return res.status(apiStatusCodes.BAD_REQUEST).json(
+        sendAPIResponse({
+          status: false,
+          message: "Each plan needs productType, planKey, amountInr",
+        }),
+      );
+    }
+    if (!isValidProductType(p.productType)) {
+      return res.status(apiStatusCodes.BAD_REQUEST).json(
+        sendAPIResponse({
+          status: false,
+          message: `Invalid productType: ${p.productType}`,
+        }),
+      );
+    }
+  }
+
+  const { data, error } = await upsertSubscriptionPlansInDB(
+    body.plans.map((p) => ({
+      productType: p.productType as ProductType,
+      planKey: p.planKey,
+      amountInr: p.amountInr,
+      isActive: p.isActive,
+    })),
+  );
+
+  if (error) {
+    return res.status(apiStatusCodes.INTERNAL_SERVER_ERROR).json(
+      sendAPIResponse({
+        status: false,
+        message: error,
+      }),
+    );
+  }
+
+  return res.status(apiStatusCodes.OKAY).json(
+    sendAPIResponse({
+      status: true,
+      message: "Subscription plans upserted",
+      data,
+    }),
+  );
+};
+
+export default withApiHandler(handler);

--- a/apps/api/src/pages/api/v1/payment/create-order.ts
+++ b/apps/api/src/pages/api/v1/payment/create-order.ts
@@ -1,8 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { apiStatusCodes, envConfig, isDevelopmentEnv } from "@/lib/constants";
+import type { ProductType } from "@/lib/constants/database";
 import { isValidProductType } from "@/lib/constants/products";
 import { addPaymentToDB } from "@/lib/database";
+import { resolveAuthoritativeOrderAmount } from "@/lib/services/payment";
 import {
   buildOrderPayload,
   createCashfreeOrder,
@@ -41,10 +43,8 @@ const handleCreateOrder = async (req: NextApiRequest, res: NextApiResponse) => {
       userId,
       productId,
       productType,
-      amount,
       customerName,
       customerEmail,
-      appliedCoupon,
       couponCode,
     } = req.body;
 
@@ -52,7 +52,6 @@ const handleCreateOrder = async (req: NextApiRequest, res: NextApiResponse) => {
       !userId ||
       !productId ||
       !productType ||
-      !amount ||
       !customerName ||
       !customerEmail
     ) {
@@ -73,11 +72,30 @@ const handleCreateOrder = async (req: NextApiRequest, res: NextApiResponse) => {
       );
     }
 
+    const resolved = await resolveAuthoritativeOrderAmount({
+      productType: productType as ProductType,
+      productId,
+      couponCode: couponCode ?? undefined,
+      userId,
+    });
+
+    if (!resolved.ok) {
+      return res.status(apiStatusCodes.BAD_REQUEST).json(
+        sendAPIResponse({
+          status: false,
+          message: resolved.error,
+        }),
+      );
+    }
+
+    const { finalAmount, appliedCoupon, couponCode: resolvedCoupon } =
+      resolved.data;
+
     const orderId = generatePaymentOrderId();
 
     const orderPayload = buildOrderPayload({
       orderId,
-      amount,
+      amount: finalAmount,
       userId,
       customerName,
       customerEmail,
@@ -101,11 +119,11 @@ const handleCreateOrder = async (req: NextApiRequest, res: NextApiResponse) => {
       userId,
       productId,
       productType,
-      amount,
+      amount: finalAmount,
       orderId,
       paymentLink,
-      appliedCoupon,
-      couponCode,
+      ...(appliedCoupon && { appliedCoupon }),
+      ...(resolvedCoupon && { couponCode: resolvedCoupon }),
     });
 
     if (error) {

--- a/apps/api/src/pages/api/v1/payment/order-status.ts
+++ b/apps/api/src/pages/api/v1/payment/order-status.ts
@@ -1,0 +1,82 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { apiStatusCodes } from "@/lib/constants";
+import { getPaymentByOrderIdFromDB } from "@/lib/database";
+import { sendAPIResponse } from "@/lib/utils";
+import { withApiHandler } from "@/middleware/requestLogger";
+
+/**
+ * Lookup payment state by Cashfree return `order_id`.
+ * Requires userId so a leaked order id cannot be queried anonymously.
+ */
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    if (req.method !== "GET") {
+      return res.status(apiStatusCodes.METHOD_NOT_ALLOWED).json(
+        sendAPIResponse({
+          status: false,
+          message: `Method ${req.method} Not Allowed`,
+        }),
+      );
+    }
+
+    const { orderId, userId } = req.query;
+
+    if (!orderId || !userId || typeof orderId !== "string") {
+      return res.status(apiStatusCodes.BAD_REQUEST).json(
+        sendAPIResponse({
+          status: false,
+          message: "orderId and userId are required",
+        }),
+      );
+    }
+
+    const { data: payment, error } = await getPaymentByOrderIdFromDB(orderId);
+
+    if (error || !payment) {
+      return res.status(apiStatusCodes.NOT_FOUND).json(
+        sendAPIResponse({
+          status: false,
+          message: error || "Payment not found",
+        }),
+      );
+    }
+
+    const ownerId =
+      typeof payment.user === "object" && payment.user !== null
+        ? String((payment.user as { _id?: unknown })._id ?? payment.user)
+        : String(payment.user);
+
+    if (ownerId !== String(userId)) {
+      return res.status(apiStatusCodes.FORBIDDEN).json(
+        sendAPIResponse({
+          status: false,
+          message: "Forbidden",
+        }),
+      );
+    }
+
+    return res.status(apiStatusCodes.OKAY).json(
+      sendAPIResponse({
+        status: true,
+        message: "Payment found",
+        data: {
+          orderId: payment.orderId,
+          paymentStatus: payment.status,
+          productType: payment.productType,
+          productId: payment.productId,
+          amount: payment.amount,
+        },
+      }),
+    );
+  } catch (error) {
+    return res.status(apiStatusCodes.INTERNAL_SERVER_ERROR).json(
+      sendAPIResponse({
+        status: false,
+        message: "Internal Server Error",
+      }),
+    );
+  }
+};
+
+export default withApiHandler(handler);

--- a/apps/api/src/pages/api/v1/payment/quote.ts
+++ b/apps/api/src/pages/api/v1/payment/quote.ts
@@ -1,0 +1,101 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { apiStatusCodes, isDevelopmentEnv } from "@/lib/constants";
+import type { ProductType } from "@/lib/constants/database";
+import { isValidProductType } from "@/lib/constants/products";
+import { resolveAuthoritativeOrderAmount } from "@/lib/services/payment";
+import { sendAPIResponse } from "@/lib/utils";
+import { withApiHandler } from "@/middleware/requestLogger";
+
+const parseQuoteInput = (
+  req: NextApiRequest,
+): {
+  productType?: string;
+  productId?: string;
+  couponCode?: string;
+  userId?: string;
+} => {
+  if (req.method === "GET") {
+    const q = req.query;
+    return {
+      productType: typeof q.productType === "string" ? q.productType : undefined,
+      productId: typeof q.productId === "string" ? q.productId : undefined,
+      couponCode: typeof q.coupon === "string" ? q.coupon : undefined,
+      userId: typeof q.userId === "string" ? q.userId : undefined,
+    };
+  }
+  const b = req.body || {};
+  return {
+    productType: b.productType,
+    productId: b.productId,
+    couponCode: b.couponCode ?? b.coupon,
+    userId: b.userId,
+  };
+};
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    if (req.method !== "GET" && req.method !== "POST") {
+      return res.status(apiStatusCodes.METHOD_NOT_ALLOWED).json(
+        sendAPIResponse({
+          status: false,
+          message: `Method ${req.method} Not Allowed`,
+        }),
+      );
+    }
+
+    const { productType, productId, couponCode, userId } = parseQuoteInput(req);
+
+    if (!productType || !productId) {
+      return res.status(apiStatusCodes.BAD_REQUEST).json(
+        sendAPIResponse({
+          status: false,
+          message: "productType and productId are required",
+        }),
+      );
+    }
+
+    if (!isValidProductType(productType)) {
+      return res.status(apiStatusCodes.BAD_REQUEST).json(
+        sendAPIResponse({
+          status: false,
+          message: `Invalid product type: ${productType}`,
+        }),
+      );
+    }
+
+    const resolved = await resolveAuthoritativeOrderAmount({
+      productType: productType as ProductType,
+      productId,
+      couponCode: couponCode ?? undefined,
+      userId,
+    });
+
+    if (!resolved.ok) {
+      return res.status(apiStatusCodes.BAD_REQUEST).json(
+        sendAPIResponse({
+          status: false,
+          message: resolved.error,
+        }),
+      );
+    }
+
+    return res.status(apiStatusCodes.OKAY).json(
+      sendAPIResponse({
+        status: true,
+        message: "Quote ready",
+        data: resolved.data,
+      }),
+    );
+  } catch (error) {
+    return res.status(apiStatusCodes.INTERNAL_SERVER_ERROR).json(
+      sendAPIResponse({
+        status: false,
+        message: "Internal Server Error",
+        error: isDevelopmentEnv && error,
+      }),
+    );
+  }
+};
+
+export default withApiHandler(handler);

--- a/apps/platform/src/pages/checkout.tsx
+++ b/apps/platform/src/pages/checkout.tsx
@@ -1,0 +1,256 @@
+import { Button, Text } from '@tbe/components';
+import { getProductConfig, routes } from '@tbe/constants';
+import type { ProductType } from '@tbe/constants';
+import { useCashfreePayment, useUser } from '@tbe/hooks';
+import { sendRequest } from '@tbe/utils';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const SUPPORTED: ProductType[] = [
+  'INTERVIEW_SHEET',
+  'SHIKSHA',
+  'PREPYATRA',
+  'DSA_YATRA',
+  'ONCAMPUS',
+];
+
+const CheckoutPage = () => {
+  const router = useRouter();
+  const { user, loading: isUserLoading } = useUser();
+  const {
+    isCashfreeLoaded,
+    error: sdkError,
+    launchPayment,
+  } = useCashfreePayment();
+
+  const productType = router.query.productType as string | undefined;
+  const productId = router.query.productId as string | undefined;
+  const coupon = router.query.coupon as string | undefined;
+  const nextPath = router.query.next as string | undefined;
+
+  const [quote, setQuote] = useState<{
+    baseAmount: number;
+    finalAmount: number;
+    couponCode?: string;
+  } | null>(null);
+  const [quoteError, setQuoteError] = useState<string | null>(null);
+  const [isQuoting, setIsQuoting] = useState(false);
+  const [isPaying, setIsPaying] = useState(false);
+  const [payError, setPayError] = useState<string | null>(null);
+
+  const isSupported =
+    productType &&
+    SUPPORTED.includes(productType as ProductType) &&
+    productId;
+
+  const productLabel = useMemo(() => {
+    if (!productType) return 'Product';
+    return getProductConfig(productType).name;
+  }, [productType]);
+
+  const loginHref = `${routes.login}?redirect=${encodeURIComponent(
+    typeof window !== 'undefined' ? window.location.pathname + window.location.search : routes.checkout,
+  )}`;
+
+  const loadQuote = useCallback(async () => {
+    if (!productType || !productId) return;
+    setIsQuoting(true);
+    setQuoteError(null);
+    const qs = new URLSearchParams({
+      productType,
+      productId,
+    });
+    if (coupon) qs.set('coupon', coupon);
+    if (user?.id) qs.set('userId', user.id);
+
+    const res = await sendRequest({
+      method: 'GET',
+      url: `${routes.api.paymentQuote}?${qs.toString()}`,
+    });
+
+    setIsQuoting(false);
+    if (!res.status || !res.data) {
+      setQuoteError(
+        typeof res.message === 'string' ? res.message : 'Unable to load price',
+      );
+      setQuote(null);
+      return;
+    }
+    setQuote({
+      baseAmount: res.data.baseAmount,
+      finalAmount: res.data.finalAmount,
+      couponCode: res.data.couponCode,
+    });
+  }, [productType, productId, coupon, user?.id]);
+
+  useEffect(() => {
+    if (!router.isReady || !isSupported) return;
+    void loadQuote();
+  }, [router.isReady, isSupported, loadQuote]);
+
+  const handlePay = async () => {
+    if (!user?.id || !productType || !productId || !isCashfreeLoaded) return;
+    setIsPaying(true);
+    setPayError(null);
+    try {
+      const res = await sendRequest({
+        method: 'POST',
+        url: routes.api.createOrder,
+        body: {
+          userId: user.id,
+          productId,
+          productType,
+          customerName: user.name,
+          customerEmail: user.email,
+          ...(coupon ? { couponCode: coupon } : {}),
+        },
+      });
+
+      if (!res.status || !res.data?.paymentSessionId || !res.data?.orderId) {
+        throw new Error(
+          typeof res.message === 'string' ? res.message : 'Failed to create order',
+        );
+      }
+
+      const { paymentSessionId, orderId } = res.data;
+
+      await launchPayment(
+        paymentSessionId,
+        () => {
+          const next =
+            nextPath && nextPath.startsWith('/') ? nextPath : routes.user.dashboard;
+          router.replace(
+            `${routes.paymentStatus}?order_id=${encodeURIComponent(orderId)}&next=${encodeURIComponent(next)}`,
+          );
+        },
+        () => {
+          setPayError('Payment failed. You can try again.');
+          setIsPaying(false);
+        },
+        () => {
+          setIsPaying(false);
+        },
+      );
+    } catch (e) {
+      setPayError(e instanceof Error ? e.message : 'Something went wrong');
+      setIsPaying(false);
+    }
+  };
+
+  if (!router.isReady) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-slate-50">
+        <Head>
+          <title>Checkout — The Boring Education</title>
+        </Head>
+        <Text level="p" className="text-slate-600">
+          Loading…
+        </Text>
+      </div>
+    );
+  }
+
+  if (!isSupported) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center bg-slate-50 px-4">
+        <Head>
+          <title>Checkout — The Boring Education</title>
+        </Head>
+        <Text level="h2" className="text-slate-900 font-semibold mb-2">
+          Invalid checkout link
+        </Text>
+        <Text level="p" className="text-slate-600 text-center max-w-md mb-6">
+          Add productType and productId to the URL. Example: interview sheet
+          checkout includes your sheet id.
+        </Text>
+        <Link href={routes.home}>
+          <Button text="Back to home" variant="PRIMARY" />
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center px-4 py-12">
+      <Head>
+        <title>{`Checkout — ${productLabel}`}</title>
+      </Head>
+
+      <div className="w-full max-w-md rounded-2xl bg-white shadow-sm border border-slate-200 p-6 sm:p-8">
+        <Text level="h1" className="text-xl font-semibold text-slate-900 mb-1">
+          {productLabel}
+        </Text>
+        <Text level="p" className="text-sm text-slate-500 mb-6">
+          Secure payment via Cashfree
+        </Text>
+
+        {isUserLoading ? (
+          <Text level="p" className="text-slate-600">
+            Checking your session…
+          </Text>
+        ) : !user ? (
+          <div className="space-y-4">
+            <Text level="p" className="text-slate-700">
+              Sign in to continue checkout. Share this page — each person pays
+              on their own account.
+            </Text>
+            <Link href={loginHref}>
+              <Button text="Sign in to pay" variant="PRIMARY" className="w-full" />
+            </Link>
+          </div>
+        ) : (
+          <>
+            <div className="rounded-xl bg-slate-50 border border-slate-100 p-4 mb-6">
+              {isQuoting ? (
+                <Text level="p" className="text-slate-600">
+                  Loading price…
+                </Text>
+              ) : quoteError ? (
+                <Text level="p" className="text-red-600 text-sm">
+                  {quoteError}
+                </Text>
+              ) : quote ? (
+                <div className="flex justify-between items-baseline">
+                  <span className="text-slate-600">Total</span>
+                  <span className="text-2xl font-bold text-slate-900">
+                    ₹{quote.finalAmount.toLocaleString('en-IN')}
+                  </span>
+                </div>
+              ) : null}
+              {quote && quote.couponCode ? (
+                <Text level="p" className="text-xs text-green-700 mt-2">
+                  Coupon {quote.couponCode} applied
+                </Text>
+              ) : null}
+            </div>
+
+            {(sdkError || payError) && (
+              <div className="mb-4 text-sm text-red-600">
+                {payError || sdkError}
+              </div>
+            )}
+
+            <Button
+              text={isPaying ? 'Processing…' : 'Pay now'}
+              variant="PRIMARY"
+              className="w-full"
+              onClick={() => void handlePay()}
+              active={!isPaying && isCashfreeLoaded && !!quote && !quoteError}
+              isLoading={isPaying}
+            />
+
+            {!isCashfreeLoaded && (
+              <Text level="p" className="text-center text-xs text-slate-500 mt-3">
+                Loading payment gateway…
+              </Text>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CheckoutPage;

--- a/apps/platform/src/pages/payment/status.tsx
+++ b/apps/platform/src/pages/payment/status.tsx
@@ -1,0 +1,141 @@
+import { Button, Text } from '@tbe/components';
+import { routes } from '@tbe/constants';
+import { useUser } from '@tbe/hooks';
+import { sendRequest } from '@tbe/utils';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const PaymentStatusPage = () => {
+  const router = useRouter();
+  const { user, loading: userLoading } = useUser();
+  const orderId = router.query.order_id as string | undefined;
+  const nextPath = router.query.next as string | undefined;
+
+  const [state, setState] = useState<
+    'idle' | 'loading' | 'success' | 'pending' | 'error'
+  >('idle');
+  const [detail, setDetail] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!router.isReady || !orderId || !user?.id) return;
+
+    const run = async () => {
+      setState('loading');
+      const res = await sendRequest({
+        method: 'GET',
+        url: `${routes.api.paymentOrderStatus}?orderId=${encodeURIComponent(orderId)}&userId=${encodeURIComponent(user.id)}`,
+      });
+
+      if (!res.status || !res.data) {
+        setState('error');
+        setDetail(
+          typeof res.message === 'string' ? res.message : 'Unable to verify payment',
+        );
+        return;
+      }
+
+      const status = res.data.paymentStatus as string;
+      if (status === 'SUCCESS') {
+        setState('success');
+      } else if (status === 'PENDING') {
+        setState('pending');
+      } else {
+        setState('error');
+        setDetail('Payment was not completed.');
+      }
+    };
+
+    void run();
+  }, [router.isReady, orderId, user?.id]);
+
+  const safeNext =
+    nextPath && nextPath.startsWith('/') ? nextPath : routes.user.dashboard;
+
+  return (
+    <>
+      <Head>
+        <title>Payment status — The Boring Education</title>
+      </Head>
+      <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center px-4 py-12">
+        <div className="w-full max-w-md rounded-2xl bg-white shadow-sm border border-slate-200 p-6 sm:p-8 text-center">
+          {userLoading ? (
+            <Text level="p" className="text-slate-600">
+              Loading…
+            </Text>
+          ) : !user ? (
+            <>
+              <Text level="h2" className="text-lg font-semibold text-slate-900 mb-2">
+                Sign in to view payment status
+              </Text>
+              <Link
+                href={`${routes.login}?redirect=${encodeURIComponent(
+                  typeof window !== 'undefined'
+                    ? window.location.pathname + window.location.search
+                    : routes.paymentStatus,
+                )}`}
+              >
+                <Button text="Sign in" variant="PRIMARY" className="w-full mt-4" />
+              </Link>
+            </>
+          ) : !orderId ? (
+            <Text level="p" className="text-slate-600">
+              Missing order reference. Open the link from your payment confirmation
+              email or history.
+            </Text>
+          ) : state === 'loading' || state === 'idle' ? (
+            <Text level="p" className="text-slate-600">
+              Verifying your payment…
+            </Text>
+          ) : state === 'success' ? (
+            <>
+              <Text level="h2" className="text-xl font-semibold text-green-800 mb-2">
+                Payment successful
+              </Text>
+              <Text level="p" className="text-slate-600 mb-6">
+                Your purchase is confirmed. It may take a moment for access to
+                unlock everywhere.
+              </Text>
+              <Link href={safeNext}>
+                <Button text="Continue" variant="PRIMARY" className="w-full" />
+              </Link>
+            </>
+          ) : state === 'pending' ? (
+            <>
+              <Text level="h2" className="text-lg font-semibold text-amber-800 mb-2">
+                Payment pending
+              </Text>
+              <Text level="p" className="text-slate-600 mb-4">
+                We are still confirming this with the bank. Refresh in a minute
+                or check your email.
+              </Text>
+              <Button
+                text="Refresh"
+                variant="SECONDARY"
+                className="w-full"
+                onClick={() => router.replace(router.asPath)}
+              />
+            </>
+          ) : (
+            <>
+              <Text level="h2" className="text-lg font-semibold text-red-800 mb-2">
+                Could not verify payment
+              </Text>
+              {detail ? (
+                <Text level="p" className="text-slate-600 mb-4">
+                  {detail}
+                </Text>
+              ) : null}
+              <Link href={routes.checkout}>
+                <Button text="Back to checkout" variant="PRIMARY" className="w-full" />
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default PaymentStatusPage;

--- a/apps/platform/src/pages/payment/status.tsx
+++ b/apps/platform/src/pages/payment/status.tsx
@@ -7,6 +7,20 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
+/** Relative in-app path only — blocks protocol-relative URLs (`//host/...`) and backslashes. */
+const sanitizeRelativeNextPath = (
+  path: string | undefined,
+  fallback: string,
+): string => {
+  if (typeof path !== 'string' || !path.startsWith('/')) {
+    return fallback;
+  }
+  if (path.startsWith('//') || path.includes('\\')) {
+    return fallback;
+  }
+  return path;
+};
+
 const PaymentStatusPage = () => {
   const router = useRouter();
   const { user, loading: userLoading } = useUser();
@@ -17,6 +31,7 @@ const PaymentStatusPage = () => {
     'idle' | 'loading' | 'success' | 'pending' | 'error'
   >('idle');
   const [detail, setDetail] = useState<string | null>(null);
+  const [refetchKey, setRefetchKey] = useState(0);
 
   useEffect(() => {
     if (!router.isReady || !orderId || !user?.id) return;
@@ -31,7 +46,9 @@ const PaymentStatusPage = () => {
       if (!res.status || !res.data) {
         setState('error');
         setDetail(
-          typeof res.message === 'string' ? res.message : 'Unable to verify payment',
+          typeof res.message === 'string'
+            ? res.message
+            : 'Unable to verify payment',
         );
         return;
       }
@@ -48,25 +65,27 @@ const PaymentStatusPage = () => {
     };
 
     void run();
-  }, [router.isReady, orderId, user?.id]);
+  }, [router.isReady, orderId, user?.id, refetchKey]);
 
-  const safeNext =
-    nextPath && nextPath.startsWith('/') ? nextPath : routes.user.dashboard;
+  const safeNext = sanitizeRelativeNextPath(nextPath, routes.user.dashboard);
 
   return (
     <>
       <Head>
         <title>Payment status — The Boring Education</title>
       </Head>
-      <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center px-4 py-12">
-        <div className="w-full max-w-md rounded-2xl bg-white shadow-sm border border-slate-200 p-6 sm:p-8 text-center">
+      <div className='min-h-screen bg-slate-50 flex flex-col items-center justify-center px-4 py-12'>
+        <div className='w-full max-w-md rounded-2xl bg-white shadow-sm border border-slate-200 p-6 sm:p-8 text-center'>
           {userLoading ? (
-            <Text level="p" className="text-slate-600">
+            <Text level='p' className='text-slate-600'>
               Loading…
             </Text>
           ) : !user ? (
             <>
-              <Text level="h2" className="text-lg font-semibold text-slate-900 mb-2">
+              <Text
+                level='h2'
+                className='text-lg font-semibold text-slate-900 mb-2'
+              >
                 Sign in to view payment status
               </Text>
               <Link
@@ -76,59 +95,76 @@ const PaymentStatusPage = () => {
                     : routes.paymentStatus,
                 )}`}
               >
-                <Button text="Sign in" variant="PRIMARY" className="w-full mt-4" />
+                <Button
+                  text='Sign in'
+                  variant='PRIMARY'
+                  className='w-full mt-4'
+                />
               </Link>
             </>
           ) : !orderId ? (
-            <Text level="p" className="text-slate-600">
-              Missing order reference. Open the link from your payment confirmation
-              email or history.
+            <Text level='p' className='text-slate-600'>
+              Missing order reference. Open the link from your payment
+              confirmation email or history.
             </Text>
           ) : state === 'loading' || state === 'idle' ? (
-            <Text level="p" className="text-slate-600">
+            <Text level='p' className='text-slate-600'>
               Verifying your payment…
             </Text>
           ) : state === 'success' ? (
             <>
-              <Text level="h2" className="text-xl font-semibold text-green-800 mb-2">
+              <Text
+                level='h2'
+                className='text-xl font-semibold text-green-800 mb-2'
+              >
                 Payment successful
               </Text>
-              <Text level="p" className="text-slate-600 mb-6">
+              <Text level='p' className='text-slate-600 mb-6'>
                 Your purchase is confirmed. It may take a moment for access to
                 unlock everywhere.
               </Text>
               <Link href={safeNext}>
-                <Button text="Continue" variant="PRIMARY" className="w-full" />
+                <Button text='Continue' variant='PRIMARY' className='w-full' />
               </Link>
             </>
           ) : state === 'pending' ? (
             <>
-              <Text level="h2" className="text-lg font-semibold text-amber-800 mb-2">
+              <Text
+                level='h2'
+                className='text-lg font-semibold text-amber-800 mb-2'
+              >
                 Payment pending
               </Text>
-              <Text level="p" className="text-slate-600 mb-4">
+              <Text level='p' className='text-slate-600 mb-4'>
                 We are still confirming this with the bank. Refresh in a minute
                 or check your email.
               </Text>
               <Button
-                text="Refresh"
-                variant="SECONDARY"
-                className="w-full"
-                onClick={() => router.replace(router.asPath)}
+                text='Refresh'
+                variant='SECONDARY'
+                className='w-full'
+                onClick={() => setRefetchKey((k) => k + 1)}
               />
             </>
           ) : (
             <>
-              <Text level="h2" className="text-lg font-semibold text-red-800 mb-2">
+              <Text
+                level='h2'
+                className='text-lg font-semibold text-red-800 mb-2'
+              >
                 Could not verify payment
               </Text>
               {detail ? (
-                <Text level="p" className="text-slate-600 mb-4">
+                <Text level='p' className='text-slate-600 mb-4'>
                   {detail}
                 </Text>
               ) : null}
               <Link href={routes.checkout}>
-                <Button text="Back to checkout" variant="PRIMARY" className="w-full" />
+                <Button
+                  text='Back to checkout'
+                  variant='PRIMARY'
+                  className='w-full'
+                />
               </Link>
             </>
           )}

--- a/apps/testing/src/e2e/platform/payment-checkout.spec.ts
+++ b/apps/testing/src/e2e/platform/payment-checkout.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "../fixtures/platform.fixture";
+
+test.describe("Platform checkout page", () => {
+  test("checkout loads for subscription query params", async ({
+    platformPage: page,
+  }) => {
+    const response = await page.goto(
+      "/checkout?productType=DSA_YATRA&productId=lifetime",
+    );
+    expect(response?.status()).toBe(200);
+    await expect(
+      page.getByRole("heading", { name: /DSA Yatra/i }),
+    ).toBeVisible();
+  });
+
+  test("checkout shows invalid message without required params", async ({
+    platformPage: page,
+  }) => {
+    const response = await page.goto("/checkout");
+    expect(response?.status()).toBe(200);
+    await expect(
+      page.getByRole("heading", { name: /Invalid checkout link/i }),
+    ).toBeVisible();
+  });
+});

--- a/apps/testing/src/unit/api-routes/admin-subscription-plans.test.ts
+++ b/apps/testing/src/unit/api-routes/admin-subscription-plans.test.ts
@@ -1,0 +1,136 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockListSubscriptionPlansFromDB = vi.fn();
+const mockUpsertSubscriptionPlansInDB = vi.fn();
+
+vi.mock("../../../../api/src/lib/database", () => ({
+  listSubscriptionPlansFromDB: (...args: unknown[]) =>
+    mockListSubscriptionPlansFromDB(...args),
+  upsertSubscriptionPlansInDB: (...args: unknown[]) =>
+    mockUpsertSubscriptionPlansInDB(...args),
+}));
+
+vi.mock("../../../../api/src/lib/constants", () => ({
+  apiStatusCodes: {
+    OKAY: 200,
+    BAD_REQUEST: 400,
+    UNAUTHORIZED: 401,
+    INTERNAL_SERVER_ERROR: 500,
+    METHOD_NOT_ALLOWED: 405,
+  },
+  envConfig: {},
+  isDevelopmentEnv: true,
+}));
+
+vi.mock("../../../../api/src/lib/constants/products", () => ({
+  isValidProductType: (t: string) =>
+    ["DSA_YATRA", "PREPYATRA", "ONCAMPUS"].includes(t),
+}));
+
+const mockAdminMiddleware = vi.fn();
+vi.mock("../../../../api/src/middleware/api", () => ({
+  adminMiddleware: (...args: unknown[]) => mockAdminMiddleware(...args),
+  connectDB: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../../api/src/lib/utils/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), request: vi.fn() },
+}));
+
+vi.mock("../../../../api/src/lib/utils/sentry", () => ({
+  captureAPIError: vi.fn(),
+}));
+
+vi.mock("../../../../api/src/lib/utils/cors", () => ({
+  cors: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../../api/src/lib/utils", () => ({
+  sendAPIResponse: (payload: Record<string, unknown>) => payload,
+}));
+
+import handler from "../../../../api/src/pages/api/v1/admin/subscription-plans/index";
+
+describe("Admin subscription-plans API", () => {
+  const OLD_ENV = process.env.ADMIN_SECRET;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ADMIN_SECRET = "test-admin-secret";
+    mockAdminMiddleware.mockImplementation(async (req: NextApiRequest) => {
+      const h = req.headers["x-admin-secret"];
+      return h === process.env.ADMIN_SECRET;
+    });
+  });
+
+  afterAll(() => {
+    process.env.ADMIN_SECRET = OLD_ENV;
+  });
+
+  it("GET does not list plans when admin middleware denies", async () => {
+    mockAdminMiddleware.mockResolvedValueOnce(false);
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+    });
+    await handler(req, res);
+    expect(mockListSubscriptionPlansFromDB).not.toHaveBeenCalled();
+  });
+
+  it("GET returns plans list", async () => {
+    mockListSubscriptionPlansFromDB.mockResolvedValue({
+      data: [{ productType: "DSA_YATRA", planKey: "lifetime", amountInr: 100 }],
+    });
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      headers: { "x-admin-secret": "test-admin-secret" },
+    });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    const body = JSON.parse(res._getData() as string);
+    expect(body.status).toBe(true);
+    expect(body.data).toHaveLength(1);
+  });
+
+  it("POST upserts plans", async () => {
+    mockUpsertSubscriptionPlansInDB.mockResolvedValue({
+      data: { matched: 1, modified: 0, upserted: 1 },
+    });
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      headers: { "x-admin-secret": "test-admin-secret" },
+      body: {
+        plans: [
+          {
+            productType: "DSA_YATRA",
+            planKey: "lifetime",
+            amountInr: 2999,
+          },
+        ],
+      },
+    });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockUpsertSubscriptionPlansInDB).toHaveBeenCalledWith([
+      {
+        productType: "DSA_YATRA",
+        planKey: "lifetime",
+        amountInr: 2999,
+        isActive: undefined,
+      },
+    ]);
+  });
+
+  it("POST returns 400 for invalid productType", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      headers: { "x-admin-secret": "test-admin-secret" },
+      body: {
+        plans: [{ productType: "INVALID", planKey: "x", amountInr: 1 }],
+      },
+    });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+  });
+});

--- a/apps/testing/src/unit/api-routes/payment-create-order.test.ts
+++ b/apps/testing/src/unit/api-routes/payment-create-order.test.ts
@@ -51,6 +51,13 @@ vi.mock("../../../../api/src/lib/database", () => ({
   addPaymentToDB: (...args: any[]) => mockAddPaymentToDB(...args),
 }));
 
+const mockResolveAuthoritativeOrderAmount = vi.fn();
+
+vi.mock("@/lib/services/payment", () => ({
+  resolveAuthoritativeOrderAmount: (...args: any[]) =>
+    mockResolveAuthoritativeOrderAmount(...args),
+}));
+
 vi.mock("../../../../api/src/lib/utils", () => ({
   buildOrderPayload: (...args: any[]) => mockBuildOrderPayload(...args),
   createCashfreeOrder: (...args: any[]) => mockCreateCashfreeOrder(...args),
@@ -85,7 +92,6 @@ const validBody = {
   userId: "user_123",
   productId: "prod_456",
   productType: "SHIKSHA",
-  amount: 999,
   customerName: "Test User",
   customerEmail: "test@example.com",
 };
@@ -98,6 +104,13 @@ describe("Payment Create Order API Route", () => {
       order_id: "order_test_123",
       order_amount: 999,
       order_currency: "INR",
+    });
+    mockResolveAuthoritativeOrderAmount.mockResolvedValue({
+      ok: true,
+      data: {
+        baseAmount: 999,
+        finalAmount: 999,
+      },
     });
   });
 
@@ -131,7 +144,6 @@ describe("Payment Create Order API Route", () => {
       "userId",
       "productId",
       "productType",
-      "amount",
       "customerName",
       "customerEmail",
     ];
@@ -244,9 +256,18 @@ describe("Payment Create Order API Route", () => {
     });
     mockAddPaymentToDB.mockResolvedValue({ data: {} });
 
+    mockResolveAuthoritativeOrderAmount.mockResolvedValue({
+      ok: true,
+      data: {
+        baseAmount: 800,
+        finalAmount: 800,
+        appliedCoupon: "coupon_id_1",
+        couponCode: "SAVE20",
+      },
+    });
+
     const bodyWithCoupon = {
       ...validBody,
-      appliedCoupon: "coupon_id_1",
       couponCode: "SAVE20",
     };
 
@@ -261,6 +282,7 @@ describe("Payment Create Order API Route", () => {
       expect.objectContaining({
         appliedCoupon: "coupon_id_1",
         couponCode: "SAVE20",
+        amount: 800,
       }),
     );
   });

--- a/apps/testing/vitest.config.ts
+++ b/apps/testing/vitest.config.ts
@@ -81,10 +81,6 @@ export default defineConfig({
       "@tbe/query": path.resolve(__dirname, "../../packages/api/src"),
       "@tbe/services": path.resolve(__dirname, "../../packages/services/src"),
       "@tbe/auth": path.resolve(__dirname, "../../packages/auth/src"),
-      "@tbe/gamification": path.resolve(
-        __dirname,
-        "../../packages/gamification/src/index.ts",
-      ),
       "@tbe/config/quizes": path.resolve(
         __dirname,
         "../../packages/config/src/quizes.ts",

--- a/docs/payment.md
+++ b/docs/payment.md
@@ -1,0 +1,73 @@
+# Payments guardrails (TBE Web)
+
+This document describes how money moves through the platform, how products plug in, and what we enforce for security.
+
+## Current stack
+
+- **Gateway:** Cashfree (orders + payment session + webhooks).
+- **API:** `apps/api` — `POST /api/v1/payment/create-order`, `GET /api/v1/payment/checkstatus`, `POST /api/v1/payment/webhook`, plus **quote** and **order status** routes documented below.
+- **Client:** Cashfree JS SDK via `useCashfreePayment` (`packages/hooks`), shared UI via `PaymentCard` (`packages/components`), and a **single frictionless checkout** on Platform (`apps/platform/src/pages/checkout.tsx`).
+
+## Product lines (how to map them)
+
+| Product | `productType` | What `productId` means | Pricing source |
+|--------|----------------|-------------------------|----------------|
+| Interview Prep (per sheet) | `INTERVIEW_SHEET` | Mongo `_id` of the sheet | Sheet `price` in DB + optional sheet discount + coupon |
+| Shiksha course | `SHIKSHA` | Course `_id` | Course `price` in DB + coupon |
+| DSA Yatra (lifetime) | `DSA_YATRA` | Plan key: `lifetime` | `SUBSCRIPTION_PLAN_PRICES.DSA_YATRA` in API |
+| On Campus (duration) | `ONCAMPUS` | Plan key: `1months`, `3months`, `6months`, `12months` | `SUBSCRIPTION_PLAN_PRICES.ONCAMPUS` |
+| PrepYatra | `PREPYATRA` | Same plan keys as today (`1months`, `3months`, `6months`, `12months`, `lifetime`) | `SUBSCRIPTION_PLAN_PRICES.PREPYATRA` |
+
+**Interview Prep “combined sheets” (e.g. React + Node):** model these as separate purchasable SKUs in admin (bundles) or keep one sheet per bundle. The payment system keys access by `(productType, productId)`; a bundle is just another `INTERVIEW_SHEET` document (or a future `productType` once defined in `PRODUCT_TYPE` and `PRODUCT_REGISTRY`).
+
+## Single checkout URL (shareable)
+
+Use `buildCheckoutUrl` from `@tbe/constants` or construct manually:
+
+```text
+/checkout?productType=ONCAMPUS&productId=3months&coupon=CAMPUS2026
+```
+
+- **Anyone can open the link.** Each user must **sign in** to pay (payment is always tied to the logged-in user).
+- Optional `next` (relative path) redirects after success, e.g. `&next=/interview-prep/explore`.
+
+Server-side **quotes** (no payment):
+
+- `GET /api/v1/payment/quote?productType=…&productId=…&coupon=…&userId=…`  
+  Returns `baseAmount`, `finalAmount`, and optional coupon metadata. Used by the checkout page to show the exact INR total.
+
+## Server-side amount resolution (security)
+
+**We do not trust the browser for price.** `POST /payment/create-order` resolves the payable amount with `resolveAuthoritativeOrderAmount` (`apps/api/src/lib/services/payment/resolveOrderAmount.ts`):
+
+- One-time products: load price from Mongo (sheet / course).
+- Subscriptions: load from `subscriptionPlanCatalog.ts` (`SUBSCRIPTION_PLAN_PRICES`).
+- Coupons: validated with `validateCouponForProductFromDB`; discount applied on the server.
+
+Tuning prices for subscriptions is done in **`apps/api/src/lib/services/payment/subscriptionPlanCatalog.ts`** (keep marketing pages and coupons aligned).
+
+## Post-payment access
+
+- Webhook: `apps/api/src/pages/api/v1/payment/webhook.ts` (signature verification + idempotency patterns as implemented).
+- Enrollment: `processPostPaymentEnrollment` → `enrollmentHandlers` (sheet enroll, course enroll, subscription create) keyed by `PRODUCT_REGISTRY` in `apps/api/src/lib/constants/products.ts`.
+- Subscription plan keys map through `planTypeMap` in `apps/api/src/lib/constants/api.ts` (includes `12months` for 1-year SKUs).
+
+## New API helpers
+
+| Route | Purpose |
+|-------|---------|
+| `GET/POST /api/v1/payment/quote` | Price quote for checkout and shareable links |
+| `GET /api/v1/payment/order-status?orderId=&userId=` | Resolve payment row after redirect (requires matching `userId`) |
+
+## Operational checklist
+
+1. Update **`SUBSCRIPTION_PLAN_PRICES`** when list prices change.
+2. Configure **coupons** in admin; scope with `applicableProducts` (use sheet/course ids or plan keys like `3months` for subscriptions).
+3. Keep **Cashfree** credentials and webhook secret only on the server.
+4. **Return URL** for hosted flows is `PLATFORM_URL/payment/status?order_id=…` (see `buildOrderPayload` in API utils).
+
+## Future hardening (recommended)
+
+- Bind **order-status** and **checkstatus** to authenticated session instead of trusting `userId` query params.
+- Extend **PROJECTS** / **WEBINAR** pricing in DB or catalog when those SKUs go live.
+- Add automated tests around `resolveAuthoritativeOrderAmount` and quote/create-order for each `productType`.

--- a/docs/payment.md
+++ b/docs/payment.md
@@ -8,15 +8,25 @@ This document describes how money moves through the platform, how products plug 
 - **API:** `apps/api` — `POST /api/v1/payment/create-order`, `GET /api/v1/payment/checkstatus`, `POST /api/v1/payment/webhook`, plus **quote** and **order status** routes documented below.
 - **Client:** Cashfree JS SDK via `useCashfreePayment` (`packages/hooks`), shared UI via `PaymentCard` (`packages/components`), and a **single frictionless checkout** on Platform (`apps/platform/src/pages/checkout.tsx`).
 
+## Subscription pricing (OSS-safe)
+
+**Subscription list prices are not stored in source code.** They live in MongoDB in the **`SubscriptionPlan`** collection (`productType` + `planKey` + `amountInr`). This avoids accidental price commits in open-source PRs.
+
+| Mechanism | Purpose |
+|-----------|---------|
+| **Admin HTTP API** | `GET/POST /api/v1/admin/subscription-plans` — requires header **`x-admin-secret: <ADMIN_SECRET>`** (same env as other admin routes). `POST` body: `{ "plans": [{ "productType", "planKey", "amountInr", "isActive?" }] }`. |
+| **Seed script** | From `apps/api`: `pnpm seed:subscription-plans` — reads **gitignored** `scripts/subscription-plans.local.json` and POSTs to the admin API. Copy from `scripts/subscription-plans.example.json` and fill INR amounts. |
+| **Runtime resolution** | `getSubscriptionPlanPriceFromDB` in `apps/api/src/lib/database/queries/subscription-plan.ts` |
+
 ## Product lines (how to map them)
 
 | Product | `productType` | What `productId` means | Pricing source |
 |--------|----------------|-------------------------|----------------|
 | Interview Prep (per sheet) | `INTERVIEW_SHEET` | Mongo `_id` of the sheet | Sheet `price` in DB + optional sheet discount + coupon |
 | Shiksha course | `SHIKSHA` | Course `_id` | Course `price` in DB + coupon |
-| DSA Yatra (lifetime) | `DSA_YATRA` | Plan key: `lifetime` | `SUBSCRIPTION_PLAN_PRICES.DSA_YATRA` in API |
-| On Campus (duration) | `ONCAMPUS` | Plan key: `1months`, `3months`, `6months`, `12months` | `SUBSCRIPTION_PLAN_PRICES.ONCAMPUS` |
-| PrepYatra | `PREPYATRA` | Same plan keys as today (`1months`, `3months`, `6months`, `12months`, `lifetime`) | `SUBSCRIPTION_PLAN_PRICES.PREPYATRA` |
+| DSA Yatra (lifetime) | `DSA_YATRA` | Plan key: `lifetime` | **`SubscriptionPlan`** row (`DSA_YATRA` + `lifetime`) |
+| On Campus (duration) | `ONCAMPUS` | `1months`, `3months`, `6months`, `12months` | **`SubscriptionPlan`** rows per key |
+| PrepYatra | `PREPYATRA` | `1months`, `3months`, `6months`, `12months`, `lifetime` | **`SubscriptionPlan`** rows per key |
 
 **Interview Prep “combined sheets” (e.g. React + Node):** model these as separate purchasable SKUs in admin (bundles) or keep one sheet per bundle. The payment system keys access by `(productType, productId)`; a bundle is just another `INTERVIEW_SHEET` document (or a future `productType` once defined in `PRODUCT_TYPE` and `PRODUCT_REGISTRY`).
 
@@ -41,10 +51,10 @@ Server-side **quotes** (no payment):
 **We do not trust the browser for price.** `POST /payment/create-order` resolves the payable amount with `resolveAuthoritativeOrderAmount` (`apps/api/src/lib/services/payment/resolveOrderAmount.ts`):
 
 - One-time products: load price from Mongo (sheet / course).
-- Subscriptions: load from `subscriptionPlanCatalog.ts` (`SUBSCRIPTION_PLAN_PRICES`).
+- Subscriptions: load **`amountInr`** from **`SubscriptionPlan`** for `(productType, planKey)` where `planKey` matches `productId` (e.g. `lifetime`, `3months`).
 - Coupons: validated with `validateCouponForProductFromDB`; discount applied on the server.
 
-Tuning prices for subscriptions is done in **`apps/api/src/lib/services/payment/subscriptionPlanCatalog.ts`** (keep marketing pages and coupons aligned).
+If no active plan row exists, quote/create-order returns a clear “pricing not configured” style error — **seed plans before going live.**
 
 ## Post-payment access
 
@@ -52,22 +62,25 @@ Tuning prices for subscriptions is done in **`apps/api/src/lib/services/payment/
 - Enrollment: `processPostPaymentEnrollment` → `enrollmentHandlers` (sheet enroll, course enroll, subscription create) keyed by `PRODUCT_REGISTRY` in `apps/api/src/lib/constants/products.ts`.
 - Subscription plan keys map through `planTypeMap` in `apps/api/src/lib/constants/api.ts` (includes `12months` for 1-year SKUs).
 
-## New API helpers
+## API reference (payment + admin)
 
-| Route | Purpose |
-|-------|---------|
-| `GET/POST /api/v1/payment/quote` | Price quote for checkout and shareable links |
-| `GET /api/v1/payment/order-status?orderId=&userId=` | Resolve payment row after redirect (requires matching `userId`) |
+| Route | Auth | Purpose |
+|-------|------|---------|
+| `GET/POST /api/v1/payment/quote` | Public | Price quote |
+| `GET /api/v1/payment/order-status?orderId=&userId=` | Query user must match payment owner | Payment row lookup |
+| `GET /api/v1/admin/subscription-plans` | **`x-admin-secret`** | List all plan rows |
+| `POST /api/v1/admin/subscription-plans` | **`x-admin-secret`** | Upsert plan rows |
 
 ## Operational checklist
 
-1. Update **`SUBSCRIPTION_PLAN_PRICES`** when list prices change.
-2. Configure **coupons** in admin; scope with `applicableProducts` (use sheet/course ids or plan keys like `3months` for subscriptions).
-3. Keep **Cashfree** credentials and webhook secret only on the server.
-4. **Return URL** for hosted flows is `PLATFORM_URL/payment/status?order_id=…` (see `buildOrderPayload` in API utils).
+1. **Production / staging:** upsert **`SubscriptionPlan`** via admin API or infra automation (never commit real amounts to git).
+2. **Local dev:** copy `apps/api/scripts/subscription-plans.example.json` → `subscription-plans.local.json` (gitignored), set amounts, run API, then `pnpm seed:subscription-plans` with `ADMIN_SECRET` set.
+3. Configure **coupons** in admin; scope with `applicableProducts` (sheet/course ids or plan keys like `3months`).
+4. Keep **Cashfree** credentials and webhook secret only on the server.
+5. **Return URL** for hosted flows is `PLATFORM_URL/payment/status?order_id=…` (see `buildOrderPayload` in API utils).
 
 ## Future hardening (recommended)
 
 - Bind **order-status** and **checkstatus** to authenticated session instead of trusting `userId` query params.
 - Extend **PROJECTS** / **WEBINAR** pricing in DB or catalog when those SKUs go live.
-- Add automated tests around `resolveAuthoritativeOrderAmount` and quote/create-order for each `productType`.
+- Add automated tests around `resolveAuthoritativeOrderAmount`, admin subscription-plans, and quote/create-order for each `productType`.

--- a/packages/components/src/containers/Cards/PaymentCard.tsx
+++ b/packages/components/src/containers/Cards/PaymentCard.tsx
@@ -40,11 +40,9 @@ const PaymentCard = ({ course, onClose, productType }: PaymentCardProps) => {
           userId: user?.id,
           productId: course._id,
           productType,
-          amount: course.price,
           customerName: user?.name,
           customerEmail: user?.email,
           ...((course as any).appliedCoupon && {
-            appliedCoupon: (course as any).appliedCoupon._id,
             couponCode: (course as any).appliedCoupon.code,
           }),
         }),

--- a/packages/components/src/containers/Page/PrepYatra/PricingPage.tsx
+++ b/packages/components/src/containers/Page/PrepYatra/PricingPage.tsx
@@ -91,6 +91,24 @@ const PricingPage: React.FC = () => {
       ],
     },
     {
+      id: "12months",
+      name: "1 Year Access",
+      price: 1799,
+      duration: "12 months",
+      description: "A full year for deep preparation and revision",
+      buttonText: "Start 1-Year Plan",
+      features: [
+        "✅ Everything in 6-Month Plan",
+        "✅ Long-term roadmap and spaced revision",
+        "✅ Extended mocks and deep dives",
+        "✅ Priority support",
+      ],
+      comingSoon: [
+        "🔄 Auto Cold Email Generation",
+        "🔄 LinkedIn Progress Auto-posting",
+      ],
+    },
+    {
       id: "lifetime",
       name: "Lifetime Access",
       price: 1999,

--- a/packages/constants/src/productConfigs.ts
+++ b/packages/constants/src/productConfigs.ts
@@ -147,6 +147,80 @@ export const PRODUCT_CONFIGS: Partial<
       buttonText: "Pay Now to Unlock",
     },
   },
+  DSA_YATRA: {
+    name: "DSA Yatra",
+    icon: CodeBracketIcon,
+    reasonsToBuy: [
+      {
+        icon: CodeBracketIcon,
+        title: "Structured DSA Path",
+        description: "Practice patterns and problems curated for interviews",
+      },
+      {
+        icon: StarIcon,
+        title: "Lifetime Access",
+        description: "One-time purchase with long-term access to DSA resources",
+      },
+      {
+        icon: ShieldCheckIcon,
+        title: "Secure Checkout",
+        description: "Payments processed safely via Cashfree",
+      },
+      {
+        icon: ClockIcon,
+        title: "Learn at Your Pace",
+        description: "Return anytime to continue your preparation",
+      },
+    ],
+    defaultFeatures: [
+      "DSA question bank",
+      "Topic-wise practice",
+      "Lifetime access",
+    ],
+    lockedMessage: {
+      title: "Unlock DSA Yatra",
+      description:
+        "Complete payment to unlock full DSA Yatra access for your account.",
+      buttonText: "Pay Now",
+    },
+  },
+  ONCAMPUS: {
+    name: "On Campus",
+    icon: UserGroupIcon,
+    reasonsToBuy: [
+      {
+        icon: UserGroupIcon,
+        title: "Campus Placement Focus",
+        description: "Aptitude, core CS, and interview prep in one place",
+      },
+      {
+        icon: ClockIcon,
+        title: "Flexible Duration",
+        description: "Choose 1, 3, 6, or 12 month plans",
+      },
+      {
+        icon: ShieldCheckIcon,
+        title: "Coupons",
+        description: "Apply campus-specific coupons at checkout",
+      },
+      {
+        icon: StarIcon,
+        title: "Support",
+        description: "Get help when you are stuck",
+      },
+    ],
+    defaultFeatures: [
+      "Placement preparation",
+      "Aptitude and interviews",
+      "Duration-based access",
+    ],
+    lockedMessage: {
+      title: "Subscribe to On Campus",
+      description:
+        "Choose a plan and complete payment to unlock On Campus content.",
+      buttonText: "Subscribe",
+    },
+  },
   PREPYATRA: {
     name: "PrepYatra Subscription",
     icon: StarIcon,

--- a/packages/constants/src/routes.ts
+++ b/packages/constants/src/routes.ts
@@ -126,6 +126,9 @@ const routes = {
     aptitude: "/dashboard/aptitude",
   },
   unskilled: "/unskilled",
+  /** Shareable, minimal payment entry (query: productType, productId, optional coupon, next) */
+  checkout: "/checkout",
+  paymentStatus: "/payment/status",
   404: "/404",
   api: {
     base: "",
@@ -156,6 +159,8 @@ const routes = {
     submitUserFeedback: "/feedback",
     createOrder: "/payment/create-order",
     checkStatus: "/payment/checkstatus",
+    paymentQuote: "/payment/quote",
+    paymentOrderStatus: "/payment/order-status",
     validateCoupon: "/coupon/validate",
     courseById: (course: string) => `/shiksha/${course}`,
     courseByIdWithUser: (course: string, userId?: string) => {
@@ -219,4 +224,21 @@ const generateSectionPath = ({
   sectionID,
 }: GenerateSectionPathProps) => `${basePath}#${sectionID}`;
 
-export { generateSectionPath, routes };
+/** Build a shareable checkout URL for any supported product line. */
+const buildCheckoutUrl = (params: {
+  productType: string;
+  productId: string;
+  coupon?: string;
+  /** Relative path after successful payment (optional) */
+  next?: string;
+}): string => {
+  const qs = new URLSearchParams({
+    productType: params.productType,
+    productId: params.productId,
+  });
+  if (params.coupon) qs.set("coupon", params.coupon);
+  if (params.next) qs.set("next", params.next);
+  return `${routes.checkout}?${qs.toString()}`;
+};
+
+export { buildCheckoutUrl, generateSectionPath, routes };


### PR DESCRIPTION
## What does this PR do?

Adds payment guardrails for TBE products: **server-resolved order amounts** (no trusted client price), a **subscription price catalog** for PrepYatra / DSA Yatra / On Campus, **quote** and **order-status** API routes, a **minimal Platform checkout** (`/checkout`) and **payment status** page, plus **`docs/payment.md`**. Extends `planTypeMap` with a **12-month** SKU and aligns PrepYatra pricing UI.

## Why?

We need a single, shareable checkout flow, consistent Cashfree integration, and clear security posture (authoritative pricing + coupon validation on the API).

---

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔌 API change (new or modified endpoints, request/response shape changes)
- [x] 📝 Documentation only

---

## Screenshots / Recordings

_N/A — draft PR; add checkout/status screenshots before merge if desired._

---

## Testing

### Does this PR include tests?

- [x] Yes — unit tests
- [ ] Yes — integration / e2e tests
- [ ] No — here's why:

### How to test manually

1. `pnpm install` then run API + Platform locally with valid `NEXT_PUBLIC_API_URL` and Cashfree sandbox credentials.
2. Open `/checkout?productType=ONCAMPUS&productId=3months` (or a real sheet/course id for `INTERVIEW_SHEET` / `SHIKSHA`), sign in, confirm quote loads and pay flow completes.
3. Verify `POST /payment/create-order` no longer requires client `amount`; optional `couponCode` still resolves via server.

---

## Checklist

- [ ] I've tested this locally and it works as expected
- [ ] I've checked for console errors / warnings
- [x] No unrelated changes snuck in
- [ ] If UI change — tested on mobile viewport too
- [x] If API change — backward compatible or migration plan noted above (`create-order` no longer accepts client `amount`; clients should rely on quote + server resolution)
