### PR TITLE
feat(dsayatra): align sheets routing with oncampus

### DIFF
--- a/apps/dsayatra/src/pages/sheets.tsx
+++ b/apps/dsayatra/src/pages/sheets.tsx
@@ -10,6 +10,7 @@ import { DSA_STUDY_GUIDE_CONFIGS, routes, TOPIC_LABELS } from "@tbe/constants";
 import { useGamification, useGamifiedAction } from "@tbe/gamification";
 import {
   useDsaCompletedQuestions,
+  useDsaPrepUrlSync,
   useDsaQuestionsForTopic,
   useDsaTopics,
   useDsaTopicSummaries,
@@ -144,11 +145,18 @@ const SheetsPageClient = () => {
   const sheetsLoading =
     topicsLoading || (!!selectedTopic && topicQuestionsLoading);
 
-  useEffect(() => {
-    if (router.isReady && router.query.topic) {
-      setSelectedTopic(router.query.topic as string);
-    }
-  }, [router.isReady, router.query.topic]);
+  const {
+    handleTopicClick,
+    handleQuestionClick: handleUrlSyncQuestionClick,
+    handleBackToTopics,
+  } = useDsaPrepUrlSync({
+    router,
+    selectedTopic,
+    setSelectedTopic,
+    setSelectedQuestion,
+    topicQuestions: questions,
+    topicQuestionsLoading: !!selectedTopic && topicQuestionsLoading,
+  });
 
   useEffect(() => {
     if (!userLoading && !isAuth) {
@@ -161,20 +169,8 @@ const SheetsPageClient = () => {
       setShowPayment(true);
       return;
     }
-    setSelectedQuestion(question);
     setShowPayment(false);
-  };
-
-  const handleTopicClick = (topic: string) => {
-    setSelectedTopic(topic);
-    setSelectedQuestion(null);
-    setShowPayment(false);
-  };
-
-  const handleBackToTopics = () => {
-    setSelectedTopic(null);
-    setSelectedQuestion(null);
-    setShowPayment(false);
+    handleUrlSyncQuestionClick(question);
   };
 
   if (sheetsLoading || userLoading || isProgressLoading) {


### PR DESCRIPTION
## What does this PR do?

Aligns the `dsayatra` sheets page routing with the `oncampus` implementation. By integrating the `useDsaPrepUrlSync` hook, it ensures that both `topic` and `question` query parameters are synchronized with the application state. This enables robust deep linking and ensures that URL slugs are generated correctly for sharing.

## Why?

Previously, `dsayatra` relied on manual state-to-URL synchronization which was incomplete. This led to issues where "Copy Link" or deep links would use incorrect slugs or fail to navigate to the specific question. Aligning it with the proven `oncampus` logic solves these inconsistencies.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🔧 Refactor / cleanup (no functional change)
- [ ] 🎨 UI / styling change
- [ ] 🔌 API change (new or modified endpoints, request/response shape changes)
- [ ] 📦 Dependency update
- [ ] 📝 Documentation only

---

## Screenshots / Recordings
## Before 
<img width="1055" height="604" alt="{78F98403-C2FC-4A0D-8E49-D8585D2CB1BB}" src="https://github.com/user-attachments/assets/2f47ba9c-188f-47a8-997f-6bd78d3d0963" />
<br/>
## After
<img width="1229" height="557" alt="{34B8F9FB-0D8A-4470-8C50-48C4B2B63DD7}" src="https://github.com/user-attachments/assets/0d6889ca-29bd-45f4-aa16-4ecae9959cfd" />


---

## Testing

### Does this PR include tests?

- [ ] Yes — unit tests
- [ ] Yes — integration / e2e tests
- [x] No — here's why: Manual verification of routing synchronization and back/forward navigation is sufficient for this logic change.

### How to test manually

1. Navigate to the `dsayatra` sheets page (`/sheets`).
2. Select a topic and verify the URL updates to `?topic=<slug>`.
3. Select a specific question and verify the URL updates to include `&question=<slug>`.
4. Refresh the browser on a question URL and verify the page hydrates correctly to that specific question.
5. Use the browser's back and forward buttons to ensure the workspace state stays in sync with the URL.

---

## Checklist

- [x] I've tested this locally and it works as expected
- [x] I've checked for console errors / warnings
- [x] No unrelated changes snuck in
- [x] If UI change — tested on mobile viewport too
- [x] If API change — backward compatible or migration plan noted above