### PR TITLE
Enhance/oncampus quiz

### DIFF
--- a/apps/oncampus/src/pages/quiz/[id]/index.tsx
+++ b/apps/oncampus/src/pages/quiz/[id]/index.tsx
@@ -6,7 +6,8 @@ import { queryKeys, useQueryClient } from "@tbe/query";
 import { gamificationApi, quizApi } from "@tbe/services";
 import type { QuizQuestion, QuizQuestionsData } from "@tbe/types";
 import { cleanOptionText, cn, sendRequest } from "@tbe/utils";
-import { ArrowLeft, CheckCircle2 } from "lucide-react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ArrowLeft, Brain, Zap } from "lucide-react";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -65,19 +66,23 @@ export default function QuizPage() {
 
   const [quiz, setQuiz] = useState<QuizQuestionsData | null>(null);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
+
+  // Per-question: which option index was chosen
   const [selectedAnswers, setSelectedAnswers] = useState<
     Record<number, number>
   >({});
-  const [questionStartTime, setQuestionStartTime] = useState(Date.now());
+  // Per-question: time taken
   const [questionTimes, setQuestionTimes] = useState<Record<number, number>>(
     {},
   );
+  const [questionStartTime, setQuestionStartTime] = useState(Date.now());
+
   const [gameState, setGameState] = useState<GameState>("loading");
   const [quizStartTime] = useState(Date.now());
   const hasSubmittedRef = useRef(false);
   const mongoUserIdRef = useRef<string | null>(null);
 
-  // Auth guard (non-dashboard route)
+  // Auth guard
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
       router.push("/login");
