### PR TITLE
fix: ensure all questions are visible across all assigned topics

### DIFF
--- a/apps/api/src/lib/database/queries/dsaSheet.ts
+++ b/apps/api/src/lib/database/queries/dsaSheet.ts
@@ -143,17 +143,9 @@ export const buildDsaMatchStage = (
     match.isRealWorldProblem = { $ne: true };
   }
 
-  if (userId && targetCompanies.length > 0) {
-    if (match.companyTypes) {
-      const currentIn: string[] = match.companyTypes.$in || [];
-      const intersection = currentIn.filter((t) => targetCompanies.includes(t));
-      match.companyTypes = {
-        $in: intersection.length > 0 ? intersection : targetCompanies,
-      };
-    } else {
-      match.companyTypes = { $in: targetCompanies };
-    }
-  }
+  // We still allow manual companyTypes filtering via the filters object (handled above),
+  // but we no longer restrict the overall result set to only targetCompanies.
+  // The targetCompanies array is still used to calculate _priorityScore for sorting.
 
   return match;
 };

--- a/apps/api/src/lib/database/queries/interview-prep.ts
+++ b/apps/api/src/lib/database/queries/interview-prep.ts
@@ -764,20 +764,17 @@ const getDSATopicSummariesFromDB = async (
   try {
     const matchStages: PipelineStage[] = [];
 
-    if (userId) {
-      const targetCompanies = await getUserDSATargetCompanies(userId);
-      if (targetCompanies.length > 0) {
-        matchStages.push({
-          $match: { companyTypes: { $in: targetCompanies } },
-        });
-      }
-    }
+    // targetCompanies is no longer used to filter topics. We want to show all topics
+    // and questions regardless of user preferences.
 
     const countPipeline: PipelineStage[] = [
       ...matchStages,
       {
+        $unwind: "$topics",
+      },
+      {
         $addFields: {
-          primaryTopic: { $toUpper: { $arrayElemAt: ["$topics", 0] } },
+          primaryTopic: { $toUpper: "$topics" },
         },
       },
       {

--- a/packages/components/src/containers/Cards/DsaPrepWorkspace.tsx
+++ b/packages/components/src/containers/Cards/DsaPrepWorkspace.tsx
@@ -77,7 +77,7 @@ const DsaPrepWorkspace = ({
     useState("before-you-start");
 
   const filteredQuestions = selectedTopic
-    ? questions.filter((q) => q.topics?.[0] === selectedTopic)
+    ? questions.filter((q) => q.topics?.includes(selectedTopic))
     : [];
 
   const lockedItemKeys = freemiumLockedQuestionIds

--- a/packages/hooks/src/useDsaQuestionsForTopic.ts
+++ b/packages/hooks/src/useDsaQuestionsForTopic.ts
@@ -53,7 +53,7 @@ export const useDsaQuestionsForTopic = (
     }),
     queryFn: async () => {
       const result = await sendRequest({
-        url: `${routes.api.base}${routes.api.dsaSheet}?topic=${encodeURIComponent(topic!)}${userId ? `&userId=${userId}` : ""}&productType=${productType}${realWorld ? `&realWorld=${realWorld}` : ""}`,
+        url: `${routes.api.base}${routes.api.dsaSheet}?topic=${encodeURIComponent(topic!)}${userId ? `&userId=${userId}` : ""}&productType=${productType}${realWorld ? `&realWorld=${realWorld}` : ""}&limit=1000`,
         method: "GET",
       });
 


### PR DESCRIPTION
fix: ensure all questions are visible across all assigned topics

- Update DsaPrepWorkspace to filter questions using .includes() instead of just the primary topic
- Update topic summary aggregation to $unwind topics for accurate multi-topic counts
- Remove automatic target companies filtering to prevent silent exclusion of questions
- Ensure limit=1000 in frontend query to prevent truncation
