### PR TITLE
fix: resume evaluation not working (#992)

### DIFF
--- a/apps/api/src/lib/database/queries/unskilled.ts
+++ b/apps/api/src/lib/database/queries/unskilled.ts
@@ -298,7 +298,7 @@ const getResumeEvaluationResultsFromDB = async ({
         );
         return {
           skill,
-          frequency: count,
+          jobCount: count,
           percentage,
         };
       });
@@ -386,8 +386,8 @@ const getResumeEvaluationResultsFromDB = async ({
     );
 
     const companyTypeDistribution = companyTypesAgg.map((type) => ({
-      name: type.name,
-      count: type.count,
+      type: type.name,
+      jobCount: type.count,
       percentage: constrainNumberToRange(
         Math.round((type.count / totalCompanies) * 100),
         0,
@@ -396,10 +396,12 @@ const getResumeEvaluationResultsFromDB = async ({
     }));
 
     const response = {
-      matchedSkills,
+      matchingSkills: matchedSkills,
       missingSkills,
+      skillsMatched: matchedSkills.length,
+      skillsMissing: missingSkills.length,
       resumeScore,
-      totalJobsAnalyzed: totalJobs,
+      jobsAnalyzed: totalJobs,
       companyTypeDistribution,
       remoteJobs: remoteJobCount,
     };

--- a/apps/testing/src/unit/services/resumeService.test.ts
+++ b/apps/testing/src/unit/services/resumeService.test.ts
@@ -4,16 +4,26 @@ vi.mock("@tbe/constants", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tbe/constants")>();
   return {
     ...actual,
-    envConfig: {
-      ...actual.envConfig,
-      UNSKILLED_API_URL: "https://unskilled.test.com",
-    },
+    JOB_EXPERIENCE_LEVEL: [
+      { label: "Fresher (0 yrs)", value: "Fresher (0 yrs)", min: 0, max: 1 },
+      {
+        label: "Mid-Level (2-4 yrs)",
+        value: "Mid-Level (2-4 yrs)",
+        min: 2,
+        max: 4,
+      },
+    ],
   };
 });
 
 global.fetch = vi.fn();
 
+// Stub the env var used by the service
+process.env.NEXT_PUBLIC_API_URL = "https://api.test.com/api/v1";
+
 import { resumeEvaluationService } from "@tbe/services";
+
+const BASE = "https://api.test.com/api/v1";
 
 describe("resumeEvaluationService", () => {
   beforeEach(() => {
@@ -26,10 +36,41 @@ describe("resumeEvaluationService", () => {
   });
 
   describe("evaluateResume", () => {
-    it("returns evaluation on success", async () => {
+    const payload = {
+      resumeSkills: ["react", "typescript"],
+      domains: ["Frontend"],
+      experienceLevel: "Mid-Level (2-4 yrs)",
+    };
+
+    it("calls the correct URL with mapped request body", async () => {
+      const mockResponse = { status: true, message: "ok", data: {} };
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => mockResponse,
+      });
+
+      await resumeEvaluationService.evaluateResume(payload);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${BASE}/unskilled/evaluation`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            skills: ["react", "typescript"],
+            domains: ["Frontend"],
+            experience: { min: 2, max: 4 },
+          }),
+        },
+      );
+    });
+
+    it("returns the parsed response on success", async () => {
       const mockResponse = {
-        score: 85,
-        feedback: ["Good experience"],
+        status: true,
+        message: "ok",
+        data: { resumeScore: 80 },
       };
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
         ok: true,
@@ -37,23 +78,26 @@ describe("resumeEvaluationService", () => {
         json: async () => mockResponse,
       });
 
-      const result = await resumeEvaluationService.evaluateResume({
-        resume: "resume text",
-        jobDescription: "job desc",
+      const result = await resumeEvaluationService.evaluateResume(payload);
+      expect(result).toEqual(mockResponse);
+    });
+
+    it("falls back to { min:0, max:100 } for unknown experience level", async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({}),
       });
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        "https://unskilled.test.com/resume/evaluate",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            resume: "resume text",
-            jobDescription: "job desc",
-          }),
-        },
+      await resumeEvaluationService.evaluateResume({
+        ...payload,
+        experienceLevel: "Unknown Level",
+      });
+
+      const body = JSON.parse(
+        (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body,
       );
-      expect(result).toEqual(mockResponse);
+      expect(body.experience).toEqual({ min: 0, max: 100 });
     });
 
     it("throws on non-JSON content-type with truncated message", async () => {
@@ -66,30 +110,24 @@ describe("resumeEvaluationService", () => {
       });
 
       await expect(
-        resumeEvaluationService.evaluateResume({
-          resume: "resume",
-          jobDescription: "job",
-        }),
+        resumeEvaluationService.evaluateResume(payload),
       ).rejects.toThrow(`Server returned 500: ${longText.substring(0, 200)}`);
     });
 
-    it("throws on HTTP error with detail", async () => {
+    it("throws on HTTP error using message field", async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
         ok: false,
         status: 400,
         headers: new Headers({ "content-type": "application/json" }),
-        json: async () => ({ detail: "Invalid resume format" }),
+        json: async () => ({ message: "Invalid resume format" }),
       });
 
       await expect(
-        resumeEvaluationService.evaluateResume({
-          resume: "resume",
-          jobDescription: "job",
-        }),
+        resumeEvaluationService.evaluateResume(payload),
       ).rejects.toThrow("Invalid resume format");
     });
 
-    it("throws on HTTP error without detail", async () => {
+    it("throws default message on HTTP error without message field", async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
         ok: false,
         status: 500,
@@ -98,10 +136,7 @@ describe("resumeEvaluationService", () => {
       });
 
       await expect(
-        resumeEvaluationService.evaluateResume({
-          resume: "resume",
-          jobDescription: "job",
-        }),
+        resumeEvaluationService.evaluateResume(payload),
       ).rejects.toThrow("Failed to evaluate resume");
     });
 
@@ -111,21 +146,14 @@ describe("resumeEvaluationService", () => {
       );
 
       await expect(
-        resumeEvaluationService.evaluateResume({
-          resume: "resume",
-          jobDescription: "job",
-        }),
+        resumeEvaluationService.evaluateResume(payload),
       ).rejects.toThrow("Network error");
     });
   });
 
   describe("checkHealth", () => {
-    it("returns health on success", async () => {
-      const mockHealth = {
-        status: true,
-        message: "OK",
-        jobsAvailable: 5,
-      };
+    it("calls the correct health URL and returns response", async () => {
+      const mockHealth = { status: true, message: "OK", jobsAvailable: 5 };
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
         ok: true,
         json: async () => mockHealth,
@@ -134,7 +162,7 @@ describe("resumeEvaluationService", () => {
       const result = await resumeEvaluationService.checkHealth();
 
       expect(global.fetch).toHaveBeenCalledWith(
-        "https://unskilled.test.com/evaluate/health",
+        `${BASE}/unskilled/evaluation/health`,
       );
       expect(result).toEqual(mockHealth);
     });

--- a/packages/services/src/resumeService.ts
+++ b/packages/services/src/resumeService.ts
@@ -1,41 +1,47 @@
 /**
  * Resume Evaluation Service
- * Handles API calls to Unskilled backend for resume evaluation
- * Follows same pattern as graph API calls
+ * Handles API calls to the local API backend for resume evaluation
  */
 
-import { envConfig } from "@tbe/constants";
+import { JOB_EXPERIENCE_LEVEL } from "@tbe/constants";
 import type {
   ResumeEvaluationRequest,
   ResumeEvaluationResponse,
 } from "@tbe/types";
 
+const getExperienceRange = (
+  experienceLevel: string,
+): { min: number; max: number } => {
+  const found = JOB_EXPERIENCE_LEVEL.find((e) => e.value === experienceLevel);
+  return found ? { min: found.min, max: found.max } : { min: 0, max: 100 };
+};
+
 /**
- * Evaluate resume against job market
- * Calls Unskilled backend directly (like graph API)
+ * Evaluate resume against job market via the local API
  */
 export const evaluateResume = async (
   payload: ResumeEvaluationRequest,
 ): Promise<ResumeEvaluationResponse> => {
   try {
-    const apiUrl = `${envConfig.UNSKILLED_API_URL}/resume/evaluate`;
+    const apiUrl = `${process.env.NEXT_PUBLIC_API_URL}/unskilled/evaluation`;
+
+    const requestBody = {
+      skills: payload.resumeSkills,
+      domains: payload.domains,
+      experience: getExperienceRange(payload.experienceLevel),
+    };
 
     const response = await fetch(apiUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(requestBody),
     });
 
-    console.log("Response status:", response.status);
-    console.log("Response headers:", response.headers);
-
-    // Check content type before parsing
     const contentType = response.headers.get("content-type");
     if (!contentType || !contentType.includes("application/json")) {
       const textResponse = await response.text();
-      console.error("Non-JSON response:", textResponse);
       throw new Error(
         `Server returned ${response.status}: ${textResponse.substring(0, 200)}`,
       );
@@ -43,7 +49,7 @@ export const evaluateResume = async (
 
     if (!response.ok) {
       const errorData = await response.json();
-      throw new Error(errorData.detail || "Failed to evaluate resume");
+      throw new Error(errorData.message || "Failed to evaluate resume");
     }
 
     const result: ResumeEvaluationResponse = await response.json();
@@ -64,7 +70,7 @@ export const checkResumeServiceHealth = async (): Promise<{
 }> => {
   try {
     const response = await fetch(
-      `${envConfig.UNSKILLED_API_URL}/evaluate/health`,
+      `${process.env.NEXT_PUBLIC_API_URL}/unskilled/evaluation/health`,
     );
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

Fixes #992 — resume evaluation was completely broken due to three layered bugs.

### Root Causes

**1. Service was calling the wrong / unconfigured external URL**
`resumeService.ts` pointed to `UNSKILLED_API_URL/resume/evaluate` (an external backend that is often not configured), instead of the project's own local API. Changed to call `NEXT_PUBLIC_API_URL/unskilled/evaluation`.

**2. Request field name mismatch**
The service sent `{ resumeSkills, domains, experienceLevel }` but the local API expected `{ skills, domains, experience: { min, max } }`. Fixed by:
- Renaming `resumeSkills` → `skills`
- Converting the `experienceLevel` string (e.g. `"Mid-Level (2-4 yrs)"`) to a `{ min, max }` object using the existing `JOB_EXPERIENCE_LEVEL` constant

**3. Response field name mismatches (DB → Types → Frontend)**
`getResumeEvaluationResultsFromDB` was returning field names that didn't match the `ResumeEvaluationData` type or what the frontend rendered:

| Was | Now |
|---|---|
| `matchedSkills` | `matchingSkills` |
| `totalJobsAnalyzed` | `jobsAnalyzed` |
| skill.`frequency` | skill.`jobCount` |
| company.`name` | company.`type` |
| company.`count` | company.`jobCount` |
| *(missing)* | `skillsMatched: number` |
| *(missing)* | `skillsMissing: number` |

## Files Changed
- `packages/services/src/resumeService.ts` — fix URL + request mapping
- `apps/api/src/lib/database/queries/unskilled.ts` — fix response field names

## Test plan
- [ ] Upload a PDF/DOCX resume
- [ ] Select 1–2 domains and an experience level
- [ ] Click "Start Evaluation" — results card should appear with score, matched/missing skills, and company type breakdown
- [ ] Verify no console errors

---
Hey @Anoop0-0 — thanks again for reporting this! The fix is ready for review. Could you please check this PR and let us know if it resolves the issue on your end? 🙏

https://claude.ai/code/session_01FPwHCen3TMjkUGiBUUCM51

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPwHCen3TMjkUGiBUUCM51)_