@@ -126,97 +131,121 @@ export default function QuizPage() {
   const questions = useMemo(() => quiz?.questions || [], [quiz?.questions]);
   const currentQuestion: QuizQuestion | undefined =
     questions[currentQuestionIndex];
-  const progress =
-    questions.length > 0
-      ? ((currentQuestionIndex + 1) / questions.length) * 100
-      : 0;
+  const total = questions.length;
+  const progress = total > 0 ? ((currentQuestionIndex + 1) / total) * 100 : 0;
 
-  const submitQuiz = useCallback(async () => {
-    if (!quizId || !quiz || hasSubmittedRef.current) return;
-    hasSubmittedRef.current = true;
-    setGameState("submitting");
+  const submitQuiz = useCallback(
+    async (currentSelectedAnswers = selectedAnswers) => {
+      if (!quizId || !quiz || hasSubmittedRef.current) return;
+      hasSubmittedRef.current = true;
+      setGameState("submitting");
 
-    const mongoUserId =
-      mongoUserIdRef.current ?? (await resolveUserIdToMongoId(user));
-    if (mongoUserId) mongoUserIdRef.current = mongoUserId;
+      const mongoUserId =
+        mongoUserIdRef.current ?? (await resolveUserIdToMongoId(user));
+      if (mongoUserId) mongoUserIdRef.current = mongoUserId;
 
-    const totalTimeSpent = Math.floor((Date.now() - quizStartTime) / 1000);
-    const answersPayload = questions.map((q, index) => {
-      const selectedAnswer = selectedAnswers[index] ?? -1;
-      const isCorrect = selectedAnswer === q.correctAnswer;
-      const timeSpent = questionTimes[index] || 0;
-      return { questionIndex: index, selectedAnswer, isCorrect, timeSpent };
-    });
+      const totalTimeSpent = Math.floor((Date.now() - quizStartTime) / 1000);
+      const answersPayload = questions.map((q, index) => {
+        const selAns = currentSelectedAnswers[index] ?? -1;
+        const correctIdx = (q as any).correctAnswer ?? (q as any).correct ?? -1;
+        const isCorrect = selAns === correctIdx;
+        const timeSpent = questionTimes[index] || 0;
+        return {
+          questionIndex: index,
+          selectedAnswer: selAns,
+          isCorrect,
+          timeSpent,
+        };
+      });
 
-    try {
-      if (mongoUserId) {
-        await quizApi.submitQuiz(quizId, {
-          userId: mongoUserId,
-          answers: answersPayload,
-          totalTimeSpent,
-        });
-
-        // gamification: best-effort
-        gamificationApi
-          .updateuserGamificationPoints({
+      try {
+        if (mongoUserId) {
+          await quizApi.submitQuiz(quizId, {
             userId: mongoUserId,
-            actionType: "COMPLETE_QUIZ",
-          } as any)
-          .then(() => {
-            void queryClient.invalidateQueries({
-              queryKey: queryKeys.gamification.points(mongoUserId),
-            });
-          })
-          .catch(() => {});
-      }
-    } catch {
-      // ignore submit errors, still show local results
-    } finally {
-      const answersParam = encodeURIComponent(
-        JSON.stringify(answersPayload.map((a) => a.selectedAnswer)),
-      );
-      router.replace(
-        `/results/${quizId}?answers=${answersParam}&timeTaken=${totalTimeSpent}`,
-      );
-    }
-  }, [
-    quizId,
-    quiz,
-    user,
-    quizStartTime,
-    questions,
-    selectedAnswers,
-    questionTimes,
-    router,
-    queryClient,
-  ]);
+            answers: answersPayload,
+            totalTimeSpent,
+          });
 
-  const selectAnswer = (answerIndex: number) => {
-    if (!quiz || !currentQuestion) return;
-    if (gameState !== "playing") return;
+          gamificationApi
+            .updateuserGamificationPoints({
+              userId: mongoUserId,
+              actionType: "COMPLETE_QUIZ",
+            } as any)
+            .then(() => {
+              void queryClient.invalidateQueries({
+                queryKey: queryKeys.gamification.points(mongoUserId),
+              });
+            })
+            .catch(() => {});
+        }
+      } catch {
+        // ignore submit errors
+      } finally {
+        const answersParam = encodeURIComponent(
+          JSON.stringify(answersPayload.map((a) => a.selectedAnswer)),
+        );
+        router.replace(
+          `/results/${quizId}?answers=${answersParam}&timeTaken=${totalTimeSpent}`,
+        );
+      }
+    },
+    [
+      quizId,
+      quiz,
+      user,
+      quizStartTime,
+      questions,
+      selectedAnswers,
+      questionTimes,
+      router,
+      queryClient,
+    ],
+  );
+
+  const selectAnswer = (idx: number) => {
+    if (!quiz || !currentQuestion || gameState !== "playing") return;
 
     const timeSpent = Math.floor((Date.now() - questionStartTime) / 1000);
     setQuestionTimes((prev) => ({
       ...prev,
       [currentQuestionIndex]: timeSpent,
     }));
-    setSelectedAnswers((prev) => ({
-      ...prev,
-      [currentQuestionIndex]: answerIndex,
-    }));
 
-    if (currentQuestionIndex < questions.length - 1) {
-      setCurrentQuestionIndex((prev) => prev + 1);
+    const updatedAnswers = { ...selectedAnswers, [currentQuestionIndex]: idx };
+    setSelectedAnswers(updatedAnswers);
+
+    if (currentQuestionIndex < total - 1) {
+      // Small visual transition delay so the user feels the selection click
+      setTimeout(() => {
+        setCurrentQuestionIndex((prev) => prev + 1);
+      }, 180);
     } else {
-      void submitQuiz();
+      setTimeout(() => {
+        void submitQuiz(updatedAnswers);
+      }, 180);
     }
   };
+
+  const handleNext = useCallback(() => {
+    if (currentQuestionIndex + 1 >= total) {
+      void submitQuiz();
+    } else {
+      setCurrentQuestionIndex((c) => c + 1);
+    }
+  }, [currentQuestionIndex, total, submitQuiz]);
+
+  const handlePrev = useCallback(() => {
+    if (currentQuestionIndex === 0) return;
+    setCurrentQuestionIndex((c) => c - 1);
+  }, [currentQuestionIndex]);
+
+  // ── Loading / Submitting screens ──────────────────────────────────────────
 
   if (gameState === "loading") {
     return (
       <OnCampusLearningLayout backHref="/dashboard/quizzes" isLoading>
         <div className="flex-1 flex items-center justify-center">
-          <Text level="p" className="text-gray-400">
+          <Text level="p" className="text-zinc-400">
             Loading quiz...
           </Text>
         </div>
@@ -232,10 +261,10 @@ export default function QuizPage() {
             <div className="flex justify-center mb-6">
               <LoadingSpinner height={10} width={10} />
             </div>
-            <Text level="h1" className="text-white font-bold text-lg">
+            <Text level="h1" className="text-zinc-100 font-bold text-lg">
               Submitting quiz...
             </Text>
-            <Text level="p" className="text-gray-400 text-sm mt-2">
+            <Text level="p" className="text-zinc-500 text-sm mt-2">
               Please wait while we process your results
             </Text>
           </div>
@@ -244,159 +273,132 @@ export default function QuizPage() {
     );
   }
 
+  if (!currentQuestion) return null;
+
   const selectedAnswer = selectedAnswers[currentQuestionIndex];
+
+  // ── Main quiz UI ──────────────────────────────────────────────────────────
 
   return (
     <OnCampusLearningLayout backHref="/dashboard" layoutMode="workspace">
       <div className="flex flex-col h-full w-full">
-        {/* Workspace Header Section — Centered Title Mode */}
-        <div className="w-full min-h-[72px] border-b border-gray-800 bg-[#0A0A0A] flex shrink-0 sticky top-0 z-20">
-          <div className="relative w-full h-full flex items-center px-6">
-            {/* Left Back Navigation */}
-            <div className="flex-1 flex items-center">
-              <button
-                onClick={() => router.push("/dashboard/quizzes")}
-                className="flex items-center justify-center w-[28px] h-[28px] rounded-[6px] border border-red-500/40 bg-red-500/5 text-red-500 hover:bg-red-500/10 hover:border-red-500 transition-all duration-300 shrink-0 shadow-[0_0_10px_rgba(239,68,68,0.1)] active:scale-95"
-                title="Back to Quizzes"
-              >
-                <ArrowLeft className="w-3.5 h-3.5" />
-              </button>
-            </div>
+        {/* ── Scrollable content ── */}
+        <div className="flex-1 w-full max-w-4xl mx-auto px-4 py-4 sm:py-0 overflow-y-auto scrollbar-hide flex flex-col justify-center">
+          <div className="relative">
+            {/* gradient border */}
+            <div className="absolute -inset-px rounded-2xl bg-gradient-to-b from-zinc-700/70 via-zinc-800/30 to-transparent pointer-events-none" />
 
-            {/* Absolute Centered Header Info */}
-            <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col items-center">
-              <Text
-                level="h1"
-                className="text-[13px] font-bold text-white tracking-tight leading-none mb-1"
-              >
-                {quiz?.categoryName || "Quiz"}
-              </Text>
-              <Text
-                level="p"
-                className="text-[8px] font-bold text-gray-500 uppercase tracking-widest leading-none bg-gray-900/50 px-2 py-0.5 rounded border border-gray-800"
-              >
-                Question {currentQuestionIndex + 1} of {questions.length}
-              </Text>
-            </div>
+            <div className="relative flex flex-col rounded-2xl border border-zinc-800 bg-zinc-900 overflow-hidden">
+              {/* Header inside the panel exactly like QuizModal */}
+              <div className="flex items-center justify-between px-4 sm:px-6 pt-3 pb-2 border-b border-zinc-800/60">
+                <div className="flex items-center gap-2.5">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/15 ring-1 ring-primary/30">
+                    <Brain className="h-4 w-4 text-primary" />
+                  </div>
+                  <div>
+                    <span className="text-sm font-semibold text-zinc-100 tracking-tight leading-none block">
+                      {quiz?.categoryName || "Quiz"}
+                    </span>
+                    <span className="text-xs font-medium text-zinc-500 mt-0.5 block">
+                      Showing {total} Questions
+                    </span>
+                  </div>
+                </div>
 
-            {/* Right-aligned Progress Tracker */}
-            <div className="flex-1 flex justify-end items-center gap-6">
-              <div className="flex items-center gap-3">
-                <div className="flex flex-col items-end mr-1">
-                  <Text
-                    level="p"
-                    className="text-[8px] font-bold text-gray-500 uppercase tracking-wider"
+                {/* Back to quizzes button inside header like close button in QuizModal */}
+                <button
+                  onClick={() => router.push("/dashboard/quizzes")}
+                  className="flex h-8 w-8 items-center justify-center rounded-lg text-zinc-500 ring-1 ring-zinc-800 hover:bg-zinc-800 hover:text-zinc-300 transition-all active:scale-95"
+                  title="Back to Quizzes"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                </button>
+              </div>
+
+              {/* Progress inside the panel exactly like QuizModal but only one text line */}
+              <div className="px-4 sm:px-6 pt-2.5 pb-0">
+                <span className="text-xs font-semibold text-zinc-500">
+                  Question {currentQuestionIndex + 1} of {total}
+                </span>
+              </div>
+
+              {/* Question and Options Content exactly like QuizModal */}
+              <div className="px-4 sm:px-6 py-3 flex-1">
+                <AnimatePresence mode="wait">
+                  <motion.div
+                    key={currentQuestionIndex}
+                    initial={{ opacity: 0, x: 20 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    exit={{ opacity: 0, x: -20 }}
+                    transition={{ duration: 0.22, ease: "easeOut" }}
                   >
-                    Progress
-                  </Text>
-                  <Text
-                    level="p"
-                    className="text-[13px] font-black text-white leading-none mt-0.5"
-                  >
-                    {Math.round(
-                      ((currentQuestionIndex + 1) / questions.length) * 100,
-                    )}
-                    %
-                  </Text>
-                </div>
-                <div className="w-20 h-1 bg-gray-900 border border-gray-800 rounded-full overflow-hidden">
-                  <div
-                    className="h-full bg-red-500 shadow-[0_0_10px_rgba(239,68,68,0.3)] transition-all duration-500"
-                    style={{
-                      width: `${((currentQuestionIndex + 1) / questions.length) * 100}%`,
-                    }}
-                  />
+                    {/* Question text */}
+                    <div className="mb-2.5 text-sm font-medium text-zinc-100 leading-relaxed">
+                      <CodeRenderer
+                        content={currentQuestion.question}
+                        theme="dark"
+                        className="max-w-none text-zinc-100 selection:bg-primary/30 [&_p]:m-0 [&_p]:leading-relaxed"
+                      />
+                    </div>
+
+                    {/* Options */}
+                    <div className="space-y-1.5">
+                      {currentQuestion.options.map((opt, idx) => {
+                        const isSelected = selectedAnswer === idx;
+
+                        let rowClass =
+                          "w-full flex items-center gap-3 rounded-xl px-4 py-1.5 text-xs text-left ring-1 transition-all duration-200 cursor-pointer ";
+
+                        if (isSelected) {
+                          rowClass +=
+                            "bg-primary/10 ring-primary/40 text-primary";
+                        } else {
+                          rowClass +=
+                            "bg-zinc-900 ring-zinc-800 text-zinc-300 hover:bg-zinc-800 hover:ring-zinc-700 hover:text-zinc-100";
+                        }
+
+                        return (
+                          <button
+                            key={idx}
+                            id={`quiz-option-${currentQuestionIndex}-${idx}`}
+                            className={rowClass}
+                            onClick={() => selectAnswer(idx)}
+                          >
+                            {/* Letter badge */}
+                            <span
+                              className={cn(
+                                "flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-[9px] font-bold ring-1 transition-all",
+                                isSelected
+                                  ? "bg-primary/20 ring-primary/50 text-primary"
+                                  : "bg-zinc-800 ring-zinc-700 text-zinc-400",
+                              )}
+                            >
+                              {String.fromCharCode(65 + idx)}
+                            </span>
+
+                            {/* Option text */}
+                            <span className="flex-1 text-zinc-300 [&_p]:m-0 [&_p]:leading-normal leading-normal text-xs font-normal">
+                              <CodeRenderer
+                                content={cleanOptionText(opt)}
+                                theme="dark"
+                                className="max-w-none transition-transform text-xs font-normal [&_p]:m-0 [&_p]:leading-normal"
+                              />
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </motion.div>
+                </AnimatePresence>
+              </div>
+
+              {/* ── Footer ── */}
+              <div className="flex items-center justify-center px-4 sm:px-6 py-2 border-t border-zinc-800/60 bg-zinc-950/20">
+                <div className="flex items-center gap-1.5 text-[10px] text-zinc-500 font-semibold tracking-wide">
+                  <Zap className="h-3 w-3 text-primary/80 shrink-0 animate-pulse" />
+                  AUTO-ADVANCING ON SELECTION
                 </div>
               </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex-1 w-full max-w-6xl mx-auto px-4 py-8 md:py-12 overflow-y-auto scrollbar-hide">
-          <div className="flex flex-col gap-3">
-            {/* Question Card */}
-            <div className="bg-[#0A0A0A] border border-gray-800 rounded-xl overflow-hidden shadow-2xl transition-all duration-300">
-              <div className="p-4 md:p-5 border-b border-gray-800/50">
-                <div className="text-white text-[15px] leading-relaxed font-semibold">
-                  <CodeRenderer
-                    content={currentQuestion.question}
-                    theme="dark"
-                    className="max-w-none text-white selection:bg-red-500/30"
-                  />
-                </div>
-              </div>
-
-              {/* Options List */}
-              <div className="p-3 md:p-4 bg-black/10">
-                <div className="grid grid-cols-1 gap-1.5">
-                  {currentQuestion.options.map((option, index) => {
-                    const isSelected = selectedAnswer === index;
-                    return (
-                      <button
-                        key={index}
-                        type="button"
-                        onClick={() => selectAnswer(index)}
-                        className={cn(
-                          "group w-full text-left py-2 px-3 rounded-lg border transition-all duration-300 flex items-center relative overflow-hidden",
-                          isSelected
-                            ? "border-red-500/50 bg-red-500/5 shadow-[0_0_10px_rgba(239,68,68,0.02)]"
-                            : "border-gray-800/60 bg-transparent hover:border-gray-700 hover:bg-white/[0.02]",
-                        )}
-                      >
-                        <div className="flex items-center gap-3 w-full">
-                          <div
-                            className={cn(
-                              "w-6 h-6 rounded-md border flex items-center justify-center text-[10px] font-black shrink-0 transition-all duration-300",
-                              isSelected
-                                ? "border-red-500 bg-red-500 text-white shadow-[0_0_10px_rgba(239,68,68,0.4)]"
-                                : "border-gray-700 bg-[#111] text-gray-500 group-hover:border-gray-500 group-hover:text-gray-200",
-                            )}
-                          >
-                            {String.fromCharCode(65 + index)}
-                          </div>
-
-                          <div
-                            className={cn(
-                              "flex-1 text-[14px] font-medium leading-tight",
-                              isSelected
-                                ? "text-white font-bold"
-                                : "text-gray-400",
-                            )}
-                          >
-                            <CodeRenderer
-                              content={cleanOptionText(option)}
-                              theme="dark"
-                              className="max-w-none transition-transform"
-                            />
-                          </div>
-
-                          <div
-                            className={cn(
-                              "shrink-0 transition-all duration-300 transform",
-                              isSelected
-                                ? "opacity-100 scale-100"
-                                : "opacity-0 scale-50",
-                            )}
-                          >
-                            <CheckCircle2 className="w-4 h-4 text-red-500" />
-                          </div>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            </div>
-
-            <div className="flex items-center justify-center gap-2 text-gray-500">
-              <div className="h-px w-8 bg-gray-800" />
-              <Text
-                level="p"
-                className="text-[11px] font-bold uppercase tracking-widest text-gray-600"
-              >
-                Auto-advancing on selection
-              </Text>
-              <div className="h-px w-8 bg-gray-800" />
             </div>
           </div>
         </div>

--- a/apps/oncampus/src/pages/quiz/[id]/index.tsx
+++ b/apps/oncampus/src/pages/quiz/[id]/index.tsx
@@ -7,7 +7,7 @@ import { gamificationApi, quizApi } from "@tbe/services";
 import type { QuizQuestion, QuizQuestionsData } from "@tbe/types";
 import { cleanOptionText, cn, sendRequest } from "@tbe/utils";
 import { AnimatePresence, motion } from "framer-motion";
-import { ArrowLeft, Brain, Zap } from "lucide-react";
+import { Brain, X, Zap } from "lucide-react";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -283,7 +283,7 @@ export default function QuizPage() {
     <OnCampusLearningLayout backHref="/dashboard" layoutMode="workspace">
       <div className="flex flex-col h-full w-full">
         {/* ── Scrollable content ── */}
-        <div className="flex-1 w-full max-w-4xl mx-auto px-4 py-4 sm:py-0 overflow-y-auto scrollbar-hide flex flex-col justify-center">
+        <div className="flex-1 w-full max-w-4xl mx-auto px-4 py-4 sm:pt-8 sm:pb-4 overflow-y-auto scrollbar-hide flex flex-col justify-start">
           <div className="relative">
             {/* gradient border */}
             <div className="absolute -inset-px rounded-2xl bg-gradient-to-b from-zinc-700/70 via-zinc-800/30 to-transparent pointer-events-none" />
@@ -292,9 +292,7 @@ export default function QuizPage() {
               {/* Header inside the panel exactly like QuizModal */}
               <div className="flex items-center justify-between px-4 sm:px-6 pt-3 pb-2 border-b border-zinc-800/60">
                 <div className="flex items-center gap-2.5">
-                  <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/15 ring-1 ring-primary/30">
-                    <Brain className="h-4 w-4 text-primary" />
-                  </div>
+                  <Brain className="h-5 w-5 text-primary shrink-0" />
                   <div>
                     <span className="text-sm font-semibold text-zinc-100 tracking-tight leading-none block">
                       {quiz?.categoryName || "Quiz"}
@@ -308,10 +306,10 @@ export default function QuizPage() {
                 {/* Back to quizzes button inside header like close button in QuizModal */}
                 <button
                   onClick={() => router.push("/dashboard/quizzes")}
-                  className="flex h-8 w-8 items-center justify-center rounded-lg text-zinc-500 ring-1 ring-zinc-800 hover:bg-zinc-800 hover:text-zinc-300 transition-all active:scale-95"
+                  className="flex h-6 w-6 items-center justify-center rounded-lg text-zinc-500 ring-1 ring-zinc-800 hover:bg-zinc-800 hover:text-zinc-300 transition-all active:scale-95 shrink-0"
                   title="Back to Quizzes"
                 >
-                  <ArrowLeft className="h-4 w-4" />
+                  <X className="h-3 w-3" />
                 </button>
               </div>
 

--- a/apps/oncampus/src/pages/results/[id]/index.tsx
+++ b/apps/oncampus/src/pages/results/[id]/index.tsx
@@ -131,7 +131,7 @@ export default function ResultsPage() {
       <div className="flex flex-col h-full w-full">
         {/* Workspace Header Section — Styled like the Quiz Header */}
         <div className="w-full min-h-[72px] border-b border-zinc-800 bg-zinc-950/40 flex shrink-0 sticky top-0 z-20 backdrop-blur-md">
-          <div className="relative w-full h-full flex items-center px-4 sm:px-6 justify-between">
+          <div className="relative w-full h-full flex items-center px-4 sm:px-6">
             {/* Left aligned: Back Navigation + Brain Icon + Stacked Header Titles */}
             <div className="flex items-center gap-3 sm:gap-4">
               <button
@@ -151,26 +151,6 @@ export default function ResultsPage() {
                   <span className="text-xs font-medium text-zinc-500 mt-0.5 block">
                     Quiz Results
                   </span>
-                </div>
-              </div>
-            </div>
-
-            {/* Right-aligned Result Badge */}
-            <div className="flex items-center gap-6">
-              <div className="flex items-center bg-primary/10 border border-primary/20 rounded-xl px-2.5 py-1.5">
-                <div className="flex flex-col items-end">
-                  <Text
-                    level="p"
-                    className="text-[8px] font-bold text-primary/70 uppercase tracking-wider leading-none"
-                  >
-                    Result
-                  </Text>
-                  <Text
-                    level="p"
-                    className="text-[14px] font-black text-primary leading-none mt-1"
-                  >
-                    {percentage}%
-                  </Text>
                 </div>
               </div>
             </div>

--- a/apps/oncampus/src/pages/results/[id]/index.tsx
+++ b/apps/oncampus/src/pages/results/[id]/index.tsx
@@ -1,18 +1,20 @@
 import { useAuth } from "@tbe/auth";
 import { CelebrationAnimation, Progress, Text } from "@tbe/components";
-import { MarkdownRenderer } from "@tbe/components/quizes";
+import { CodeRenderer } from "@tbe/components/quizes";
 import { quizApi } from "@tbe/services";
 import type { QuizQuestion, QuizQuestionsData } from "@tbe/types";
 import { cleanOptionText, cn } from "@tbe/utils";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   ArrowLeft,
+  Brain,
   CheckCircle2,
   ChevronUp,
   Clock,
   Monitor,
   RotateCcw,
   Target,
+  X,
   XCircle,
 } from "lucide-react";
 import { useRouter } from "next/router";
@@ -104,7 +106,7 @@ export default function ResultsPage() {
     return (
       <OnCampusLearningLayout backHref="/dashboard" isLoading>
         <div className="flex-1 flex items-center justify-center">
-          <Text level="p" className="text-gray-400">
+          <Text level="p" className="text-zinc-400">
             Loading results...
           </Text>
         </div>
@@ -116,7 +118,7 @@ export default function ResultsPage() {
     return (
       <OnCampusLearningLayout backHref="/dashboard">
         <div className="flex-1 flex items-center justify-center">
-          <div className="text-red-400">
+          <div className="text-primary font-semibold text-sm">
             Failed to load results. Please try again.
           </div>
         </div>
@@ -127,49 +129,45 @@ export default function ResultsPage() {
   return (
     <OnCampusLearningLayout backHref="/dashboard" layoutMode="workspace">
       <div className="flex flex-col h-full w-full">
-        {/* Workspace Header Section — Centered Title Mode */}
-        <div className="w-full min-h-[72px] border-b border-gray-800 bg-[#0A0A0A] flex shrink-0 sticky top-0 z-20">
-          <div className="relative w-full h-full flex items-center px-6">
-            {/* Left Back Navigation */}
-            <div className="flex-1 flex items-center">
+        {/* Workspace Header Section — Styled like the Quiz Header */}
+        <div className="w-full min-h-[72px] border-b border-zinc-800 bg-zinc-950/40 flex shrink-0 sticky top-0 z-20 backdrop-blur-md">
+          <div className="relative w-full h-full flex items-center px-4 sm:px-6 justify-between">
+            {/* Left aligned: Back Navigation + Brain Icon + Stacked Header Titles */}
+            <div className="flex items-center gap-3 sm:gap-4">
               <button
                 onClick={() => router.push("/dashboard/quizzes")}
-                className="flex items-center justify-center w-[28px] h-[28px] rounded-[6px] border border-red-500/40 bg-red-500/5 text-red-500 hover:bg-red-500/10 hover:border-red-500 transition-all duration-300 shrink-0 shadow-[0_0_10px_rgba(239,68,68,0.1)] active:scale-95"
+                className="flex h-6 w-6 items-center justify-center rounded-lg text-zinc-500 ring-1 ring-zinc-800 hover:bg-zinc-800 hover:text-zinc-300 transition-all active:scale-95 shrink-0"
                 title="Back to Quizzes"
               >
-                <ArrowLeft className="w-3.5 h-3.5" />
+                <X className="h-3 w-3" />
               </button>
-            </div>
 
-            {/* Absolute Centered Header Info */}
-            <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col items-center">
-              <Text
-                level="h1"
-                className="text-[13px] font-bold text-white tracking-tight leading-none mb-1"
-              >
-                Quiz Results
-              </Text>
-              <Text
-                level="p"
-                className="text-[8px] font-bold text-gray-500 uppercase tracking-widest leading-none bg-gray-900/50 px-2 py-0.5 rounded border border-gray-800"
-              >
-                {quiz?.categoryName || "Review Mode"}
-              </Text>
+              <div className="flex items-center gap-2.5">
+                <Brain className="h-5 w-5 text-primary shrink-0" />
+                <div>
+                  <span className="text-sm font-semibold text-zinc-100 tracking-tight block truncate max-w-[120px] sm:max-w-none">
+                    {quiz?.categoryName || "Quiz"}
+                  </span>
+                  <span className="text-xs font-medium text-zinc-500 mt-0.5 block">
+                    Quiz Results
+                  </span>
+                </div>
+              </div>
             </div>
 
             {/* Right-aligned Result Badge */}
-            <div className="flex-1 flex justify-end items-center gap-6">
-              <div className="flex items-center bg-red-500/5 border border-red-500/20 rounded-lg px-2.5 py-1.5">
+            <div className="flex items-center gap-6">
+              <div className="flex items-center bg-primary/10 border border-primary/20 rounded-xl px-2.5 py-1.5">
                 <div className="flex flex-col items-end">
                   <Text
                     level="p"
-                    className="text-[8px] font-bold text-red-500/70 uppercase tracking-wider leading-none"
+                    className="text-[8px] font-bold text-primary/70 uppercase tracking-wider leading-none"
                   >
                     Result
                   </Text>
                   <Text
                     level="p"
-                    className="text-[14px] font-black text-red-500 leading-none mt-1"
+                    className="text-[14px] font-black text-primary leading-none mt-1"
                   >
                     {percentage}%
                   </Text>
@@ -189,9 +187,9 @@ export default function ResultsPage() {
           </div>
 
           <div className="w-full max-w-6xl mx-auto px-4 md:px-6">
-            <div className="flex flex-col lg:flex-row gap-8 items-start">
+            <div className="flex flex-col lg:flex-row gap-4 lg:gap-8 items-start">
               {/* Left Column - Score Summary */}
-              <div className="w-full lg:w-[320px] lg:sticky lg:top-0 h-fit pt-6 md:pt-8 pb-4 z-10">
+              <div className="w-full lg:w-[320px] lg:sticky lg:top-0 h-fit pt-4 lg:pt-8 pb-0 lg:pb-4 z-10">
                 <motion.div
                   initial={{ opacity: 0, x: -20 }}
                   animate={{ opacity: 1, x: 0 }}
@@ -199,111 +197,123 @@ export default function ResultsPage() {
                   className="space-y-4"
                 >
                   {/* Score Display */}
-                  <div className="bg-[#0F0F0F] border border-gray-800 rounded-2xl p-4 text-center shadow-xl">
-                    <div className="relative inline-block mb-1">
-                      <div className="text-4xl font-black text-red-500 tracking-tighter">
-                        {percentage}%
+                  <div className="relative">
+                    {/* gradient border */}
+                    <div className="absolute -inset-px rounded-2xl bg-gradient-to-b from-zinc-700/70 via-zinc-800/30 to-transparent pointer-events-none" />
+                    <div className="relative flex flex-col rounded-2xl border border-zinc-800 bg-zinc-900 p-4 text-center overflow-hidden">
+                      <div className="relative inline-block mb-1">
+                        <div className="text-4xl font-black text-primary tracking-tighter">
+                          {percentage}%
+                        </div>
                       </div>
+                      <h2 className="text-sm font-bold text-zinc-100 mb-0.5">
+                        {percentage >= 70
+                          ? "Fantastic Work!"
+                          : "Keep practicing!"}
+                      </h2>
+                      <p className="text-zinc-500 text-xs font-medium">
+                        You completed the quiz!
+                      </p>
                     </div>
-                    <h2 className="text-lg font-bold text-white mb-0.5">
-                      {percentage >= 70
-                        ? "Fantastic Work!"
-                        : "Keep practicing!"}
-                    </h2>
-                    <p className="text-gray-400 text-xs text-medium">
-                      You completed the quiz!
-                    </p>
                   </div>
 
                   {/* Stats Grid */}
                   <div className="grid grid-cols-2 gap-2">
-                    <div className="bg-[#0F0F0F] border border-gray-800 rounded-xl p-3 flex flex-col items-center justify-center text-center">
-                      <Target className="w-4 h-4 text-red-500 mb-1.5" />
-                      <div className="text-xl font-black text-white leading-none mb-1">
+                    <div className="bg-zinc-900 border border-zinc-800/80 rounded-xl p-3 flex flex-col items-center justify-center text-center">
+                      <Target className="w-4 h-4 text-primary mb-1.5 ring-1 ring-primary/10 rounded-md p-0.5 bg-primary/5" />
+                      <div className="text-xl font-bold text-zinc-100 leading-none mb-1 tracking-tight">
                         {score}
                       </div>
-                      <div className="text-[9px] text-gray-500 uppercase font-bold tracking-wider">
+                      <div className="text-[9px] text-zinc-500 uppercase font-bold tracking-wider">
                         of {totalQuestions} Correct
                       </div>
                     </div>
-                    <div className="bg-[#0F0F0F] border border-gray-800 rounded-xl p-3 flex flex-col items-center justify-center text-center">
-                      <Clock className="w-4 h-4 text-red-500 mb-1.5" />
-                      <div className="text-xl font-black text-white leading-none mb-1">
+                    <div className="bg-zinc-900 border border-zinc-800/80 rounded-xl p-3 flex flex-col items-center justify-center text-center">
+                      <Clock className="w-4 h-4 text-primary mb-1.5 ring-1 ring-primary/10 rounded-md p-0.5 bg-primary/5" />
+                      <div className="text-xl font-bold text-zinc-100 leading-none mb-1 tracking-tight">
                         {Math.floor(timeTaken / 60)}:
                         {String(timeTaken % 60).padStart(2, "0")}
                       </div>
-                      <div className="text-[9px] text-gray-500 uppercase font-bold tracking-wider">
+                      <div className="text-[9px] text-zinc-500 uppercase font-bold tracking-wider">
                         Total Time
                       </div>
                     </div>
                   </div>
 
                   {/* Progress Detail */}
-                  <div className="bg-[#0F0F0F] border border-gray-800 rounded-xl p-3 space-y-2">
+                  <div className="bg-zinc-900 border border-zinc-800/80 rounded-xl p-3 space-y-2">
                     <div className="flex justify-between items-center text-[10px] font-bold uppercase tracking-wider">
-                      <span className="text-gray-400">Progress</span>
-                      <span className="text-white">{percentage}%</span>
+                      <span className="text-zinc-400">Progress</span>
+                      <span className="text-zinc-100">{percentage}%</span>
                     </div>
                     <Progress
                       value={percentage}
-                      className="h-1.5 bg-gray-800"
+                      className="h-1.5 bg-zinc-800"
                     />
                   </div>
 
                   {/* Quiz Info Card */}
-                  <div className="bg-[#0A0A0A] border border-gray-800 rounded-xl p-3 flex items-center gap-3">
-                    <div className="w-10 h-10 rounded-lg bg-gray-900 border border-gray-800 flex items-center justify-center shrink-0">
+                  <div className="bg-zinc-900 border border-zinc-800/80 rounded-xl p-3 flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-lg bg-zinc-950/40 border border-zinc-800 flex items-center justify-center shrink-0">
                       <Monitor
-                        className="w-3.5 h-3.5 text-gray-400"
+                        className="w-3.5 h-3.5 text-zinc-400"
                         strokeWidth={2}
                       />
                     </div>
                     <div className="flex-1 min-w-0">
-                      <div className="text-[9px] text-gray-500 uppercase font-bold tracking-wider mb-0.5">
+                      <div className="text-[9px] text-zinc-500 uppercase font-bold tracking-wider mb-0.5">
                         Current Quiz
                       </div>
-                      <div className="text-white font-bold truncate text-xs">
+                      <div className="text-zinc-100 font-semibold truncate text-xs">
                         {quiz.categoryName}
                       </div>
                     </div>
                   </div>
 
                   {/* Action Buttons */}
-                  <div className="flex items-center justify-center gap-3 pt-2">
+                  <div className="flex items-center justify-center gap-3 pt-1">
                     <button
                       onClick={() => router.push(`/quiz/${quizId}`)}
-                      className="flex-1 w-full flex items-center justify-center gap-2 bg-transparent border border-red-500/50 text-red-500 hover:bg-red-500/10 hover:border-red-500 font-bold h-10 rounded-lg text-xs whitespace-nowrap transition-colors"
+                      className="flex-1 w-full flex items-center justify-center gap-2 bg-transparent border border-primary/30 text-primary hover:bg-primary/10 hover:border-primary font-semibold h-9 rounded-xl text-xs whitespace-nowrap transition-all active:scale-95 duration-200"
                     >
                       <span>Try Again</span>
-                      <RotateCcw className="w-3.5 h-3.5 shrink-0" />
+                      <RotateCcw className="w-3 h-3 shrink-0" />
                     </button>
                     <button
                       onClick={() => router.push("/dashboard")}
-                      className="flex-1 w-full flex items-center justify-center gap-2 bg-transparent border border-red-500/50 text-red-500 hover:bg-red-500/10 hover:border-red-500 font-bold h-10 rounded-lg text-xs whitespace-nowrap transition-colors"
+                      className="flex-1 w-full flex items-center justify-center gap-2 bg-transparent border border-primary/30 text-primary hover:bg-primary/10 hover:border-primary font-semibold h-9 rounded-xl text-xs whitespace-nowrap transition-all active:scale-95 duration-200"
                     >
                       <span>Quizzes</span>
-                      <ArrowLeft className="w-3.5 h-3.5 rotate-180 shrink-0" />
+                      <ArrowLeft className="w-3 h-3 rotate-180 shrink-0" />
                     </button>
                   </div>
                 </motion.div>
               </div>
 
               {/* Right Column - Review List */}
-              <div className="flex-1 w-full space-y-6 min-w-0 pt-6 md:pt-8 pb-8">
+              <div className="flex-1 w-full space-y-6 min-w-0 pt-2 lg:pt-8 pb-8">
                 <div className="flex items-center justify-between">
-                  <h1 className="text-2xl font-black text-white tracking-tight">
+                  <h2 className="text-lg sm:text-xl font-bold text-zinc-100 tracking-tight">
                     Review Answers
-                  </h1>
-                  <div className="text-[11px] text-gray-500 font-bold uppercase tracking-widest">
-                    {questions.length} Questions analyzed
+                  </h2>
+                  <div className="text-xs font-semibold text-zinc-500 tracking-wide uppercase">
+                    {questions.length} Questions
                   </div>
                 </div>
 
-                <div className="space-y-3">
+                <div className="space-y-2.5">
                   {questions.map((question, index) => {
                     const userAnswer = answers[index];
                     const isCorrect = userAnswer === question.correctAnswer;
                     const isExpanded = expandedQuestion === index;
+
+                    // If the question contains a markdown code block, hide it when the item is collapsed
+                    const displayQuestion = isExpanded
+                      ? question.question
+                      : question.question.includes("```")
+                        ? question.question.split("```")[0]?.trim() ||
+                          question.question
+                        : question.question;
 
                     return (
                       <motion.div
@@ -315,70 +325,93 @@ export default function ResultsPage() {
                       >
                         <div
                           className={cn(
-                            "border rounded-2xl bg-[#0A0A0A] overflow-hidden transition-all duration-300 relative",
+                            "border rounded-2xl bg-zinc-900 overflow-hidden transition-all duration-300 relative",
                             isExpanded
-                              ? "border-gray-700 ring-1 ring-gray-800 shadow-2xl"
-                              : "border-gray-800 hover:border-gray-700",
+                              ? "border-zinc-700 ring-1 ring-zinc-700/30 shadow-2xl"
+                              : "border-zinc-800 hover:border-zinc-700",
                           )}
                         >
                           {/* Accordion Header */}
-                          <button
-                            type="button"
+                          <div
                             onClick={() =>
                               setExpandedQuestion(isExpanded ? null : index)
                             }
-                            className="w-full flex items-center gap-4 p-4 text-left transition-colors hover:bg-white/[0.01]"
+                            className="w-full flex items-start gap-2.5 sm:gap-4 py-2 px-3 sm:py-2.5 sm:px-4 text-left transition-colors hover:bg-zinc-800/10 cursor-pointer"
                           >
+                            {/* Left-aligned status circle box (hidden on mobile, flex on desktop) */}
                             <div
                               className={cn(
-                                "flex-shrink-0 w-8 h-8 rounded-lg flex items-center justify-center border transition-colors",
+                                "hidden sm:flex flex-shrink-0 w-8 h-8 rounded-lg items-center justify-center border transition-colors mt-0.5",
                                 isCorrect
-                                  ? "bg-green-500/10 border-green-500/20 text-green-500"
-                                  : "bg-red-500/10 border-red-500/20 text-red-500",
+                                  ? "bg-emerald-500/10 border-emerald-500/20 text-emerald-400"
+                                  : "bg-primary/10 border-primary/20 text-primary",
                               )}
                             >
                               {isCorrect ? (
-                                <CheckCircle2 className="w-4 h-4" />
+                                <CheckCircle2 className="w-4 h-4 text-emerald-400 shrink-0" />
                               ) : (
-                                <XCircle className="w-4 h-4" />
+                                <XCircle className="w-4 h-4 text-primary shrink-0" />
                               )}
                             </div>
 
                             <div className="flex-1 min-w-0">
-                              <div className="flex items-center gap-2 mb-1">
-                                <span className="text-[10px] font-black text-gray-600 uppercase tracking-[0.2em]">
-                                  Question {index + 1}
-                                </span>
+                              <div className="flex items-center justify-between gap-2 mb-1.5 w-full">
+                                <div className="flex items-center gap-2">
+                                  {/* Mobile-only status icon */}
+                                  <div className="sm:hidden shrink-0">
+                                    {isCorrect ? (
+                                      <CheckCircle2 className="w-3.5 h-3.5 text-emerald-400" />
+                                    ) : (
+                                      <XCircle className="w-3.5 h-3.5 text-primary" />
+                                    )}
+                                  </div>
+                                  <span className="text-[10px] font-bold text-zinc-500 uppercase tracking-widest">
+                                    Question {index + 1}
+                                  </span>
+                                </div>
                                 <span
                                   className={cn(
-                                    "px-2 py-0.5 rounded text-[10px] font-black uppercase tracking-widest border",
+                                    "px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-widest border shrink-0",
                                     isCorrect
-                                      ? "bg-green-500/5 border-green-500/20 text-green-400"
-                                      : "bg-red-500/5 border-red-500/20 text-red-400",
+                                      ? "bg-emerald-500/5 border-emerald-500/20 text-emerald-400"
+                                      : "bg-primary/5 border-primary/20 text-primary",
                                   )}
                                 >
                                   {isCorrect ? "Correct" : "Incorrect"}
                                 </span>
                               </div>
-                              <div className="text-white font-semibold truncate text-[14px] md:text-[15px] tracking-tight">
-                                {question.question
-                                  .replace(/[#*`]/g, "")
-                                  .substring(0, 100)}
-                                ...
+                              <div
+                                className="text-zinc-100 font-semibold text-sm tracking-tight leading-relaxed"
+                                onClick={(e) => {
+                                  // Prevent clicks inside code layout elements from bubbling up & collapsing accordion
+                                  if (
+                                    (e.target as HTMLElement).closest(
+                                      "pre, code, button",
+                                    )
+                                  ) {
+                                    e.stopPropagation();
+                                  }
+                                }}
+                              >
+                                <CodeRenderer
+                                  content={displayQuestion}
+                                  theme="dark"
+                                  className="text-zinc-100 text-sm [&_p]:m-0 [&_p]:leading-relaxed"
+                                />
                               </div>
                             </div>
 
-                            <div className="flex-shrink-0 ml-4">
+                            <div className="flex-shrink-0 ml-2 sm:ml-4 mt-0.5">
                               <div
                                 className={cn(
-                                  "w-8 h-8 rounded-full bg-gray-900 border border-gray-800 flex items-center justify-center transition-transform duration-300",
+                                  "w-6 h-6 sm:w-7 sm:h-7 rounded-lg bg-zinc-950/40 border border-zinc-800 flex items-center justify-center transition-all duration-200 active:scale-95",
                                   isExpanded ? "rotate-0" : "rotate-180",
                                 )}
                               >
-                                <ChevronUp className="w-4 h-4 text-gray-500" />
+                                <ChevronUp className="w-4 h-4 text-zinc-500" />
                               </div>
                             </div>
-                          </button>
+                          </div>
 
                           {/* Accordion Content */}
                           <AnimatePresence>
@@ -392,28 +425,14 @@ export default function ResultsPage() {
                                   ease: "easeInOut",
                                 }}
                               >
-                                <div className="px-4 pb-6 pt-2 border-t border-gray-800/50 bg-[#050505]">
-                                  <div className="space-y-6 mt-4">
-                                    {/* Question Description */}
-                                    <div className="space-y-2">
-                                      <div className="text-[10px] text-gray-500 uppercase font-black tracking-[0.3em] ml-1">
-                                        The Question
-                                      </div>
-                                      <div className="p-4 bg-[#0A0A0A] rounded-xl border border-gray-800/80">
-                                        <MarkdownRenderer
-                                          content={question.question}
-                                          theme="dark"
-                                          className="text-white text-[15px] leading-relaxed selection:bg-red-500/30 font-medium"
-                                        />
-                                      </div>
-                                    </div>
-
+                                <div className="px-3 sm:px-4 pb-3.5 pt-1.5 border-t border-zinc-800 bg-zinc-950/20">
+                                  <div className="space-y-4 mt-3">
                                     {/* Answers Grid */}
-                                    <div className="space-y-3">
-                                      <div className="text-[10px] text-gray-500 uppercase font-black tracking-[0.3em] ml-1">
+                                    <div className="space-y-2">
+                                      <div className="text-[10px] text-zinc-500 uppercase font-bold tracking-widest ml-1">
                                         Option Breakdown
                                       </div>
-                                      <div className="grid grid-cols-1 gap-2.5">
+                                      <div className="grid grid-cols-1 gap-2">
                                         {question.options.map(
                                           (option, optionIndex) => {
                                             const isAnswerCorrect =
@@ -426,23 +445,24 @@ export default function ResultsPage() {
                                               <div
                                                 key={optionIndex}
                                                 className={cn(
-                                                  "py-2.5 px-3.5 rounded-lg border transition-all duration-300 flex items-center relative gap-3.5 overflow-hidden",
+                                                  "w-full flex items-start gap-2.5 sm:gap-3 rounded-xl px-3 sm:px-4 py-1.5 text-xs text-left ring-1 transition-all duration-200 relative",
                                                   isAnswerCorrect
-                                                    ? "border-green-500 bg-green-500/[0.03] shadow-[0_0_20px_rgba(34,197,94,0.05)]"
+                                                    ? "bg-emerald-500/5 ring-emerald-500/30 text-emerald-400"
                                                     : isUserPicked && !isCorrect
-                                                      ? "border-red-500 bg-red-500/[0.03] shadow-[0_0_20px_rgba(239,68,68,0.05)]"
-                                                      : "border-gray-800 bg-black/40 opacity-50 shadow-none",
+                                                      ? "bg-primary/10 ring-primary/40 text-primary"
+                                                      : "bg-zinc-900/50 ring-zinc-800/80 text-zinc-400 opacity-60",
                                                 )}
                                               >
+                                                {/* Letter badge */}
                                                 <span
                                                   className={cn(
-                                                    "flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-md text-[10px] font-black border transition-all",
+                                                    "flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-[9px] font-bold ring-1 transition-all mt-0.5",
                                                     isAnswerCorrect
-                                                      ? "bg-green-500 border-green-500 text-white shadow-[0_0_8px_rgba(34,197,94,0.3)]"
+                                                      ? "bg-emerald-500/20 ring-emerald-500/50 text-emerald-400"
                                                       : isUserPicked &&
                                                           !isCorrect
-                                                        ? "bg-red-500 border-red-500 text-white shadow-[0_0_8px_rgba(239,68,68,0.3)]"
-                                                        : "bg-[#111] border-gray-800 text-gray-500",
+                                                        ? "bg-primary/20 ring-primary/50 text-primary"
+                                                        : "bg-zinc-800 ring-zinc-700 text-zinc-500",
                                                   )}
                                                 >
                                                   {String.fromCharCode(
@@ -450,21 +470,22 @@ export default function ResultsPage() {
                                                   )}
                                                 </span>
 
-                                                <div className="flex-1 text-[14px] font-bold text-white">
-                                                  <MarkdownRenderer
+                                                {/* Option text */}
+                                                <div className="flex-1 text-zinc-300 [&_p]:m-0 [&_p]:leading-normal leading-normal text-xs font-normal">
+                                                  <CodeRenderer
                                                     content={cleanOptionText(
                                                       option,
                                                     )}
                                                     theme="dark"
-                                                    className="text-white selection:bg-red-500/20"
+                                                    className="max-w-none text-xs font-normal [&_p]:m-0 [&_p]:leading-normal text-zinc-300"
                                                   />
                                                 </div>
 
                                                 {isAnswerCorrect && (
-                                                  <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
+                                                  <CheckCircle2 className="w-3.5 h-3.5 text-emerald-400 shrink-0 mt-0.5" />
                                                 )}
                                                 {isUserPicked && !isCorrect && (
-                                                  <XCircle className="w-4 h-4 text-red-500 shrink-0" />
+                                                  <XCircle className="w-3.5 h-3.5 text-primary shrink-0 mt-0.5" />
                                                 )}
                                               </div>
                                             );
@@ -474,17 +495,17 @@ export default function ResultsPage() {
                                     </div>
 
                                     {/* Explanation Card */}
-                                    <div className="mt-4 p-4 bg-red-500/[0.02] rounded-xl border border-red-500/10 relative group overflow-hidden">
-                                      <div className="absolute left-0 top-0 bottom-0 w-1 bg-red-500/30" />
-                                      <div className="flex items-center gap-2 text-red-500 font-bold text-[10px] mb-2 uppercase tracking-widest">
-                                        <Target className="w-3.5 h-3.5" />
+                                    <div className="mt-3 p-3 bg-primary/5 rounded-xl border border-primary/10 relative group overflow-hidden">
+                                      <div className="absolute left-0 top-0 bottom-0 w-1 bg-primary/40" />
+                                      <div className="flex items-center gap-2 text-primary font-bold text-[10px] mb-2 uppercase tracking-widest">
+                                        <Target className="w-3.5 h-3.5 shrink-0" />
                                         <span>Explanation & Insights</span>
                                       </div>
-                                      <div className="text-gray-300 text-[13px] md:text-sm leading-relaxed font-medium">
-                                        <MarkdownRenderer
+                                      <div className="text-zinc-300 text-xs md:text-xs leading-relaxed font-normal [&_p]:m-0">
+                                        <CodeRenderer
                                           content={question.explanation}
                                           theme="dark"
-                                          className="text-gray-300"
+                                          className="text-zinc-300 font-normal text-xs [&_p]:m-0"
                                         />
                                       </div>
                                     </div>


### PR DESCRIPTION
## What does this PR do?

Overhauls the styling and responsiveness of the OnCampus Quiz and Results pages:
- **🎨 Reddish Brand Theme:** Aligned all icons, badges, borders, and selection states with our primary brand color (`#FF5757`).
- **📱 Full-Width Questions on Mobile:** Hid bulky status boxes on mobile and aligned correct/incorrect badges to the far right, allowing questions and code blocks to take up 100% card width.
- **💻 Smart Code Hiding:** Question code blocks are hidden when collapsed and animate cleanly into view only when expanded.
- **✖ Standard Close Buttons:** Upgraded small cross buttons on both screens to a standard, tap-friendly `h-6 w-6` size with a `h-3 w-3` `X` icon.

## Why?

Improves visual consistency across the platform, makes long code-heavy quiz reviews easy to scroll through, and ensures touch targets are fully mobile-friendly.

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 Refactor / cleanup (no functional change)
- [x] 🎨 UI / styling change
- [ ] 🔌 API change (new or modified endpoints, request/response shape changes)
- [ ] 📦 Dependency update
- [ ] 📝 Documentation only

---

## Screenshots / Recordings
## Before
<img width="810" height="971" alt="{9DCD2B54-3091-4243-B84A-8F47CBB9366C}" src="https://github.com/user-attachments/assets/6318dc06-469a-466b-b0ef-a999a0a88623" />
<img width="1825" height="798" alt="image" src="https://github.com/user-attachments/assets/5c71d3a4-11ab-4f49-b8d4-c271be2a2ec5" />
<img width="408" height="810" alt="image" src="https://github.com/user-attachments/assets/49c02d09-e158-4670-abd0-ccbd41681244" />
<img width="415" height="801" alt="{00A8D478-F873-495B-835B-BCBA8D9B985C}" src="https://github.com/user-attachments/assets/a241f321-8290-4d28-993d-652af4bfdfc0" />


## After

<img width="637" height="686" alt="{F774746E-606C-4B10-B330-75703796DCE1}" src="https://github.com/user-attachments/assets/3f78b90c-71ed-4716-89b4-b098a4fbbb54" />
<img width="1693" height="792" alt="image" src="https://github.com/user-attachments/assets/68cc39c6-b239-4e07-8ed1-468159154c7c" />
<img width="514" height="852" alt="{AED25F76-C79A-4011-9D42-4CADFF9B1633}" src="https://github.com/user-attachments/assets/088dd7f8-cd4b-4840-a110-a660cc019bd9" />
<img width="1893" height="820" alt="{65F196AD-37A8-41C9-B373-FDE5C281BC68}" src="https://github.com/user-attachments/assets/41621143-a8b9-42fe-af70-7c0570572635" />


---

## Testing

### Does this PR include tests?

- [x] No — Pure visual UI/styling update.

### How to test manually

1. Open the OnCampus quiz page on mobile view. Verify that the exit button is a standard `h-6 w-6` container.
2. Complete the quiz and load the Results screen.
3. Confirm that collapsed cards hide code blocks, question titles stretch full-width, and the Correct/Incorrect badges align to the far right.

---

## Checklist

- [x] I've tested this locally and it works as expected
- [x] I've checked for console errors / warnings
- [x] No unrelated changes snuck in
- [x] If UI change — tested on mobile viewport too
