### PR TITLE
unify prep/DSA progress API and remove legacy stats route

### DIFF
--- a/The Boring Education.postman_collection.json
+++ b/The Boring Education.postman_collection.json
@@ -7667,9 +7667,9 @@
                 "method": "GET",
                 "header": [],
                 "url": {
-                  "raw": "{{HOST}}/prepyatra/prep-log/stats?userId=686e9213c3eb7c364597d872",
+                  "raw": "{{HOST}}/user/prepyatra/progress?userId=686e9213c3eb7c364597d872",
                   "host": ["{{HOST}}"],
-                  "path": ["prepyatra", "prep-log", "stats"],
+                  "path": ["user", "prepyatra", "progress"],
                   "query": [
                     {
                       "key": "userId",

--- a/apps/api/src/pages/api/v1/user/prepyatra/progress.ts
+++ b/apps/api/src/pages/api/v1/user/prepyatra/progress.ts
@@ -8,7 +8,7 @@ import { withApiHandler } from "@/middleware/requestLogger";
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   switch (req.method) {
     case "GET":
-      return handleGetPrepLogStats(req, res);
+      return handleGetProgress(req, res);
     default:
       return res.status(apiStatusCodes.METHOD_NOT_ALLOWED).json(
         sendAPIResponse({
@@ -19,10 +19,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-const handleGetPrepLogStats = async (
-  req: NextApiRequest,
-  res: NextApiResponse,
-) => {
+const handleGetProgress = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     const { userId } = req.query;
 
@@ -38,12 +35,19 @@ const handleGetPrepLogStats = async (
     const { data, error } = await getUserPrepLogStats(userId);
 
     if (error) {
-      return res.status(apiStatusCodes.BAD_REQUEST).json(
-        sendAPIResponse({
-          status: false,
-          message: error,
-        }),
-      );
+      const isUserNotFound = error === "User not found";
+      return res
+        .status(
+          isUserNotFound
+            ? apiStatusCodes.NOT_FOUND
+            : apiStatusCodes.INTERNAL_SERVER_ERROR,
+        )
+        .json(
+          sendAPIResponse({
+            status: false,
+            message: error,
+          }),
+        );
     }
 
     return res.status(apiStatusCodes.OKAY).json(
@@ -56,7 +60,7 @@ const handleGetPrepLogStats = async (
     return res.status(apiStatusCodes.INTERNAL_SERVER_ERROR).json(
       sendAPIResponse({
         status: false,
-        message: "Something went wrong while fetching prep log stats",
+        message: "Something went wrong while fetching prep progress",
         error,
       }),
     );

--- a/apps/testing/src/e2e/fixtures/authenticated-dashboard-smoke.ts
+++ b/apps/testing/src/e2e/fixtures/authenticated-dashboard-smoke.ts
@@ -43,7 +43,7 @@ export async function mockDsayatraDashboardApis(page: Page): Promise<void> {
     });
   });
 
-  await page.route("**/prepyatra/prep-log/stats**", (route) => {
+  await page.route("**/api/proxy/user/prepyatra/progress**", (route) => {
     if (route.request().method() !== "GET") {
       return route.continue();
     }

--- a/packages/services/src/prep-stats.ts
+++ b/packages/services/src/prep-stats.ts
@@ -26,7 +26,7 @@ export const prepStatsService = {
   async getByUserId(userId: string): Promise<PrepStats> {
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/prepyatra/prep-log/stats?userId=${userId}`,
+        `${process.env.NEXT_PUBLIC_API_URL}/user/prepyatra/progress?userId=${userId}`,
         {
           headers: {
             "Content-Type": "application/json",


### PR DESCRIPTION
## What does this PR do?

Unifies progress endpoints across DSA Yatra and Prep Yatra by using `/user/{product}/progress`, and removes the legacy PrepYatra `/prepyatra/prep-log/stats` route.

## Why?

We had inconsistent naming (`/progress` vs `/stats`) for similar user progress data. This standardizes API usage, simplifies frontend integration, and avoids confusion.

---

## Type of Change

- [x] 🔧 Refactor / cleanup (no functional change)
- [x] 🔌 API change (new or modified endpoints, request/response shape changes)
- [x] 📝 Documentation only

---

## Screenshots / Recordings
<img width="885" height="718" alt="{AE40BED1-1AD3-47F3-B275-E68F989445F3}" src="https://github.com/user-attachments/assets/b5f9d505-b2a6-4622-8e34-a1ad31c0d7c9" />

<img width="997" height="718" alt="{4B108206-D88F-4081-A6B7-8AD3822D145D}" src="https://github.com/user-attachments/assets/3fe59c8f-baca-4d92-9f72-30e76e8e459d" />



N/A (API and routing updates only)

---

## Testing

### Does this PR include tests?

- [ ] Yes — unit tests
- [x] Yes — integration / e2e tests
- [ ] No — here's why:

### How to test manually

1. Run API app and open:
   - `GET /api/v1/user/dsayatra/progress?userId=<userId>`
   - `GET /api/v1/user/prepyatra/progress?userId=<userId>`
2. Verify both return `200` with `status: true` and expected data.
3. Verify old route fails:
   - `GET /api/v1/prepyatra/prep-log/stats?userId=<userId>` (should be 404).

---

## Checklist

- [x] I've tested this locally and it works as expected
- [x] I've checked for console errors / warnings
- [x] No unrelated changes snuck in
- [ ] If UI change — tested on mobile viewport too
