### PR TITLE
fix links

### DIFF
--- a/apps/resources/content/agentic-ai-engineer-roadmap/index.html
+++ b/apps/resources/content/agentic-ai-engineer-roadmap/index.html
@@ -67,20 +67,28 @@
             transition: background 0.2s;
         }
 
-        .print-btn:hover { background: #e04040; }
-        .print-btn svg { width: 16px; height: 16px; }
+        .print-btn:hover {
+            background: #e04040;
+        }
+
+        .print-btn svg {
+            width: 16px;
+            height: 16px;
+        }
 
         .page {
             width: 794px;
             max-width: 100%;
             background: var(--white);
-            box-shadow: 0 4px 40px rgba(0,0,0,0.18);
+            box-shadow: 0 4px 40px rgba(0, 0, 0, 0.18);
             position: relative;
             overflow: visible;
             margin-bottom: 0;
         }
 
-        .page + .page { margin-top: 2px; }
+        .page+.page {
+            margin-top: 2px;
+        }
 
         /* ── COVER ── */
         .cover {
@@ -158,7 +166,9 @@
             margin-bottom: 16px;
         }
 
-        .cover-title span { color: var(--red); }
+        .cover-title span {
+            color: var(--red);
+        }
 
         .cover-subtitle {
             font-size: 16px;
@@ -281,9 +291,25 @@
             flex-shrink: 0;
         }
 
-        .page-header img { height: 22px; opacity: 0.7; }
-        .page-header-logo { font-family: var(--mono); font-size: 11px; font-weight: 700; color: var(--soft); }
-        .page-header-title { font-family: var(--mono); font-size: 11px; color: var(--soft); text-transform: uppercase; letter-spacing: 0.08em; }
+        .page-header img {
+            height: 22px;
+            opacity: 0.7;
+        }
+
+        .page-header-logo {
+            font-family: var(--mono);
+            font-size: 11px;
+            font-weight: 700;
+            color: var(--soft);
+        }
+
+        .page-header-title {
+            font-family: var(--mono);
+            font-size: 11px;
+            color: var(--soft);
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
 
         .page-body {
             flex: 1;
@@ -314,7 +340,10 @@
             gap: 8px;
         }
 
-        .section-label::before { content: '//'; opacity: 0.5; }
+        .section-label::before {
+            content: '//';
+            opacity: 0.5;
+        }
 
         .section-title {
             font-size: 26px;
@@ -326,9 +355,17 @@
         }
 
         /* ── ROADMAP STEPS ── */
-        .roadmap { display: flex; flex-direction: column; gap: 0; }
+        .roadmap {
+            display: flex;
+            flex-direction: column;
+            gap: 0;
+        }
 
-        .step { display: flex; gap: 0; position: relative; }
+        .step {
+            display: flex;
+            gap: 0;
+            position: relative;
+        }
 
         .step-left {
             display: flex;
@@ -363,7 +400,10 @@
             margin: 4px 0;
         }
 
-        .step-content { flex: 1; padding: 2px 0 18px 20px; }
+        .step-content {
+            flex: 1;
+            padding: 2px 0 18px 20px;
+        }
 
         .step-phase {
             font-family: var(--mono);
@@ -375,11 +415,26 @@
             margin-bottom: 2px;
         }
 
-        .step-heading { font-size: 15px; font-weight: 700; color: var(--dark); margin-bottom: 4px; }
+        .step-heading {
+            font-size: 15px;
+            font-weight: 700;
+            color: var(--dark);
+            margin-bottom: 4px;
+        }
 
-        .step-desc { font-size: 12px; color: var(--mid); line-height: 1.6; margin-bottom: 6px; }
+        .step-desc {
+            font-size: 12px;
+            color: var(--mid);
+            line-height: 1.6;
+            margin-bottom: 6px;
+        }
 
-        .step-tags { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 5px; }
+        .step-tags {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+            margin-bottom: 5px;
+        }
 
         .tag {
             font-family: var(--mono);
@@ -399,7 +454,12 @@
         }
 
         /* ── YOUTUBE LINKS ── */
-        .yt-links { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 4px; }
+        .yt-links {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+            margin-top: 4px;
+        }
 
         .yt-link {
             display: inline-flex;
@@ -417,8 +477,14 @@
             transition: background 0.15s;
         }
 
-        .yt-link:hover { background: #ffe0e0; }
-        .yt-link::before { content: '▶'; font-size: 8px; }
+        .yt-link:hover {
+            background: #ffe0e0;
+        }
+
+        .yt-link::before {
+            content: '▶';
+            font-size: 8px;
+        }
 
         /* ── TIME BADGE ── */
         .time-badge {
@@ -451,14 +517,27 @@
             align-items: flex-start;
         }
 
-        .tip-icon { font-size: 16px; flex-shrink: 0; }
+        .tip-icon {
+            font-size: 16px;
+            flex-shrink: 0;
+        }
 
-        .tip-text { font-size: 12px; color: var(--dark); line-height: 1.6; }
+        .tip-text {
+            font-size: 12px;
+            color: var(--dark);
+            line-height: 1.6;
+        }
 
-        .tip-text strong { color: var(--red); }
+        .tip-text strong {
+            color: var(--red);
+        }
 
         /* ── DIVIDER ── */
-        .divider { border: none; border-top: 1px solid var(--border); margin: 14px 0; }
+        .divider {
+            border: none;
+            border-top: 1px solid var(--border);
+            margin: 14px 0;
+        }
 
         /* ── SKILLS TABLE ── */
         .skills-row {
@@ -468,7 +547,11 @@
             margin-bottom: 14px;
         }
 
-        .skill-col { display: flex; flex-direction: column; gap: 5px; }
+        .skill-col {
+            display: flex;
+            flex-direction: column;
+            gap: 5px;
+        }
 
         .skill-col-title {
             font-family: var(--mono);
@@ -523,12 +606,33 @@
             background: var(--red);
         }
 
-        .resource-card-name { font-size: 13px; font-weight: 700; color: var(--dark); margin-bottom: 3px; }
-        .resource-card-desc { font-size: 11px; color: var(--mid); line-height: 1.5; margin-bottom: 7px; }
-        .resource-card-links { display: flex; flex-direction: column; gap: 4px; }
+        .resource-card-name {
+            font-size: 13px;
+            font-weight: 700;
+            color: var(--dark);
+            margin-bottom: 3px;
+        }
+
+        .resource-card-desc {
+            font-size: 11px;
+            color: var(--mid);
+            line-height: 1.5;
+            margin-bottom: 7px;
+        }
+
+        .resource-card-links {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
 
         /* ── CHECKLIST ── */
-        .checklist { display: flex; flex-direction: column; gap: 6px; margin-bottom: 0; }
+        .checklist {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            margin-bottom: 0;
+        }
 
         .check-item {
             display: flex;
@@ -564,7 +668,12 @@
             text-decoration: none;
         }
 
-        .social-icon { width: 24px; height: 24px; display: block; margin: 0 auto; }
+        .social-icon {
+            width: 24px;
+            height: 24px;
+            display: block;
+            margin: 0 auto;
+        }
 
         .social-name {
             font-family: var(--mono);
@@ -576,7 +685,11 @@
             margin-bottom: 2px;
         }
 
-        .social-handle { font-size: 11px; font-weight: 600; color: var(--dark); }
+        .social-handle {
+            font-size: 11px;
+            font-weight: 600;
+            color: var(--dark);
+        }
 
         /* ── CTA ── */
         .cta-block {
@@ -594,14 +707,28 @@
             width: 200px;
             height: 200px;
             border-radius: 50%;
-            background: radial-gradient(circle, rgba(255,87,87,0.3) 0%, transparent 70%);
+            background: radial-gradient(circle, rgba(255, 87, 87, 0.3) 0%, transparent 70%);
             top: -60px;
             right: -60px;
             pointer-events: none;
         }
 
-        .cta-title { font-size: 20px; font-weight: 800; color: white; margin-bottom: 6px; position: relative; }
-        .cta-sub { font-size: 13px; color: #aaa; margin-bottom: 14px; line-height: 1.5; position: relative; }
+        .cta-title {
+            font-size: 20px;
+            font-weight: 800;
+            color: white;
+            margin-bottom: 6px;
+            position: relative;
+        }
+
+        .cta-sub {
+            font-size: 13px;
+            color: #aaa;
+            margin-bottom: 14px;
+            line-height: 1.5;
+            position: relative;
+        }
+
         .cta-link {
             display: inline-block;
             background: var(--red);
@@ -616,7 +743,11 @@
         }
 
         /* ── COMPACT TWO-COL ── */
-        .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+        .two-col {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 16px;
+        }
 
         /* ── SALARY / STACK TABLE ── */
         .stack-table {
@@ -646,8 +777,16 @@
             line-height: 1.4;
         }
 
-        .stack-table tr:last-child td { border-bottom: none; }
-        .stack-table td:first-child { font-family: var(--mono); font-size: 11px; font-weight: 700; color: var(--red); }
+        .stack-table tr:last-child td {
+            border-bottom: none;
+        }
+
+        .stack-table td:first-child {
+            font-family: var(--mono);
+            font-size: 11px;
+            font-weight: 700;
+            color: var(--red);
+        }
 
         /* ── MOBILE ── */
         @media (max-width: 600px) {
@@ -666,10 +805,13 @@
                 position: sticky;
                 top: 0;
                 z-index: 100;
-                box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+                box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
             }
 
-            .print-btn { width: 100%; justify-content: center; }
+            .print-btn {
+                width: 100%;
+                justify-content: center;
+            }
 
             .page {
                 width: 100%;
@@ -679,45 +821,104 @@
                 overflow: visible;
             }
 
-            .page + .page { margin-top: 8px; }
+            .page+.page {
+                margin-top: 8px;
+            }
 
-            .cover { height: auto; }
+            .cover {
+                height: auto;
+            }
 
-            .cover-header { padding: 20px 20px 0; }
+            .cover-header {
+                padding: 20px 20px 0;
+            }
 
             .cover-hero {
                 padding: 28px 20px 28px;
                 justify-content: flex-start;
             }
 
-            .cover-title { font-size: 36px; }
-            .cover-subtitle { font-size: 13px; max-width: 100%; }
+            .cover-title {
+                font-size: 36px;
+            }
 
-            .cover-quote-block { padding: 20px; max-width: 100%; }
-            .cover-quote-text { font-size: 14px; }
+            .cover-subtitle {
+                font-size: 13px;
+                max-width: 100%;
+            }
 
-            .cover-stats { gap: 16px; flex-wrap: wrap; }
-            .stat-num { font-size: 24px; }
+            .cover-quote-block {
+                padding: 20px;
+                max-width: 100%;
+            }
 
-            .cover-footer { padding: 14px 20px; flex-wrap: wrap; }
+            .cover-quote-text {
+                font-size: 14px;
+            }
 
-            .inner-page { height: auto; }
+            .cover-stats {
+                gap: 16px;
+                flex-wrap: wrap;
+            }
 
-            .page-header { padding: 14px 20px 12px; }
-            .page-body { padding: 20px 20px; }
-            .page-footer { padding: 12px 20px; }
+            .stat-num {
+                font-size: 24px;
+            }
 
-            .section-title { font-size: 20px; }
-            .step-content { padding: 2px 0 16px 12px; }
+            .cover-footer {
+                padding: 14px 20px;
+                flex-wrap: wrap;
+            }
 
-            .skills-row { grid-template-columns: 1fr; gap: 16px; }
-            .resource-grid { grid-template-columns: 1fr; }
-            .two-col { grid-template-columns: 1fr; }
+            .inner-page {
+                height: auto;
+            }
 
-            .socials-grid { grid-template-columns: repeat(3, 1fr); gap: 8px; }
-            .social-card { padding: 10px 8px; }
+            .page-header {
+                padding: 14px 20px 12px;
+            }
 
-            .page-num { display: none; }
+            .page-body {
+                padding: 20px 20px;
+            }
+
+            .page-footer {
+                padding: 12px 20px;
+            }
+
+            .section-title {
+                font-size: 20px;
+            }
+
+            .step-content {
+                padding: 2px 0 16px 12px;
+            }
+
+            .skills-row {
+                grid-template-columns: 1fr;
+                gap: 16px;
+            }
+
+            .resource-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .two-col {
+                grid-template-columns: 1fr;
+            }
+
+            .socials-grid {
+                grid-template-columns: repeat(3, 1fr);
+                gap: 8px;
+            }
+
+            .social-card {
+                padding: 10px 8px;
+            }
+
+            .page-num {
+                display: none;
+            }
 
             .cover-decoration {
                 width: 140px;
@@ -727,12 +928,21 @@
                 transform: none;
             }
 
-            .stack-table { font-size: 11px; }
-            .stack-table th, .stack-table td { padding: 6px 8px; }
+            .stack-table {
+                font-size: 11px;
+            }
+
+            .stack-table th,
+            .stack-table td {
+                padding: 6px 8px;
+            }
         }
 
         @media print {
-            @page { size: A4 portrait; margin: 0; }
+            @page {
+                size: A4 portrait;
+                margin: 0;
+            }
 
             .resource-viewer {
                 margin: 0;
@@ -742,7 +952,9 @@
                 width: 210mm;
             }
 
-            .print-bar { display: none !important; }
+            .print-bar {
+                display: none !important;
+            }
 
             .page {
                 width: 210mm;
@@ -755,7 +967,9 @@
                 overflow: hidden;
             }
 
-            .page + .page { margin-top: 0; }
+            .page+.page {
+                margin-top: 0;
+            }
 
             .cover {
                 height: 297mm;
@@ -767,923 +981,1199 @@
                 min-height: unset;
             }
 
-            .page-body { overflow: hidden; }
+            .page-body {
+                overflow: hidden;
+            }
 
             * {
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
             }
 
-            .page:last-child { page-break-after: avoid; break-after: avoid; }
+            .page:last-child {
+                page-break-after: avoid;
+                break-after: avoid;
+            }
         }
     </style>
 </head>
 
 <body>
-<div class="resource-viewer">
+    <div class="resource-viewer">
 
-    <!-- PRINT BAR -->
-    <div class="print-bar">
-        <button class="print-btn" onclick="window.print()">
-            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-                <path d="M6 9V2h12v7M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2M6 14h12v8H6z"/>
-            </svg>
-            Save as PDF
-        </button>
-    </div>
-
-    <!-- ══════════════════════ PAGE 1 — COVER ══════════════════════ -->
-    <div class="page cover">
-        <div class="cover-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="cover-badge">2026 Edition</span>
+        <!-- PRINT BAR -->
+        <div class="print-bar">
+            <button class="print-btn" onclick="window.print()">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                    <path
+                        d="M6 9V2h12v7M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2M6 14h12v8H6z" />
+                </svg>
+                Save as PDF
+            </button>
         </div>
 
-        <div class="cover-hero">
-            <div class="cover-decoration"></div>
-
-            <div class="cover-hook">The complete path — autonomous AI systems</div>
-
-            <h1 class="cover-title">
-                Agentic<br><span>AI</span><br>Engineer<br>Roadmap
-            </h1>
-
-            <p class="cover-subtitle">
-                From Python & LLM basics to building fully autonomous AI agents in 2026. Orchestration, tool use, memory systems, multi-agent pipelines, evals — everything you need with free YouTube resources for every phase.
-            </p>
-
-            <div class="cover-quote-block">
-                <div class="cover-quote-text">
-                    "The next wave isn't AI that answers questions. It's AI that acts, plans, and executes — end to end, without a human in the loop. The engineer who can build that is the most sought-after person in tech right now."
-                </div>
-                <div class="cover-quote-sub">— The Boring Education Team</div>
+        <!-- ══════════════════════ PAGE 1 — COVER ══════════════════════ -->
+        <div class="page cover">
+            <div class="cover-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="cover-badge">2026 Edition</span>
             </div>
 
-            <div class="cover-stats">
-                <div class="stat-item">
-                    <div class="stat-num">12–18</div>
-                    <div class="stat-label">Months to job-ready</div>
+            <div class="cover-hero">
+                <div class="cover-decoration"></div>
+
+                <div class="cover-hook">The complete path — autonomous AI systems</div>
+
+                <h1 class="cover-title">
+                    Agentic<br><span>AI</span><br>Engineer<br>Roadmap
+                </h1>
+
+                <p class="cover-subtitle">
+                    From Python & LLM basics to building fully autonomous AI agents in 2026. Orchestration, tool use,
+                    memory systems, multi-agent pipelines, evals — everything you need with free YouTube resources for
+                    every phase.
+                </p>
+
+                <div class="cover-quote-block">
+                    <div class="cover-quote-text">
+                        "The next wave isn't AI that answers questions. It's AI that acts, plans, and executes — end to
+                        end, without a human in the loop. The engineer who can build that is the most sought-after
+                        person in tech right now."
+                    </div>
+                    <div class="cover-quote-sub">— The Boring Education Team</div>
                 </div>
-                <div class="stat-item">
-                    <div class="stat-num">11</div>
-                    <div class="stat-label">Phases to master</div>
+
+                <div class="cover-stats">
+                    <div class="stat-item">
+                        <div class="stat-num">12–18</div>
+                        <div class="stat-label">Months to job-ready</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-num">11</div>
+                        <div class="stat-label">Phases to master</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-num">50+</div>
+                        <div class="stat-label">Free YT resources</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-num">∞</div>
+                        <div class="stat-label">Career ceiling</div>
+                    </div>
                 </div>
-                <div class="stat-item">
-                    <div class="stat-num">50+</div>
-                    <div class="stat-label">Free YT resources</div>
-                </div>
-                <div class="stat-item">
-                    <div class="stat-num">∞</div>
-                    <div class="stat-label">Career ceiling</div>
-                </div>
+            </div>
+
+            <div class="cover-footer">
+                <span class="cover-footer-text">theboringeducation.com &nbsp;·&nbsp; Free Tech Education for
+                    Everyone</span>
+                <span class="page-num">01</span>
             </div>
         </div>
 
-        <div class="cover-footer">
-            <span class="cover-footer-text">theboringeducation.com &nbsp;·&nbsp; Free Tech Education for Everyone</span>
-            <span class="page-num">01</span>
-        </div>
-    </div>
-
-    <!-- ══════════════════════ PAGE 2 — PHASES 1–3 ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Agentic AI Engineer Roadmap · 2026</span>
-            <span class="page-num">02</span>
-        </div>
-
-        <div class="page-body">
-            <div class="section-label">Foundation Layer</div>
-            <h2 class="section-title">Start Here — Python, LLMs & APIs</h2>
-
-            <div class="roadmap">
-
-                <!-- PHASE 1 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">1</div>
-                        <div class="step-line"></div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 1–4</div>
-                        <div class="step-phase">Phase 01 · Python for Agents</div>
-                        <div class="step-heading">Python Essentials for Agentic Development</div>
-                        <div class="step-desc">Agents are primarily written in Python. You need more than syntax — you need fluency in async programming, API design, and the ecosystem. Master <strong>async/await</strong> for non-blocking agent loops. Understand <strong>type hints, Pydantic models</strong> and data validation — LLM responses need strict schemas. Learn <strong>environment management</strong> with dotenv and secrets handling. Practice <strong>REST API consumption</strong> with httpx and requests. Understand JSON schema, function signatures, and dict manipulation — these are how agents communicate with tools.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Non-negotiable</span>
-                            <span class="tag">Python async/await</span>
-                            <span class="tag">Pydantic v2</span>
-                            <span class="tag">Type hints</span>
-                            <span class="tag">httpx / requests</span>
-                            <span class="tag">JSON schema</span>
-                            <span class="tag">dotenv / secrets</span>
-                            <span class="tag">venv / uv</span>
-                        </div>
-                        <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=rfscVS0vtbw" target="_blank">Python Full Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=t8pPdKYpowI" target="_blank">Python Async/Await – Tech With Tim</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=502XOB0u8OY" target="_blank">Pydantic v2 Crash Course – ArjanCodes</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=v-a3QTeSoJk" target="_blank">REST APIs with Python – freeCodeCamp</a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- PHASE 2 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">2</div>
-                        <div class="step-line"></div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 3–7</div>
-                        <div class="step-phase">Phase 02 · LLM Fundamentals</div>
-                        <div class="step-heading">How LLMs Work — Tokens, Attention & Context Windows</div>
-                        <div class="step-desc">You cannot build reliable agents without understanding the engine under the hood. Study <strong>tokenization</strong>: BPE, token limits, cost implications. Understand <strong>attention mechanisms</strong> and why context order matters. Learn <strong>temperature, top-p, and sampling strategies</strong> — agents need deterministic behavior (low temp), humans want creativity (high temp). Understand <strong>context windows</strong>: 8k vs 128k vs 1M — and what fits inside. Study the differences between GPT-4o, Claude 3.5, Gemini 1.5, Llama 3.1 — each has different strengths for agentic tasks. This knowledge will save you hours of debugging.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Core knowledge</span>
-                            <span class="tag">Tokenization / BPE</span>
-                            <span class="tag">Attention mechanism</span>
-                            <span class="tag">Context windows</span>
-                            <span class="tag">Temperature / top-p</span>
-                            <span class="tag">GPT-4o / Claude 3.5</span>
-                            <span class="tag">Llama 3.1 / Mistral</span>
-                            <span class="tag">Model benchmarking</span>
-                        </div>
-                        <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=aircAruvnKk" target="_blank">Neural Networks – 3Blue1Brown</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=4Bdc55j80l8" target="_blank">Transformers from Scratch – Andrej Karpathy</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=T-D1OfcDW1M" target="_blank">LLMs from Scratch – Andrej Karpathy</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=zjkBMFhNj_g" target="_blank">Intro to LLMs – Andrej Karpathy</a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- PHASE 3 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">3</div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 5–10</div>
-                        <div class="step-phase">Phase 03 · Prompt Engineering</div>
-                        <div class="step-heading">Advanced Prompting — The Backbone of Every Agent</div>
-                        <div class="step-desc">Prompt engineering is not just "write a good sentence." For agents, it is system design. Master <strong>system prompts</strong>: role definition, persona, constraints, output format. Learn <strong>few-shot prompting</strong>: 3–5 examples in-context dramatically improve reliability. Study <strong>Chain-of-Thought (CoT)</strong>: forcing step-by-step reasoning reduces hallucinations by 40–60%. Understand <strong>ReAct pattern</strong> (Reason + Act): the primary loop used in all production agents. Learn prompt injection defense — a critical security skill. Practice <strong>output structuring</strong>: JSON-mode, XML tags, and function-calling schemas. Reliable prompting = reliable agents.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Agent backbone</span>
-                            <span class="tag">System prompts</span>
-                            <span class="tag">Few-shot prompting</span>
-                            <span class="tag">Chain-of-Thought</span>
-                            <span class="tag">ReAct pattern</span>
-                            <span class="tag">JSON / XML output</span>
-                            <span class="tag">Prompt injection</span>
-                            <span class="tag">Function calling</span>
-                        </div>
-                        <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=dOxUroR57xs" target="_blank">Prompt Engineering Guide – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=_ZvnD73m40o" target="_blank">Advanced Prompting – Andrej Karpathy</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=bZQun8Y4L2A" target="_blank">Chain-of-Thought Prompting – AI Explained</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=zt_RBDHE9JE" target="_blank">Function Calling Explained – Fireship</a>
-                        </div>
-                    </div>
-                </div>
-
+        <!-- ══════════════════════ PAGE 2 — PHASES 1–3 ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Agentic AI Engineer Roadmap · 2026</span>
+                <span class="page-num">02</span>
             </div>
 
-            <div style="margin-top:16px;">
+            <div class="page-body">
+                <div class="section-label">Foundation Layer</div>
+                <h2 class="section-title">Start Here — Python, LLMs & APIs</h2>
+
+                <div class="roadmap">
+
+                    <!-- PHASE 1 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">1</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 1–4</div>
+                            <div class="step-phase">Phase 01 · Python for Agents</div>
+                            <div class="step-heading">Python Essentials for Agentic Development</div>
+                            <div class="step-desc">Agents are primarily written in Python. You need more than syntax —
+                                you need fluency in async programming, API design, and the ecosystem. Master
+                                <strong>async/await</strong> for non-blocking agent loops. Understand <strong>type
+                                    hints, Pydantic models</strong> and data validation — LLM responses need strict
+                                schemas. Learn <strong>environment management</strong> with dotenv and secrets handling.
+                                Practice <strong>REST API consumption</strong> with httpx and requests. Understand JSON
+                                schema, function signatures, and dict manipulation — these are how agents communicate
+                                with tools.</div>
+                            <div class="step-tags">
+                                <span class="tag red">Non-negotiable</span>
+                                <span class="tag">Python async/await</span>
+                                <span class="tag">Pydantic v2</span>
+                                <span class="tag">Type hints</span>
+                                <span class="tag">httpx / requests</span>
+                                <span class="tag">JSON schema</span>
+                                <span class="tag">dotenv / secrets</span>
+                                <span class="tag">venv / uv</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Python%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Python Full Course – freeCodeCamp</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Python%20Async%2FAwait%20%E2%80%93%20Tech%20With%20Tim"
+                                    target="_blank">Python Async/Await – Tech With Tim</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Pydantic%20v2%20Crash%20Course%20%E2%80%93%20ArjanCodes"
+                                    target="_blank">Pydantic v2 Crash Course – ArjanCodes</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=REST%20APIs%20with%20Python%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">REST APIs with Python – freeCodeCamp</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- PHASE 2 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">2</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 3–7</div>
+                            <div class="step-phase">Phase 02 · LLM Fundamentals</div>
+                            <div class="step-heading">How LLMs Work — Tokens, Attention & Context Windows</div>
+                            <div class="step-desc">You cannot build reliable agents without understanding the engine
+                                under the hood. Study <strong>tokenization</strong>: BPE, token limits, cost
+                                implications. Understand <strong>attention mechanisms</strong> and why context order
+                                matters. Learn <strong>temperature, top-p, and sampling strategies</strong> — agents
+                                need deterministic behavior (low temp), humans want creativity (high temp). Understand
+                                <strong>context windows</strong>: 8k vs 128k vs 1M — and what fits inside. Study the
+                                differences between GPT-4o, Claude 3.5, Gemini 1.5, Llama 3.1 — each has different
+                                strengths for agentic tasks. This knowledge will save you hours of debugging.</div>
+                            <div class="step-tags">
+                                <span class="tag red">Core knowledge</span>
+                                <span class="tag">Tokenization / BPE</span>
+                                <span class="tag">Attention mechanism</span>
+                                <span class="tag">Context windows</span>
+                                <span class="tag">Temperature / top-p</span>
+                                <span class="tag">GPT-4o / Claude 3.5</span>
+                                <span class="tag">Llama 3.1 / Mistral</span>
+                                <span class="tag">Model benchmarking</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Neural%20Networks%20%E2%80%93%203Blue1Brown"
+                                    target="_blank">Neural Networks – 3Blue1Brown</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Transformers%20from%20Scratch%20%E2%80%93%20Andrej%20Karpathy"
+                                    target="_blank">Transformers from Scratch – Andrej Karpathy</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=LLMs%20from%20Scratch%20%E2%80%93%20Andrej%20Karpathy"
+                                    target="_blank">LLMs from Scratch – Andrej Karpathy</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Intro%20to%20LLMs%20%E2%80%93%20Andrej%20Karpathy"
+                                    target="_blank">Intro to LLMs – Andrej Karpathy</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- PHASE 3 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">3</div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 5–10</div>
+                            <div class="step-phase">Phase 03 · Prompt Engineering</div>
+                            <div class="step-heading">Advanced Prompting — The Backbone of Every Agent</div>
+                            <div class="step-desc">Prompt engineering is not just "write a good sentence." For agents,
+                                it is system design. Master <strong>system prompts</strong>: role definition, persona,
+                                constraints, output format. Learn <strong>few-shot prompting</strong>: 3–5 examples
+                                in-context dramatically improve reliability. Study <strong>Chain-of-Thought
+                                    (CoT)</strong>: forcing step-by-step reasoning reduces hallucinations by 40–60%.
+                                Understand <strong>ReAct pattern</strong> (Reason + Act): the primary loop used in all
+                                production agents. Learn prompt injection defense — a critical security skill. Practice
+                                <strong>output structuring</strong>: JSON-mode, XML tags, and function-calling schemas.
+                                Reliable prompting = reliable agents.</div>
+                            <div class="step-tags">
+                                <span class="tag red">Agent backbone</span>
+                                <span class="tag">System prompts</span>
+                                <span class="tag">Few-shot prompting</span>
+                                <span class="tag">Chain-of-Thought</span>
+                                <span class="tag">ReAct pattern</span>
+                                <span class="tag">JSON / XML output</span>
+                                <span class="tag">Prompt injection</span>
+                                <span class="tag">Function calling</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Prompt%20Engineering%20Guide%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Prompt Engineering Guide – freeCodeCamp</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Advanced%20Prompting%20%E2%80%93%20Andrej%20Karpathy"
+                                    target="_blank">Advanced Prompting – Andrej Karpathy</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Chain-of-Thought%20Prompting%20%E2%80%93%20AI%20Explained"
+                                    target="_blank">Chain-of-Thought Prompting – AI Explained</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Function%20Calling%20Explained%20%E2%80%93%20Fireship"
+                                    target="_blank">Function Calling Explained – Fireship</a>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+
+                <div style="margin-top:16px;">
+                    <div class="tip-block">
+                        <div class="tip-icon">🤖</div>
+                        <div class="tip-text"><strong>Agents are only as smart as their prompts.</strong> A poorly
+                            structured system prompt turns a GPT-4 agent into a confused mess. A brilliant system prompt
+                            makes a GPT-3.5 agent perform like GPT-4. Master prompting before you touch any framework —
+                            it's the multiplier on everything else.</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">02 / 08</span>
+            </div>
+        </div>
+
+        <!-- ══════════════════════ PAGE 3 — PHASES 4–5 ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Agentic AI Engineer Roadmap · 2026</span>
+                <span class="page-num">03</span>
+            </div>
+
+            <div class="page-body">
+                <div class="section-label">Tool Use & Memory Systems</div>
+                <h2 class="section-title">Function Calling, RAG & Agent Memory</h2>
+
+                <div class="roadmap">
+
+                    <!-- PHASE 4 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">4</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 8–14</div>
+                            <div class="step-phase">Phase 04 · Tool Use & Function Calling</div>
+                            <div class="step-heading">Giving Agents Hands — Tools, APIs & the Real World</div>
+                            <div class="step-desc">An agent without tools is just a chatbot. Tool use is what makes
+                                agents <em>act</em>. Learn <strong>OpenAI function calling</strong> and
+                                <strong>Anthropic tool use</strong> — define JSON schemas, handle tool results, manage
+                                multi-turn tool loops. Build your own tools: <strong>web search</strong> (Tavily, Serper
+                                API), <strong>code execution</strong> (E2B sandboxes, Python REPL), <strong>file
+                                    I/O</strong>, <strong>browser automation</strong> (Playwright, Puppeteer),
+                                <strong>database queries</strong>, and <strong>external API calls</strong>. Understand
+                                <strong>tool selection strategy</strong>: how to design tool schemas so LLMs reliably
+                                pick the right tool. Study <strong>parallel tool execution</strong> for speed. Learn
+                                error handling when tools fail — agents must retry gracefully.</div>
+                            <div class="step-tags">
+                                <span class="tag red">What makes agents agents</span>
+                                <span class="tag">Function calling</span>
+                                <span class="tag">Anthropic tool use</span>
+                                <span class="tag">Tavily / Serper</span>
+                                <span class="tag">E2B code sandbox</span>
+                                <span class="tag">Playwright</span>
+                                <span class="tag">Parallel tool use</span>
+                                <span class="tag">Error recovery</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Function%20Calling%20Deep%20Dive%20%E2%80%93%20Fireship"
+                                    target="_blank">Function Calling Deep Dive – Fireship</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=OpenAI%20Tools%20Tutorial%20%E2%80%93%20Patrick%20Loeber"
+                                    target="_blank">OpenAI Tools Tutorial – Patrick Loeber</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Playwright%20Python%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Playwright Python – freeCodeCamp</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Tool-using%20Agents%20%E2%80%93%20LangChain"
+                                    target="_blank">Tool-using Agents – LangChain</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=E2B%20Code%20Execution%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">E2B Code Execution – freeCodeCamp</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- PHASE 5 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">5</div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 10–18</div>
+                            <div class="step-phase">Phase 05 · RAG & Agent Memory</div>
+                            <div class="step-heading">Memory Architecture — Short-Term, Long-Term & Semantic Search
+                            </div>
+                            <div class="step-desc">Agents without memory are amnesiac. Build all four memory types:
+                                <strong>In-context memory</strong> (conversation history in the prompt window — simple
+                                but limited), <strong>External memory</strong> via vector databases (Pinecone, Qdrant,
+                                ChromaDB) for semantic search over docs/chat history, <strong>Episodic memory</strong>
+                                (storing past task outcomes for future reference), and <strong>Procedural
+                                    memory</strong> (system prompts encoding skills and behaviors). Master the full
+                                <strong>RAG pipeline</strong>: chunking strategies, embedding models (OpenAI
+                                text-embedding-3, BGE, Nomic), vector DB indexing, hybrid search (dense + sparse), and
+                                <strong>re-ranking</strong> with Cohere Rerank or BGE. Build a memory manager that
+                                decides what to store, retrieve, and forget.</div>
+                            <div class="step-tags">
+                                <span class="tag red">Core architecture</span>
+                                <span class="tag">Vector DBs (Qdrant)</span>
+                                <span class="tag">Embedding models</span>
+                                <span class="tag">Hybrid search</span>
+                                <span class="tag">Chunking strategies</span>
+                                <span class="tag">Re-ranking</span>
+                                <span class="tag">Episodic memory</span>
+                                <span class="tag">Mem0 / Zep</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=RAG%20Tutorial%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">RAG Tutorial – freeCodeCamp</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Vector%20DBs%20Explained%20%E2%80%93%20Fireship"
+                                    target="_blank">Vector DBs Explained – Fireship</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Advanced%20RAG%20Techniques%20%E2%80%93%20Hugging%20Face"
+                                    target="_blank">Advanced RAG Techniques – Hugging Face</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Hybrid%20Search%20%26%20Reranking%20%E2%80%93%20James%20Briggs"
+                                    target="_blank">Hybrid Search & Reranking – James Briggs</a>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+
+                <hr class="divider">
+
                 <div class="tip-block">
-                    <div class="tip-icon">🤖</div>
-                    <div class="tip-text"><strong>Agents are only as smart as their prompts.</strong> A poorly structured system prompt turns a GPT-4 agent into a confused mess. A brilliant system prompt makes a GPT-3.5 agent perform like GPT-4. Master prompting before you touch any framework — it's the multiplier on everything else.</div>
+                    <div class="tip-icon">🧠</div>
+                    <div class="tip-text"><strong>Memory is your agent's biggest lever.</strong> The difference between
+                        a toy demo and a production agent is almost always memory design. How does your agent remember
+                        what it did last week? What it learned about the user? Use Mem0 or build a custom memory layer —
+                        but build something. Stateless agents don't survive contact with real users.</div>
                 </div>
+
+                <div style="margin-top:14px;">
+                    <div class="section-label">Memory Architecture Comparison</div>
+                    <table class="stack-table">
+                        <thead>
+                            <tr>
+                                <th>Memory Type</th>
+                                <th>Storage</th>
+                                <th>Best For</th>
+                                <th>Tools</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>In-Context</td>
+                                <td>LLM context window</td>
+                                <td>Short conversation history, few recent facts</td>
+                                <td>Message array, summarization</td>
+                            </tr>
+                            <tr>
+                                <td>Semantic (Vector)</td>
+                                <td>Vector database</td>
+                                <td>Docs, knowledge base, past conversations</td>
+                                <td>Qdrant, Pinecone, ChromaDB</td>
+                            </tr>
+                            <tr>
+                                <td>Episodic</td>
+                                <td>SQL / NoSQL DB</td>
+                                <td>Past task outcomes, user preferences</td>
+                                <td>Postgres, MongoDB, Mem0</td>
+                            </tr>
+                            <tr>
+                                <td>Procedural</td>
+                                <td>System prompt / config</td>
+                                <td>Agent persona, skills, behavioral rules</td>
+                                <td>Hardcoded prompts, dynamic prompt builders</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">03 / 08</span>
             </div>
         </div>
 
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">02 / 08</span>
-        </div>
-    </div>
+        <!-- ══════════════════════ PAGE 4 — PHASES 6–7 ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Agentic AI Engineer Roadmap · 2026</span>
+                <span class="page-num">04</span>
+            </div>
 
-    <!-- ══════════════════════ PAGE 3 — PHASES 4–5 ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Agentic AI Engineer Roadmap · 2026</span>
-            <span class="page-num">03</span>
-        </div>
+            <div class="page-body">
+                <div class="section-label">Agent Frameworks & Orchestration</div>
+                <h2 class="section-title">LangChain, LangGraph, AutoGen & Beyond</h2>
 
-        <div class="page-body">
-            <div class="section-label">Tool Use & Memory Systems</div>
-            <h2 class="section-title">Function Calling, RAG & Agent Memory</h2>
+                <div class="roadmap">
 
-            <div class="roadmap">
-
-                <!-- PHASE 4 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">4</div>
-                        <div class="step-line"></div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 8–14</div>
-                        <div class="step-phase">Phase 04 · Tool Use & Function Calling</div>
-                        <div class="step-heading">Giving Agents Hands — Tools, APIs & the Real World</div>
-                        <div class="step-desc">An agent without tools is just a chatbot. Tool use is what makes agents <em>act</em>. Learn <strong>OpenAI function calling</strong> and <strong>Anthropic tool use</strong> — define JSON schemas, handle tool results, manage multi-turn tool loops. Build your own tools: <strong>web search</strong> (Tavily, Serper API), <strong>code execution</strong> (E2B sandboxes, Python REPL), <strong>file I/O</strong>, <strong>browser automation</strong> (Playwright, Puppeteer), <strong>database queries</strong>, and <strong>external API calls</strong>. Understand <strong>tool selection strategy</strong>: how to design tool schemas so LLMs reliably pick the right tool. Study <strong>parallel tool execution</strong> for speed. Learn error handling when tools fail — agents must retry gracefully.</div>
-                        <div class="step-tags">
-                            <span class="tag red">What makes agents agents</span>
-                            <span class="tag">Function calling</span>
-                            <span class="tag">Anthropic tool use</span>
-                            <span class="tag">Tavily / Serper</span>
-                            <span class="tag">E2B code sandbox</span>
-                            <span class="tag">Playwright</span>
-                            <span class="tag">Parallel tool use</span>
-                            <span class="tag">Error recovery</span>
+                    <!-- PHASE 6 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">6</div>
+                            <div class="step-line"></div>
                         </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 14–22</div>
+                            <div class="step-phase">Phase 06 · Agent Frameworks</div>
+                            <div class="step-heading">LangChain, LangGraph, LlamaIndex & the Orchestration Layer</div>
+                            <div class="step-desc">Frameworks abstract the hard parts so you can focus on logic. Start
+                                with <strong>LangChain</strong>: chains, agents, tools, memory, callbacks — it's the
+                                most popular and has the most tutorials. Then master <strong>LangGraph</strong> — the
+                                graph-based successor for stateful agent workflows. LangGraph models agents as directed
+                                graphs with nodes (LLM calls/tools) and edges (conditional routing). Learn
+                                <strong>LlamaIndex</strong> for data-heavy agents: document ingestion, query engines,
+                                sub-question decomposition, and agentic RAG. Study <strong>LangSmith</strong> for
+                                tracing and debugging agent runs — you cannot debug an agent without observability.
+                                Understand when to use frameworks vs. building from scratch (LangGraph for complex
+                                state, raw API calls for simple agents).</div>
+                            <div class="step-tags">
+                                <span class="tag red">Orchestration layer</span>
+                                <span class="tag">LangChain v0.3</span>
+                                <span class="tag">LangGraph</span>
+                                <span class="tag">LlamaIndex</span>
+                                <span class="tag">LangSmith tracing</span>
+                                <span class="tag">Stateful graphs</span>
+                                <span class="tag">Conditional routing</span>
+                                <span class="tag">Agent observability</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=LangChain%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">LangChain Full Course – freeCodeCamp</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=LangGraph%20Tutorial%20%E2%80%93%20LangChain"
+                                    target="_blank">LangGraph Tutorial – LangChain</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=LlamaIndex%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">LlamaIndex Full Course – freeCodeCamp</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=LangSmith%20Debugging%20%E2%80%93%20LangChain"
+                                    target="_blank">LangSmith Debugging – LangChain</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Agentic%20RAG%20with%20LlamaIndex%20%E2%80%93%20AI%20Jason"
+                                    target="_blank">Agentic RAG with LlamaIndex – AI Jason</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- PHASE 7 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">7</div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 18–26</div>
+                            <div class="step-phase">Phase 07 · Multi-Agent Systems</div>
+                            <div class="step-heading">Multi-Agent Orchestration — CrewAI, AutoGen & Agent Networks</div>
+                            <div class="step-desc">The most powerful agentic systems use multiple specialized agents
+                                working together. Study <strong>CrewAI</strong>: define agents with roles, goals, and
+                                backstories; assign tasks; let a crew collaborate hierarchically or sequentially. Learn
+                                <strong>Microsoft AutoGen</strong>: conversational multi-agent patterns, group chats,
+                                code-execution agents. Understand <strong>agent roles</strong>: Planner, Executor,
+                                Critic, Summarizer — classic division of labor. Master <strong>inter-agent communication
+                                    protocols</strong>: how agents pass structured messages vs free-form conversation.
+                                Study <strong>supervisor patterns</strong>: one LLM orchestrating a team of specialized
+                                sub-agents. Learn when multi-agent adds value vs. when a single agent loop is simpler
+                                and more reliable.</div>
+                            <div class="step-tags">
+                                <span class="tag red">Multi-agent systems</span>
+                                <span class="tag">CrewAI</span>
+                                <span class="tag">AutoGen</span>
+                                <span class="tag">Agent roles</span>
+                                <span class="tag">Supervisor pattern</span>
+                                <span class="tag">Message passing</span>
+                                <span class="tag">Hierarchical agents</span>
+                                <span class="tag">Swarm patterns</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=CrewAI%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">CrewAI Full Course – freeCodeCamp</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=AutoGen%20Tutorial%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">AutoGen Tutorial – freeCodeCamp</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Multi-Agent%20with%20LangGraph%20%E2%80%93%20LangChain"
+                                    target="_blank">Multi-Agent with LangGraph – LangChain</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=AI%20Agent%20Networks%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">AI Agent Networks – freeCodeCamp</a>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+
+                <hr class="divider">
+
+                <div class="tip-block">
+                    <div class="tip-icon">🕸️</div>
+                    <div class="tip-text"><strong>Start with LangGraph, not CrewAI.</strong> CrewAI is great for demos.
+                        LangGraph is what production teams actually use. It gives you fine-grained control over state,
+                        branching, and cycles — essential when an agent needs to loop, backtrack, or take conditional
+                        paths. Learn LangGraph first; everything else becomes easier.</div>
+                </div>
+
+                <div style="margin-top:14px;">
+                    <div class="section-label">Framework Comparison — When to Use What</div>
+                    <table class="stack-table">
+                        <thead>
+                            <tr>
+                                <th>Framework</th>
+                                <th>Best For</th>
+                                <th>Complexity</th>
+                                <th>Production-Ready?</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>LangGraph</td>
+                                <td>Stateful, cyclic, complex agent flows</td>
+                                <td>Medium–High</td>
+                                <td>Yes — used at scale</td>
+                            </tr>
+                            <tr>
+                                <td>LangChain</td>
+                                <td>RAG, chains, quick prototyping</td>
+                                <td>Low–Medium</td>
+                                <td>Yes with care</td>
+                            </tr>
+                            <tr>
+                                <td>LlamaIndex</td>
+                                <td>Data-heavy agents, document Q&amp;A</td>
+                                <td>Medium</td>
+                                <td>Yes for data apps</td>
+                            </tr>
+                            <tr>
+                                <td>CrewAI</td>
+                                <td>Role-based multi-agent collaboration</td>
+                                <td>Low</td>
+                                <td>Demos &amp; MVPs</td>
+                            </tr>
+                            <tr>
+                                <td>AutoGen</td>
+                                <td>Code-executing multi-agent conversations</td>
+                                <td>Medium</td>
+                                <td>Research &amp; internal tools</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">04 / 08</span>
+            </div>
+        </div>
+
+        <!-- ══════════════════════ PAGE 5 — PHASES 8–9 ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Agentic AI Engineer Roadmap · 2026</span>
+                <span class="page-num">05</span>
+            </div>
+
+            <div class="page-body">
+                <div class="section-label">Evaluation, Safety & Production</div>
+                <h2 class="section-title">Evals, Guardrails & Deploying Agents at Scale</h2>
+
+                <div class="roadmap">
+
+                    <!-- PHASE 8 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">8</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 20–28</div>
+                            <div class="step-phase">Phase 08 · Agent Evaluation & Testing</div>
+                            <div class="step-heading">Evals — The Discipline That Separates Hobbyists from Engineers
+                            </div>
+                            <div class="step-desc">You cannot ship agents without systematic evaluation. Most people
+                                skip this — it's why most agents fail in production. Build <strong>unit evals</strong>:
+                                test individual LLM calls with expected outputs. Build <strong>end-to-end
+                                    evals</strong>: does the full agent task succeed? Learn
+                                <strong>LLM-as-judge</strong>: use GPT-4 to score agent outputs on criteria like
+                                accuracy, helpfulness, safety, and format adherence. Use <strong>RAGAS</strong> for RAG
+                                evaluation: faithfulness, answer relevancy, context precision, recall. Learn
+                                <strong>Braintrust</strong>, <strong>LangSmith evals</strong>, and <strong>Weights &
+                                    Biases Weave</strong> for structured eval pipelines. Build a <strong>regression test
+                                    suite</strong> — every time you change a prompt or model, run your evals. Agents
+                                without evals degrade silently.</div>
+                            <div class="step-tags">
+                                <span class="tag red">Ship-or-fail gate</span>
+                                <span class="tag">LLM-as-judge</span>
+                                <span class="tag">RAGAS</span>
+                                <span class="tag">Braintrust</span>
+                                <span class="tag">LangSmith evals</span>
+                                <span class="tag">W&B Weave</span>
+                                <span class="tag">Unit evals</span>
+                                <span class="tag">Regression tests</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Agent%20Evals%20with%20LangSmith%20%E2%80%93%20LangChain"
+                                    target="_blank">Agent Evals with LangSmith – LangChain</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=RAGAS%20RAG%20Evaluation%20%E2%80%93%20James%20Briggs"
+                                    target="_blank">RAGAS RAG Evaluation – James Briggs</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=LLM-as-Judge%20Pattern%20%E2%80%93%20Weights%20%26%20Biases"
+                                    target="_blank">LLM-as-Judge Pattern – Weights & Biases</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Agent%20Testing%20Strategies%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Agent Testing Strategies – freeCodeCamp</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- PHASE 9 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">9</div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 24–34</div>
+                            <div class="step-phase">Phase 09 · Agent Safety & Guardrails</div>
+                            <div class="step-heading">Guardrails, Prompt Injection Defense & Responsible Agents</div>
+                            <div class="step-desc">Autonomous agents can cause real-world harm — they can delete data,
+                                send emails, make purchases, execute code. Safety is not optional. Learn
+                                <strong>input/output guardrails</strong> with NeMo Guardrails and Guardrails AI:
+                                validate LLM inputs/outputs against policy rules. Study <strong>prompt injection
+                                    attacks</strong>: malicious content in tool results or user inputs hijacking agent
+                                behavior — this is the SQL injection of the agent era. Learn
+                                <strong>sandboxing</strong>: never let agents execute code outside a contained
+                                environment (E2B, Docker). Implement <strong>human-in-the-loop (HITL)</strong> for
+                                high-stakes actions: confirm before sending emails, deleting files, or spending money.
+                                Study <strong>principle of least privilege</strong> for agent tool access. Learn
+                                <strong>Constitutional AI</strong> principles for alignment.</div>
+                            <div class="step-tags">
+                                <span class="tag red">Non-negotiable for prod</span>
+                                <span class="tag">NeMo Guardrails</span>
+                                <span class="tag">Guardrails AI</span>
+                                <span class="tag">Prompt injection</span>
+                                <span class="tag">E2B sandboxing</span>
+                                <span class="tag">HITL pattern</span>
+                                <span class="tag">Least privilege</span>
+                                <span class="tag">Constitutional AI</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=NeMo%20Guardrails%20%E2%80%93%20NVIDIA"
+                                    target="_blank">NeMo Guardrails – NVIDIA</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Agent%20Safety%20Patterns%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Agent Safety Patterns – freeCodeCamp</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Prompt%20Injection%20Attacks%20%E2%80%93%20Simon%20Willison"
+                                    target="_blank">Prompt Injection Attacks – Simon Willison</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Human-in-the-Loop%20Agents%20%E2%80%93%20LangGraph"
+                                    target="_blank">Human-in-the-Loop Agents – LangGraph</a>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+
+                <hr class="divider">
+
+                <div class="section-label">Agentic Design Patterns — The Core Patterns Every Engineer Must Know</div>
+
+                <div class="resource-grid">
+                    <div class="resource-card">
+                        <div class="resource-card-name">🔁 ReAct Loop</div>
+                        <div class="resource-card-desc">Reason → Act → Observe → Repeat. The fundamental agent loop. LLM
+                            reasons about what to do, executes a tool, observes the result, then reasons again. Used in
+                            nearly every production agent.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=zt_RBDHE9JE" target="_blank">Function Calling Deep Dive – Fireship</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=_9pFGdGXL5s" target="_blank">OpenAI Tools Tutorial – Patrick Loeber</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=Ix9WIZpArm0" target="_blank">Playwright Python – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=vFnb6F7Qe7U" target="_blank">Tool-using Agents – LangChain</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=E2shqsYwxck" target="_blank">E2B Code Execution – freeCodeCamp</a>
+                            <a class="yt-link"
+                                href="https://www.youtube.com/results?search_query=ReAct%20Pattern%20%E2%80%93%20LangChain"
+                                target="_blank">ReAct Pattern – LangChain</a>
                         </div>
                     </div>
-                </div>
-
-                <!-- PHASE 5 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">5</div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 10–18</div>
-                        <div class="step-phase">Phase 05 · RAG & Agent Memory</div>
-                        <div class="step-heading">Memory Architecture — Short-Term, Long-Term & Semantic Search</div>
-                        <div class="step-desc">Agents without memory are amnesiac. Build all four memory types: <strong>In-context memory</strong> (conversation history in the prompt window — simple but limited), <strong>External memory</strong> via vector databases (Pinecone, Qdrant, ChromaDB) for semantic search over docs/chat history, <strong>Episodic memory</strong> (storing past task outcomes for future reference), and <strong>Procedural memory</strong> (system prompts encoding skills and behaviors). Master the full <strong>RAG pipeline</strong>: chunking strategies, embedding models (OpenAI text-embedding-3, BGE, Nomic), vector DB indexing, hybrid search (dense + sparse), and <strong>re-ranking</strong> with Cohere Rerank or BGE. Build a memory manager that decides what to store, retrieve, and forget.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Core architecture</span>
-                            <span class="tag">Vector DBs (Qdrant)</span>
-                            <span class="tag">Embedding models</span>
-                            <span class="tag">Hybrid search</span>
-                            <span class="tag">Chunking strategies</span>
-                            <span class="tag">Re-ranking</span>
-                            <span class="tag">Episodic memory</span>
-                            <span class="tag">Mem0 / Zep</span>
-                        </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">🌳 Plan-and-Execute</div>
+                        <div class="resource-card-desc">Planner LLM breaks a complex goal into subtasks upfront.
+                            Executor agents complete each step. More reliable for long-horizon tasks than pure ReAct.
+                            Used in OpenAI's deep research.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=sVcwVQRHIc8" target="_blank">RAG Tutorial – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=Yhtjd7yGGGA" target="_blank">Vector DBs Explained – Fireship</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=eTieetk2dSw" target="_blank">Advanced RAG Techniques – Hugging Face</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=qN_2fnOPY-M" target="_blank">Hybrid Search & Reranking – James Briggs</a>
+                            <a class="yt-link"
+                                href="https://www.youtube.com/results?search_query=Plan%20%26%20Execute%20%E2%80%93%20LangGraph"
+                                target="_blank">Plan & Execute – LangGraph</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">🔍 Reflection Pattern</div>
+                        <div class="resource-card-desc">Agent generates a draft, a critic agent reviews it, the
+                            generator revises. Iterative self-improvement. Dramatically improves output quality for
+                            writing, code, and research tasks.</div>
+                        <div class="yt-links">
+                            <a class="yt-link"
+                                href="https://www.youtube.com/results?search_query=Reflection%20Agents%20%E2%80%93%20freeCodeCamp"
+                                target="_blank">Reflection Agents – freeCodeCamp</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">🧩 Subagent Delegation</div>
+                        <div class="resource-card-desc">Orchestrator agent routes subtasks to specialized agents (a
+                            coding agent, a research agent, a writing agent). Each expert agent has its own tools and
+                            context. The supervisor pattern in practice.</div>
+                        <div class="yt-links">
+                            <a class="yt-link"
+                                href="https://www.youtube.com/results?search_query=Subagents%20%E2%80%93%20AutoGen"
+                                target="_blank">Subagents – AutoGen</a>
                         </div>
                     </div>
                 </div>
-
             </div>
 
-            <hr class="divider">
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">05 / 08</span>
+            </div>
+        </div>
 
-            <div class="tip-block">
-                <div class="tip-icon">🧠</div>
-                <div class="tip-text"><strong>Memory is your agent's biggest lever.</strong> The difference between a toy demo and a production agent is almost always memory design. How does your agent remember what it did last week? What it learned about the user? Use Mem0 or build a custom memory layer — but build something. Stateless agents don't survive contact with real users.</div>
+        <!-- ══════════════════════ PAGE 6 — PHASES 10–11 ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Agentic AI Engineer Roadmap · 2026</span>
+                <span class="page-num">06</span>
             </div>
 
-            <div style="margin-top:14px;">
-                <div class="section-label">Memory Architecture Comparison</div>
+            <div class="page-body">
+                <div class="section-label">Deployment & Specialization</div>
+                <h2 class="section-title">Shipping Agents to Production & Specialization Tracks</h2>
+
+                <div class="roadmap">
+
+                    <!-- PHASE 10 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">10</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 26–36</div>
+                            <div class="step-phase">Phase 10 · Production Deployment</div>
+                            <div class="step-heading">Serving Agents — FastAPI, Streaming, Queues & Monitoring</div>
+                            <div class="step-desc">Building an agent that works in a notebook is 20% of the job. Deploy
+                                it: serve agents as <strong>streaming REST APIs</strong> with FastAPI — SSE (Server-Sent
+                                Events) for real-time token streaming to frontend clients. Use <strong>task
+                                    queues</strong> (Celery + Redis, or BullMQ) for async long-running agent tasks that
+                                can't block an HTTP request. Learn <strong>containerization</strong> with Docker —
+                                package your agent + dependencies. Deploy on <strong>Cloud Run, Railway, Fly.io</strong>
+                                for managed serverless. Add <strong>observability</strong>: structured logging with
+                                Loguru, tracing with LangSmith/Langfuse, metrics with Prometheus. Monitor
+                                <strong>latency, token usage, and cost per agent run</strong>. Set up alerts for agent
+                                failures. Study <strong>rate limiting and cost controls</strong> — uncapped agents can
+                                burn $1000s in minutes.</div>
+                            <div class="step-tags">
+                                <span class="tag red">Production essentials</span>
+                                <span class="tag">FastAPI + SSE streaming</span>
+                                <span class="tag">Celery + Redis</span>
+                                <span class="tag">Docker</span>
+                                <span class="tag">Cloud Run / Railway</span>
+                                <span class="tag">Langfuse</span>
+                                <span class="tag">Token cost tracking</span>
+                                <span class="tag">Rate limiting</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=FastAPI%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">FastAPI Full Course – freeCodeCamp</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Docker%20Full%20Course%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Docker Full Course – TechWorld with Nana</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Agent%20Monitoring%20%E2%80%93%20Langfuse"
+                                    target="_blank">Agent Monitoring – Langfuse</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Async%20Task%20Queues%20%E2%80%93%20DataTalks.Club"
+                                    target="_blank">Async Task Queues – DataTalks.Club</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Cloud%20Run%20Deployment%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Cloud Run Deployment – freeCodeCamp</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- PHASE 11 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">11</div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Month 9–14 (Specialization)</div>
+                            <div class="step-phase">Phase 11 · Advanced Specialization</div>
+                            <div class="step-heading">Computer-Use Agents, Fine-tuning & Frontier Systems</div>
+                            <div class="step-desc">Once you're comfortable with the full stack, specialize.
+                                <strong>Computer-Use Agents</strong>: Anthropic's Computer Use API, browser agents with
+                                Playwright/Stagehand, desktop automation — agents that can actually operate a computer
+                                like a human. <strong>Voice Agents</strong>: realtime speech pipelines with Deepgram
+                                (STT) + LLM + ElevenLabs/Cartesia (TTS) — sub-300ms latency for real conversations.
+                                <strong>Fine-tuning for agents</strong>: fine-tune Llama 3.1 or Mistral on agent
+                                trajectories (tool use examples) to improve reliability and reduce costs vs. GPT-4.
+                                Study <strong>MCP (Model Context Protocol)</strong> — Anthropic's standard for
+                                agent-tool integration. Learn <strong>OpenAI Assistants API</strong> and
+                                <strong>Responses API</strong> for managed agent infrastructure. These are the skills
+                                unlocking senior and research roles.</div>
+                            <div class="step-tags">
+                                <span class="tag red">Frontier skills</span>
+                                <span class="tag">Computer Use API</span>
+                                <span class="tag">Browser agents (Stagehand)</span>
+                                <span class="tag">Voice agents (Deepgram)</span>
+                                <span class="tag">Agent fine-tuning</span>
+                                <span class="tag">MCP protocol</span>
+                                <span class="tag">OpenAI Responses API</span>
+                                <span class="tag">Realtime API</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Computer%20Use%20Agents%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Computer Use Agents – freeCodeCamp</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Voice%20Agents%20with%20Deepgram%20%E2%80%93%20Hugging%20Face"
+                                    target="_blank">Voice Agents with Deepgram – Hugging Face</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Fine-tuning%20for%20Tool%20Use%20%E2%80%93%20Hugging%20Face"
+                                    target="_blank">Fine-tuning for Tool Use – Hugging Face</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=MCP%20Protocol%20Deep%20Dive%20%E2%80%93%20LangChain"
+                                    target="_blank">MCP Protocol Deep Dive – LangChain</a>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+
+                <hr class="divider">
+
+                <div class="section-label">Specialization Tracks — Pick Your Path</div>
                 <table class="stack-table">
                     <thead>
                         <tr>
-                            <th>Memory Type</th>
-                            <th>Storage</th>
-                            <th>Best For</th>
-                            <th>Tools</th>
+                            <th>Track</th>
+                            <th>Focus</th>
+                            <th>Key Tools</th>
+                            <th>Who's Hiring</th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr>
-                            <td>In-Context</td>
-                            <td>LLM context window</td>
-                            <td>Short conversation history, few recent facts</td>
-                            <td>Message array, summarization</td>
+                            <td>Coding Agents</td>
+                            <td>Code gen, review, debugging, repo navigation</td>
+                            <td>Code Interpreter, Tree-sitter, E2B</td>
+                            <td>Cursor, GitHub, Sourcegraph, startups</td>
                         </tr>
                         <tr>
-                            <td>Semantic (Vector)</td>
-                            <td>Vector database</td>
-                            <td>Docs, knowledge base, past conversations</td>
-                            <td>Qdrant, Pinecone, ChromaDB</td>
+                            <td>Browser / Web Agents</td>
+                            <td>Web scraping, form-filling, research automation</td>
+                            <td>Playwright, Stagehand, Computer Use</td>
+                            <td>Automation cos., enterprises, SaaS</td>
                         </tr>
                         <tr>
-                            <td>Episodic</td>
-                            <td>SQL / NoSQL DB</td>
-                            <td>Past task outcomes, user preferences</td>
-                            <td>Postgres, MongoDB, Mem0</td>
+                            <td>Voice Agents</td>
+                            <td>Real-time conversational AI, call centers</td>
+                            <td>Deepgram, ElevenLabs, LiveKit, VAD</td>
+                            <td>Retell AI, VAPI, healthcare, sales</td>
                         </tr>
                         <tr>
-                            <td>Procedural</td>
-                            <td>System prompt / config</td>
-                            <td>Agent persona, skills, behavioral rules</td>
-                            <td>Hardcoded prompts, dynamic prompt builders</td>
+                            <td>Research Agents</td>
+                            <td>Deep research, doc analysis, knowledge synthesis</td>
+                            <td>Tavily, RAG, multi-step planning</td>
+                            <td>OpenAI, Perplexity, finance, legal</td>
                         </tr>
                     </tbody>
                 </table>
             </div>
+
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">06 / 08</span>
+            </div>
         </div>
 
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">03 / 08</span>
-        </div>
-    </div>
+        <!-- ══════════════════════ PAGE 7 — SKILL MAP + PROJECTS ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Agentic AI Engineer Roadmap · 2026</span>
+                <span class="page-num">07</span>
+            </div>
 
-    <!-- ══════════════════════ PAGE 4 — PHASES 6–7 ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Agentic AI Engineer Roadmap · 2026</span>
-            <span class="page-num">04</span>
-        </div>
+            <div class="page-body">
+                <div class="section-label">Skill Map & Projects</div>
+                <h2 class="section-title">Full Timeline & Portfolio Projects to Build</h2>
 
-        <div class="page-body">
-            <div class="section-label">Agent Frameworks & Orchestration</div>
-            <h2 class="section-title">LangChain, LangGraph, AutoGen & Beyond</h2>
-
-            <div class="roadmap">
-
-                <!-- PHASE 6 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">6</div>
-                        <div class="step-line"></div>
+                <div class="skills-row">
+                    <div class="skill-col">
+                        <div class="skill-col-title">🟥 Month 1–4</div>
+                        <div class="skill-item">Python async + Pydantic</div>
+                        <div class="skill-item">LLM fundamentals + APIs</div>
+                        <div class="skill-item">Prompt engineering (CoT, ReAct)</div>
+                        <div class="skill-item">Function calling / tool use</div>
+                        <div class="skill-item">RAG pipeline basics</div>
+                        <div class="skill-item">Vector DB (Qdrant / Pinecone)</div>
+                        <div class="skill-item">LangChain fundamentals</div>
                     </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 14–22</div>
-                        <div class="step-phase">Phase 06 · Agent Frameworks</div>
-                        <div class="step-heading">LangChain, LangGraph, LlamaIndex & the Orchestration Layer</div>
-                        <div class="step-desc">Frameworks abstract the hard parts so you can focus on logic. Start with <strong>LangChain</strong>: chains, agents, tools, memory, callbacks — it's the most popular and has the most tutorials. Then master <strong>LangGraph</strong> — the graph-based successor for stateful agent workflows. LangGraph models agents as directed graphs with nodes (LLM calls/tools) and edges (conditional routing). Learn <strong>LlamaIndex</strong> for data-heavy agents: document ingestion, query engines, sub-question decomposition, and agentic RAG. Study <strong>LangSmith</strong> for tracing and debugging agent runs — you cannot debug an agent without observability. Understand when to use frameworks vs. building from scratch (LangGraph for complex state, raw API calls for simple agents).</div>
-                        <div class="step-tags">
-                            <span class="tag red">Orchestration layer</span>
-                            <span class="tag">LangChain v0.3</span>
-                            <span class="tag">LangGraph</span>
-                            <span class="tag">LlamaIndex</span>
-                            <span class="tag">LangSmith tracing</span>
-                            <span class="tag">Stateful graphs</span>
-                            <span class="tag">Conditional routing</span>
-                            <span class="tag">Agent observability</span>
-                        </div>
+                    <div class="skill-col">
+                        <div class="skill-col-title">🟧 Month 5–9</div>
+                        <div class="skill-item">LangGraph stateful agents</div>
+                        <div class="skill-item">Multi-agent (CrewAI / AutoGen)</div>
+                        <div class="skill-item">Agent memory systems (Mem0)</div>
+                        <div class="skill-item">LangSmith tracing + evals</div>
+                        <div class="skill-item">RAGAS evaluation</div>
+                        <div class="skill-item">Guardrails + prompt injection</div>
+                        <div class="skill-item">FastAPI + SSE deployment</div>
+                    </div>
+                    <div class="skill-col">
+                        <div class="skill-col-title">🟩 Month 10–18</div>
+                        <div class="skill-item">Computer-use / browser agents</div>
+                        <div class="skill-item">Voice agent pipelines</div>
+                        <div class="skill-item">Agent fine-tuning (LoRA)</div>
+                        <div class="skill-item">MCP protocol integration</div>
+                        <div class="skill-item">Cost optimization & caching</div>
+                        <div class="skill-item">Specialization track depth</div>
+                        <div class="skill-item">Published demos + blog</div>
+                    </div>
+                </div>
+
+                <hr class="divider">
+
+                <div class="section-label">Portfolio Projects — Build These 5 to Get Hired</div>
+
+                <div class="resource-grid">
+                    <div class="resource-card">
+                        <div class="resource-card-name">🔍 Deep Research Agent</div>
+                        <div class="resource-card-desc">Agent that takes a complex question, plans sub-questions,
+                            searches the web (Tavily), reads and synthesizes sources, writes a structured report with
+                            citations. Deployed as a web app with streaming output. Uses LangGraph + RAG + LangSmith
+                            evals.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=aywZrzNaKjs" target="_blank">LangChain Full Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=R8KB-Zcynxc" target="_blank">LangGraph Tutorial – LangChain</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=WB37L7PjI5k" target="_blank">LlamaIndex Full Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=NUxNM7aN4_M" target="_blank">LangSmith Debugging – LangChain</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=bZQun8Y4L2A" target="_blank">Agentic RAG with LlamaIndex – AI Jason</a>
+                            <a class="yt-link"
+                                href="https://www.youtube.com/results?search_query=RAG%20Pipeline%20%E2%80%93%20freeCodeCamp"
+                                target="_blank">RAG Pipeline – freeCodeCamp</a>
                         </div>
                     </div>
-                </div>
-
-                <!-- PHASE 7 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">7</div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 18–26</div>
-                        <div class="step-phase">Phase 07 · Multi-Agent Systems</div>
-                        <div class="step-heading">Multi-Agent Orchestration — CrewAI, AutoGen & Agent Networks</div>
-                        <div class="step-desc">The most powerful agentic systems use multiple specialized agents working together. Study <strong>CrewAI</strong>: define agents with roles, goals, and backstories; assign tasks; let a crew collaborate hierarchically or sequentially. Learn <strong>Microsoft AutoGen</strong>: conversational multi-agent patterns, group chats, code-execution agents. Understand <strong>agent roles</strong>: Planner, Executor, Critic, Summarizer — classic division of labor. Master <strong>inter-agent communication protocols</strong>: how agents pass structured messages vs free-form conversation. Study <strong>supervisor patterns</strong>: one LLM orchestrating a team of specialized sub-agents. Learn when multi-agent adds value vs. when a single agent loop is simpler and more reliable.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Multi-agent systems</span>
-                            <span class="tag">CrewAI</span>
-                            <span class="tag">AutoGen</span>
-                            <span class="tag">Agent roles</span>
-                            <span class="tag">Supervisor pattern</span>
-                            <span class="tag">Message passing</span>
-                            <span class="tag">Hierarchical agents</span>
-                            <span class="tag">Swarm patterns</span>
-                        </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">💻 Coding Assistant Agent</div>
+                        <div class="resource-card-desc">Agent that reads a GitHub repo, understands the codebase via
+                            RAG, accepts feature requests, writes code, executes it in an E2B sandbox, debugs failures,
+                            and opens a PR. The mini-Cursor. Shows you understand the full agentic coding loop.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=sPzc6hMg7So" target="_blank">CrewAI Full Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=V2qZ_lgxTzg" target="_blank">AutoGen Tutorial – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=R8KB-Zcynxc" target="_blank">Multi-Agent with LangGraph – LangChain</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=AxnL-cAM2Q8" target="_blank">AI Agent Networks – freeCodeCamp</a>
+                            <a class="yt-link"
+                                href="https://www.youtube.com/results?search_query=E2B%20Code%20Execution%20%E2%80%93%20freeCodeCamp"
+                                target="_blank">E2B Code Execution – freeCodeCamp</a>
                         </div>
                     </div>
-                </div>
-
-            </div>
-
-            <hr class="divider">
-
-            <div class="tip-block">
-                <div class="tip-icon">🕸️</div>
-                <div class="tip-text"><strong>Start with LangGraph, not CrewAI.</strong> CrewAI is great for demos. LangGraph is what production teams actually use. It gives you fine-grained control over state, branching, and cycles — essential when an agent needs to loop, backtrack, or take conditional paths. Learn LangGraph first; everything else becomes easier.</div>
-            </div>
-
-            <div style="margin-top:14px;">
-                <div class="section-label">Framework Comparison — When to Use What</div>
-                <table class="stack-table">
-                    <thead>
-                        <tr>
-                            <th>Framework</th>
-                            <th>Best For</th>
-                            <th>Complexity</th>
-                            <th>Production-Ready?</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>LangGraph</td>
-                            <td>Stateful, cyclic, complex agent flows</td>
-                            <td>Medium–High</td>
-                            <td>Yes — used at scale</td>
-                        </tr>
-                        <tr>
-                            <td>LangChain</td>
-                            <td>RAG, chains, quick prototyping</td>
-                            <td>Low–Medium</td>
-                            <td>Yes with care</td>
-                        </tr>
-                        <tr>
-                            <td>LlamaIndex</td>
-                            <td>Data-heavy agents, document Q&amp;A</td>
-                            <td>Medium</td>
-                            <td>Yes for data apps</td>
-                        </tr>
-                        <tr>
-                            <td>CrewAI</td>
-                            <td>Role-based multi-agent collaboration</td>
-                            <td>Low</td>
-                            <td>Demos &amp; MVPs</td>
-                        </tr>
-                        <tr>
-                            <td>AutoGen</td>
-                            <td>Code-executing multi-agent conversations</td>
-                            <td>Medium</td>
-                            <td>Research &amp; internal tools</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">04 / 08</span>
-        </div>
-    </div>
-
-    <!-- ══════════════════════ PAGE 5 — PHASES 8–9 ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Agentic AI Engineer Roadmap · 2026</span>
-            <span class="page-num">05</span>
-        </div>
-
-        <div class="page-body">
-            <div class="section-label">Evaluation, Safety & Production</div>
-            <h2 class="section-title">Evals, Guardrails & Deploying Agents at Scale</h2>
-
-            <div class="roadmap">
-
-                <!-- PHASE 8 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">8</div>
-                        <div class="step-line"></div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 20–28</div>
-                        <div class="step-phase">Phase 08 · Agent Evaluation & Testing</div>
-                        <div class="step-heading">Evals — The Discipline That Separates Hobbyists from Engineers</div>
-                        <div class="step-desc">You cannot ship agents without systematic evaluation. Most people skip this — it's why most agents fail in production. Build <strong>unit evals</strong>: test individual LLM calls with expected outputs. Build <strong>end-to-end evals</strong>: does the full agent task succeed? Learn <strong>LLM-as-judge</strong>: use GPT-4 to score agent outputs on criteria like accuracy, helpfulness, safety, and format adherence. Use <strong>RAGAS</strong> for RAG evaluation: faithfulness, answer relevancy, context precision, recall. Learn <strong>Braintrust</strong>, <strong>LangSmith evals</strong>, and <strong>Weights & Biases Weave</strong> for structured eval pipelines. Build a <strong>regression test suite</strong> — every time you change a prompt or model, run your evals. Agents without evals degrade silently.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Ship-or-fail gate</span>
-                            <span class="tag">LLM-as-judge</span>
-                            <span class="tag">RAGAS</span>
-                            <span class="tag">Braintrust</span>
-                            <span class="tag">LangSmith evals</span>
-                            <span class="tag">W&B Weave</span>
-                            <span class="tag">Unit evals</span>
-                            <span class="tag">Regression tests</span>
-                        </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">🗂️ Personal AI Assistant</div>
+                        <div class="resource-card-desc">Multi-tool agent with long-term memory (Mem0), calendar
+                            integration, email drafting, web search, and document Q&A over your own notes. Voice input
+                            via Whisper. Demonstrates tool use, memory, and integration engineering.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=NUxNM7aN4_M" target="_blank">Agent Evals with LangSmith – LangChain</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=Xpz9Fy23pIg" target="_blank">RAGAS RAG Evaluation – James Briggs</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=0VLAoVGf_74" target="_blank">LLM-as-Judge Pattern – Weights & Biases</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=eTieetk2dSw" target="_blank">Agent Testing Strategies – freeCodeCamp</a>
+                            <a class="yt-link"
+                                href="https://www.youtube.com/results?search_query=LangChain%20Agent%20Tools"
+                                target="_blank">LangChain Agent Tools</a>
                         </div>
                     </div>
-                </div>
-
-                <!-- PHASE 9 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">9</div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 24–34</div>
-                        <div class="step-phase">Phase 09 · Agent Safety & Guardrails</div>
-                        <div class="step-heading">Guardrails, Prompt Injection Defense & Responsible Agents</div>
-                        <div class="step-desc">Autonomous agents can cause real-world harm — they can delete data, send emails, make purchases, execute code. Safety is not optional. Learn <strong>input/output guardrails</strong> with NeMo Guardrails and Guardrails AI: validate LLM inputs/outputs against policy rules. Study <strong>prompt injection attacks</strong>: malicious content in tool results or user inputs hijacking agent behavior — this is the SQL injection of the agent era. Learn <strong>sandboxing</strong>: never let agents execute code outside a contained environment (E2B, Docker). Implement <strong>human-in-the-loop (HITL)</strong> for high-stakes actions: confirm before sending emails, deleting files, or spending money. Study <strong>principle of least privilege</strong> for agent tool access. Learn <strong>Constitutional AI</strong> principles for alignment.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Non-negotiable for prod</span>
-                            <span class="tag">NeMo Guardrails</span>
-                            <span class="tag">Guardrails AI</span>
-                            <span class="tag">Prompt injection</span>
-                            <span class="tag">E2B sandboxing</span>
-                            <span class="tag">HITL pattern</span>
-                            <span class="tag">Least privilege</span>
-                            <span class="tag">Constitutional AI</span>
-                        </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">🤝 Multi-Agent Pipeline</div>
+                        <div class="resource-card-desc">CrewAI or LangGraph system with 3+ specialized agents
+                            (Researcher → Writer → Editor → SEO Optimizer) collaborating on long-form content. Shows
+                            multi-agent orchestration, inter-agent messaging, and quality control loops.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=NFgEgqua-fg" target="_blank">NeMo Guardrails – NVIDIA</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=sPzc6hMg7So" target="_blank">Agent Safety Patterns – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=E2shqsYwxck" target="_blank">Prompt Injection Attacks – Simon Willison</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=R8KB-Zcynxc" target="_blank">Human-in-the-Loop Agents – LangGraph</a>
+                            <a class="yt-link"
+                                href="https://www.youtube.com/results?search_query=CrewAI%20Full%20Course"
+                                target="_blank">CrewAI Full Course</a>
                         </div>
                     </div>
                 </div>
 
-            </div>
+                <hr class="divider">
 
-            <hr class="divider">
-
-            <div class="section-label">Agentic Design Patterns — The Core Patterns Every Engineer Must Know</div>
-
-            <div class="resource-grid">
-                <div class="resource-card">
-                    <div class="resource-card-name">🔁 ReAct Loop</div>
-                    <div class="resource-card-desc">Reason → Act → Observe → Repeat. The fundamental agent loop. LLM reasons about what to do, executes a tool, observes the result, then reasons again. Used in nearly every production agent.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=vFnb6F7Qe7U" target="_blank">ReAct Pattern – LangChain</a>
+                <div class="section-label">Daily Routine</div>
+                <div style="font-size:14px; font-weight:700; color:var(--dark); margin-bottom:10px;">The Boring Agentic
+                    AI Routine That Works</div>
+                <div class="checklist">
+                    <div class="check-item">
+                        <div class="check-box"></div> Read one agentic AI paper or blog post (Simon Willison, Lilian
+                        Weng, or Anthropic research blog)
                     </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">🌳 Plan-and-Execute</div>
-                    <div class="resource-card-desc">Planner LLM breaks a complex goal into subtasks upfront. Executor agents complete each step. More reliable for long-horizon tasks than pure ReAct. Used in OpenAI's deep research.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=R8KB-Zcynxc" target="_blank">Plan & Execute – LangGraph</a>
+                    <div class="check-item">
+                        <div class="check-box"></div> 1 hour of hands-on building — one new tool, one new eval, one
+                        deployment improvement
                     </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">🔍 Reflection Pattern</div>
-                    <div class="resource-card-desc">Agent generates a draft, a critic agent reviews it, the generator revises. Iterative self-improvement. Dramatically improves output quality for writing, code, and research tasks.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=AxnL-cAM2Q8" target="_blank">Reflection Agents – freeCodeCamp</a>
+                    <div class="check-item">
+                        <div class="check-box"></div> Run your eval suite — catch regressions before they catch you in
+                        production
                     </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">🧩 Subagent Delegation</div>
-                    <div class="resource-card-desc">Orchestrator agent routes subtasks to specialized agents (a coding agent, a research agent, a writing agent). Each expert agent has its own tools and context. The supervisor pattern in practice.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=V2qZ_lgxTzg" target="_blank">Subagents – AutoGen</a>
+                    <div class="check-item">
+                        <div class="check-box"></div> Track one failure mode — what did your agent do wrong today? Write
+                        it down
+                    </div>
+                    <div class="check-item">
+                        <div class="check-box"></div> Share one build update, failure, or insight on LinkedIn or
+                        X/Twitter
                     </div>
                 </div>
             </div>
+
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">07 / 08</span>
+            </div>
         </div>
 
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">05 / 08</span>
-        </div>
-    </div>
+        <!-- ══════════════════════ PAGE 8 — RESOURCES + CTA ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Agentic AI Engineer Roadmap · 2026</span>
+                <span class="page-num">08</span>
+            </div>
 
-    <!-- ══════════════════════ PAGE 6 — PHASES 10–11 ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Agentic AI Engineer Roadmap · 2026</span>
-            <span class="page-num">06</span>
-        </div>
+            <div class="page-body">
+                <div class="section-label">Master Resource List</div>
+                <h2 class="section-title">Best Free YouTube Channels for Agentic AI</h2>
 
-        <div class="page-body">
-            <div class="section-label">Deployment & Specialization</div>
-            <h2 class="section-title">Shipping Agents to Production & Specialization Tracks</h2>
-
-            <div class="roadmap">
-
-                <!-- PHASE 10 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">10</div>
-                        <div class="step-line"></div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 26–36</div>
-                        <div class="step-phase">Phase 10 · Production Deployment</div>
-                        <div class="step-heading">Serving Agents — FastAPI, Streaming, Queues & Monitoring</div>
-                        <div class="step-desc">Building an agent that works in a notebook is 20% of the job. Deploy it: serve agents as <strong>streaming REST APIs</strong> with FastAPI — SSE (Server-Sent Events) for real-time token streaming to frontend clients. Use <strong>task queues</strong> (Celery + Redis, or BullMQ) for async long-running agent tasks that can't block an HTTP request. Learn <strong>containerization</strong> with Docker — package your agent + dependencies. Deploy on <strong>Cloud Run, Railway, Fly.io</strong> for managed serverless. Add <strong>observability</strong>: structured logging with Loguru, tracing with LangSmith/Langfuse, metrics with Prometheus. Monitor <strong>latency, token usage, and cost per agent run</strong>. Set up alerts for agent failures. Study <strong>rate limiting and cost controls</strong> — uncapped agents can burn $1000s in minutes.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Production essentials</span>
-                            <span class="tag">FastAPI + SSE streaming</span>
-                            <span class="tag">Celery + Redis</span>
-                            <span class="tag">Docker</span>
-                            <span class="tag">Cloud Run / Railway</span>
-                            <span class="tag">Langfuse</span>
-                            <span class="tag">Token cost tracking</span>
-                            <span class="tag">Rate limiting</span>
-                        </div>
+                <div class="resource-grid">
+                    <div class="resource-card">
+                        <div class="resource-card-name">📺 Andrej Karpathy</div>
+                        <div class="resource-card-desc">Former Tesla AI Director, OpenAI co-founder. "Neural Networks:
+                            Zero to Hero" is mandatory. His LLM talks explain exactly how the models your agents run on
+                            work internally. Watch everything he posts.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=ENrzD9HAZK4" target="_blank">FastAPI Full Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=3c-iBn73dDE" target="_blank">Docker Full Course – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=NUxNM7aN4_M" target="_blank">Agent Monitoring – Langfuse</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=LdNWOiSkMVE" target="_blank">Async Task Queues – DataTalks.Club</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=k1RI5locZE4" target="_blank">Cloud Run Deployment – freeCodeCamp</a>
+                            <a class="yt-link" href="https://www.youtube.com/@AndrejKarpathy"
+                                target="_blank">@AndrejKarpathy</a>
                         </div>
                     </div>
-                </div>
-
-                <!-- PHASE 11 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">11</div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Month 9–14 (Specialization)</div>
-                        <div class="step-phase">Phase 11 · Advanced Specialization</div>
-                        <div class="step-heading">Computer-Use Agents, Fine-tuning & Frontier Systems</div>
-                        <div class="step-desc">Once you're comfortable with the full stack, specialize. <strong>Computer-Use Agents</strong>: Anthropic's Computer Use API, browser agents with Playwright/Stagehand, desktop automation — agents that can actually operate a computer like a human. <strong>Voice Agents</strong>: realtime speech pipelines with Deepgram (STT) + LLM + ElevenLabs/Cartesia (TTS) — sub-300ms latency for real conversations. <strong>Fine-tuning for agents</strong>: fine-tune Llama 3.1 or Mistral on agent trajectories (tool use examples) to improve reliability and reduce costs vs. GPT-4. Study <strong>MCP (Model Context Protocol)</strong> — Anthropic's standard for agent-tool integration. Learn <strong>OpenAI Assistants API</strong> and <strong>Responses API</strong> for managed agent infrastructure. These are the skills unlocking senior and research roles.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Frontier skills</span>
-                            <span class="tag">Computer Use API</span>
-                            <span class="tag">Browser agents (Stagehand)</span>
-                            <span class="tag">Voice agents (Deepgram)</span>
-                            <span class="tag">Agent fine-tuning</span>
-                            <span class="tag">MCP protocol</span>
-                            <span class="tag">OpenAI Responses API</span>
-                            <span class="tag">Realtime API</span>
-                        </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">📺 LangChain Official</div>
+                        <div class="resource-card-desc">The primary channel for LangGraph, LangChain, and LangSmith
+                            tutorials. State-of-the-art agentic patterns from the team that built the most widely-used
+                            agent framework. Follow for new pattern releases.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=AxnL-cAM2Q8" target="_blank">Computer Use Agents – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=q9MBvgf-QZk" target="_blank">Voice Agents with Deepgram – Hugging Face</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=eTieetk2dSw" target="_blank">Fine-tuning for Tool Use – Hugging Face</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=R8KB-Zcynxc" target="_blank">MCP Protocol Deep Dive – LangChain</a>
+                            <a class="yt-link" href="https://www.youtube.com/@LangChain" target="_blank">@LangChain</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">📺 freeCodeCamp</div>
+                        <div class="resource-card-desc">Full-length free courses on LangChain, CrewAI, AutoGen, FastAPI,
+                            Docker, and more. The best place for comprehensive, project-based agentic AI learning with
+                            zero cost.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/@freecodecamp"
+                                target="_blank">@freecodecamp</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">📺 James Briggs</div>
+                        <div class="resource-card-desc">The clearest technical tutorials on RAG, vector databases,
+                            semantic search, and agent memory. His Pinecone collaboration videos are the best resource
+                            for production-grade knowledge retrieval systems.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/@jamesbriggs"
+                                target="_blank">@jamesbriggs</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">📺 AI Jason</div>
+                        <div class="resource-card-desc">Practical walkthroughs of agent patterns, RAG pipelines, and
+                            LlamaIndex workflows. Great for going from theory to working code. Projects are real-world
+                            and well-explained.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/@AIJasonZ" target="_blank">@AIJasonZ</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">📺 Krish Naik</div>
+                        <div class="resource-card-desc">India's most practical AI educator. Deep dives on LangChain,
+                            LlamaIndex, Hugging Face, and agentic deployments. Best for bridging the gap between
+                            tutorials and real-world implementation.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/@krishnaik06"
+                                target="_blank">@krishnaik06</a>
                         </div>
                     </div>
                 </div>
 
+                <hr class="divider">
+
+                <div class="section-label">Tools by TBE — Use These</div>
+                <div style="display:flex; gap:8px; flex-wrap:wrap; margin-bottom:14px;">
+                    <span class="tag red">DSA Yatra — Daily practice</span>
+                    <span class="tag red">Prep Yatra — Interview tracker</span>
+                    <span class="tag red">Tech Yatra — Learning roadmaps</span>
+                    <span class="tag red">Resume Yatra — ATS-ready resume</span>
+                    <span class="tag">Shiksha — Free courses</span>
+                    <span class="tag">YouFocus — Distraction-free YT</span>
+                    <span class="tag">Interview Prep — Question banks</span>
+                    <span class="tag">Community — Peer learning</span>
+                </div>
+
+                <div class="cta-block">
+                    <div class="cta-title">The Agentic Era Is Here 🤖</div>
+                    <div class="cta-sub">The engineers building autonomous AI systems today are defining how software
+                        works for the next decade.<br>Start small. Build one tool-using agent. Deploy it. Then make it
+                        smarter.</div>
+                    <a href="https://www.theboringeducation.com" class="cta-link" target="_blank">→
+                        theboringeducation.com</a>
+                </div>
+
+                <hr class="divider">
+
+                <div class="section-label">Find Us Everywhere</div>
+                <div class="socials-grid">
+                    <a class="social-card" href="https://instagram.com/theboringeducation" target="_blank">
+                        <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/2111/2111463.png"
+                            alt="Instagram">
+                        <span class="social-name">Instagram</span>
+                        <div class="social-handle">@theboringeducation</div>
+                    </a>
+                    <a class="social-card" href="https://linkedin.com/company/the-boring-education" target="_blank">
+                        <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png"
+                            alt="LinkedIn">
+                        <span class="social-name">LinkedIn</span>
+                        <div class="social-handle">The Boring Education</div>
+                    </a>
+                    <a class="social-card" href="https://github.com/The-Boring-Education" target="_blank">
+                        <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/733/733609.png"
+                            alt="GitHub">
+                        <span class="social-name">GitHub</span>
+                        <div class="social-handle">The-Boring-Education</div>
+                    </a>
+                </div>
             </div>
 
-            <hr class="divider">
-
-            <div class="section-label">Specialization Tracks — Pick Your Path</div>
-            <table class="stack-table">
-                <thead>
-                    <tr>
-                        <th>Track</th>
-                        <th>Focus</th>
-                        <th>Key Tools</th>
-                        <th>Who's Hiring</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Coding Agents</td>
-                        <td>Code gen, review, debugging, repo navigation</td>
-                        <td>Code Interpreter, Tree-sitter, E2B</td>
-                        <td>Cursor, GitHub, Sourcegraph, startups</td>
-                    </tr>
-                    <tr>
-                        <td>Browser / Web Agents</td>
-                        <td>Web scraping, form-filling, research automation</td>
-                        <td>Playwright, Stagehand, Computer Use</td>
-                        <td>Automation cos., enterprises, SaaS</td>
-                    </tr>
-                    <tr>
-                        <td>Voice Agents</td>
-                        <td>Real-time conversational AI, call centers</td>
-                        <td>Deepgram, ElevenLabs, LiveKit, VAD</td>
-                        <td>Retell AI, VAPI, healthcare, sales</td>
-                    </tr>
-                    <tr>
-                        <td>Research Agents</td>
-                        <td>Deep research, doc analysis, knowledge synthesis</td>
-                        <td>Tavily, RAG, multi-step planning</td>
-                        <td>OpenAI, Perplexity, finance, legal</td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="page-footer">
+                <span class="cover-footer-text">© 2026 The Boring Education · Free Tech Education for Everyone</span>
+                <span class="page-num">08 / 08</span>
+            </div>
         </div>
 
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">06 / 08</span>
-        </div>
     </div>
-
-    <!-- ══════════════════════ PAGE 7 — SKILL MAP + PROJECTS ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Agentic AI Engineer Roadmap · 2026</span>
-            <span class="page-num">07</span>
-        </div>
-
-        <div class="page-body">
-            <div class="section-label">Skill Map & Projects</div>
-            <h2 class="section-title">Full Timeline & Portfolio Projects to Build</h2>
-
-            <div class="skills-row">
-                <div class="skill-col">
-                    <div class="skill-col-title">🟥 Month 1–4</div>
-                    <div class="skill-item">Python async + Pydantic</div>
-                    <div class="skill-item">LLM fundamentals + APIs</div>
-                    <div class="skill-item">Prompt engineering (CoT, ReAct)</div>
-                    <div class="skill-item">Function calling / tool use</div>
-                    <div class="skill-item">RAG pipeline basics</div>
-                    <div class="skill-item">Vector DB (Qdrant / Pinecone)</div>
-                    <div class="skill-item">LangChain fundamentals</div>
-                </div>
-                <div class="skill-col">
-                    <div class="skill-col-title">🟧 Month 5–9</div>
-                    <div class="skill-item">LangGraph stateful agents</div>
-                    <div class="skill-item">Multi-agent (CrewAI / AutoGen)</div>
-                    <div class="skill-item">Agent memory systems (Mem0)</div>
-                    <div class="skill-item">LangSmith tracing + evals</div>
-                    <div class="skill-item">RAGAS evaluation</div>
-                    <div class="skill-item">Guardrails + prompt injection</div>
-                    <div class="skill-item">FastAPI + SSE deployment</div>
-                </div>
-                <div class="skill-col">
-                    <div class="skill-col-title">🟩 Month 10–18</div>
-                    <div class="skill-item">Computer-use / browser agents</div>
-                    <div class="skill-item">Voice agent pipelines</div>
-                    <div class="skill-item">Agent fine-tuning (LoRA)</div>
-                    <div class="skill-item">MCP protocol integration</div>
-                    <div class="skill-item">Cost optimization & caching</div>
-                    <div class="skill-item">Specialization track depth</div>
-                    <div class="skill-item">Published demos + blog</div>
-                </div>
-            </div>
-
-            <hr class="divider">
-
-            <div class="section-label">Portfolio Projects — Build These 5 to Get Hired</div>
-
-            <div class="resource-grid">
-                <div class="resource-card">
-                    <div class="resource-card-name">🔍 Deep Research Agent</div>
-                    <div class="resource-card-desc">Agent that takes a complex question, plans sub-questions, searches the web (Tavily), reads and synthesizes sources, writes a structured report with citations. Deployed as a web app with streaming output. Uses LangGraph + RAG + LangSmith evals.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=sVcwVQRHIc8" target="_blank">RAG Pipeline – freeCodeCamp</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">💻 Coding Assistant Agent</div>
-                    <div class="resource-card-desc">Agent that reads a GitHub repo, understands the codebase via RAG, accepts feature requests, writes code, executes it in an E2B sandbox, debugs failures, and opens a PR. The mini-Cursor. Shows you understand the full agentic coding loop.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=E2shqsYwxck" target="_blank">E2B Code Execution – freeCodeCamp</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">🗂️ Personal AI Assistant</div>
-                    <div class="resource-card-desc">Multi-tool agent with long-term memory (Mem0), calendar integration, email drafting, web search, and document Q&A over your own notes. Voice input via Whisper. Demonstrates tool use, memory, and integration engineering.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=aywZrzNaKjs" target="_blank">LangChain Agent Tools</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">🤝 Multi-Agent Pipeline</div>
-                    <div class="resource-card-desc">CrewAI or LangGraph system with 3+ specialized agents (Researcher → Writer → Editor → SEO Optimizer) collaborating on long-form content. Shows multi-agent orchestration, inter-agent messaging, and quality control loops.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=sPzc6hMg7So" target="_blank">CrewAI Full Course</a>
-                    </div>
-                </div>
-            </div>
-
-            <hr class="divider">
-
-            <div class="section-label">Daily Routine</div>
-            <div style="font-size:14px; font-weight:700; color:var(--dark); margin-bottom:10px;">The Boring Agentic AI Routine That Works</div>
-            <div class="checklist">
-                <div class="check-item">
-                    <div class="check-box"></div> Read one agentic AI paper or blog post (Simon Willison, Lilian Weng, or Anthropic research blog)
-                </div>
-                <div class="check-item">
-                    <div class="check-box"></div> 1 hour of hands-on building — one new tool, one new eval, one deployment improvement
-                </div>
-                <div class="check-item">
-                    <div class="check-box"></div> Run your eval suite — catch regressions before they catch you in production
-                </div>
-                <div class="check-item">
-                    <div class="check-box"></div> Track one failure mode — what did your agent do wrong today? Write it down
-                </div>
-                <div class="check-item">
-                    <div class="check-box"></div> Share one build update, failure, or insight on LinkedIn or X/Twitter
-                </div>
-            </div>
-        </div>
-
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">07 / 08</span>
-        </div>
-    </div>
-
-    <!-- ══════════════════════ PAGE 8 — RESOURCES + CTA ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Agentic AI Engineer Roadmap · 2026</span>
-            <span class="page-num">08</span>
-        </div>
-
-        <div class="page-body">
-            <div class="section-label">Master Resource List</div>
-            <h2 class="section-title">Best Free YouTube Channels for Agentic AI</h2>
-
-            <div class="resource-grid">
-                <div class="resource-card">
-                    <div class="resource-card-name">📺 Andrej Karpathy</div>
-                    <div class="resource-card-desc">Former Tesla AI Director, OpenAI co-founder. "Neural Networks: Zero to Hero" is mandatory. His LLM talks explain exactly how the models your agents run on work internally. Watch everything he posts.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/@AndrejKarpathy" target="_blank">@AndrejKarpathy</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">📺 LangChain Official</div>
-                    <div class="resource-card-desc">The primary channel for LangGraph, LangChain, and LangSmith tutorials. State-of-the-art agentic patterns from the team that built the most widely-used agent framework. Follow for new pattern releases.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/@LangChain" target="_blank">@LangChain</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">📺 freeCodeCamp</div>
-                    <div class="resource-card-desc">Full-length free courses on LangChain, CrewAI, AutoGen, FastAPI, Docker, and more. The best place for comprehensive, project-based agentic AI learning with zero cost.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/@freecodecamp" target="_blank">@freecodecamp</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">📺 James Briggs</div>
-                    <div class="resource-card-desc">The clearest technical tutorials on RAG, vector databases, semantic search, and agent memory. His Pinecone collaboration videos are the best resource for production-grade knowledge retrieval systems.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/@jamesbriggs" target="_blank">@jamesbriggs</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">📺 AI Jason</div>
-                    <div class="resource-card-desc">Practical walkthroughs of agent patterns, RAG pipelines, and LlamaIndex workflows. Great for going from theory to working code. Projects are real-world and well-explained.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/@AIJasonZ" target="_blank">@AIJasonZ</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">📺 Krish Naik</div>
-                    <div class="resource-card-desc">India's most practical AI educator. Deep dives on LangChain, LlamaIndex, Hugging Face, and agentic deployments. Best for bridging the gap between tutorials and real-world implementation.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/@krishnaik06" target="_blank">@krishnaik06</a>
-                    </div>
-                </div>
-            </div>
-
-            <hr class="divider">
-
-            <div class="section-label">Tools by TBE — Use These</div>
-            <div style="display:flex; gap:8px; flex-wrap:wrap; margin-bottom:14px;">
-                <span class="tag red">DSA Yatra — Daily practice</span>
-                <span class="tag red">Prep Yatra — Interview tracker</span>
-                <span class="tag red">Tech Yatra — Learning roadmaps</span>
-                <span class="tag red">Resume Yatra — ATS-ready resume</span>
-                <span class="tag">Shiksha — Free courses</span>
-                <span class="tag">YouFocus — Distraction-free YT</span>
-                <span class="tag">Interview Prep — Question banks</span>
-                <span class="tag">Community — Peer learning</span>
-            </div>
-
-            <div class="cta-block">
-                <div class="cta-title">The Agentic Era Is Here 🤖</div>
-                <div class="cta-sub">The engineers building autonomous AI systems today are defining how software works for the next decade.<br>Start small. Build one tool-using agent. Deploy it. Then make it smarter.</div>
-                <a href="https://www.theboringeducation.com" class="cta-link" target="_blank">→ theboringeducation.com</a>
-            </div>
-
-            <hr class="divider">
-
-            <div class="section-label">Find Us Everywhere</div>
-            <div class="socials-grid">
-                <a class="social-card" href="https://instagram.com/theboringeducation" target="_blank">
-                    <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/2111/2111463.png" alt="Instagram">
-                    <span class="social-name">Instagram</span>
-                    <div class="social-handle">@theboringeducation</div>
-                </a>
-                <a class="social-card" href="https://linkedin.com/company/the-boring-education" target="_blank">
-                    <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png" alt="LinkedIn">
-                    <span class="social-name">LinkedIn</span>
-                    <div class="social-handle">The Boring Education</div>
-                </a>
-                <a class="social-card" href="https://github.com/The-Boring-Education" target="_blank">
-                    <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/733/733609.png" alt="GitHub">
-                    <span class="social-name">GitHub</span>
-                    <div class="social-handle">The-Boring-Education</div>
-                </a>
-            </div>
-        </div>
-
-        <div class="page-footer">
-            <span class="cover-footer-text">© 2026 The Boring Education · Free Tech Education for Everyone</span>
-            <span class="page-num">08 / 08</span>
-        </div>
-    </div>
-
-</div>
 </body>
+
 </html>

--- a/apps/resources/content/aiml-engineer-roadmap/index.html
+++ b/apps/resources/content/aiml-engineer-roadmap/index.html
@@ -1091,10 +1091,10 @@
                                 <span class="tag">Matrix ops</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=fNk_zzaMoSs" target="_blank">Linear Algebra – 3Blue1Brown</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=WUvTyaaNkzM" target="_blank">Essence of Calculus – 3Blue1Brown</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=xxpc-HPKN28" target="_blank">Statistics for ML – StatQuest</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=HZGCoVF3YvM" target="_blank">Probability for ML – Brandon Foltz</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Linear%20Algebra%20%E2%80%93%203Blue1Brown" target="_blank">Linear Algebra – 3Blue1Brown</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Essence%20of%20Calculus%20%E2%80%93%203Blue1Brown" target="_blank">Essence of Calculus – 3Blue1Brown</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Statistics%20for%20ML%20%E2%80%93%20StatQuest" target="_blank">Statistics for ML – StatQuest</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Probability%20for%20ML%20%E2%80%93%20Brandon%20Foltz" target="_blank">Probability for ML – Brandon Foltz</a>
                             </div>
                         </div>
                     </div>
@@ -1126,10 +1126,10 @@
                                 <span class="tag">venv / conda</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=rfscVS0vtbw" target="_blank">Python Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=QUT1VHiLmmI" target="_blank">NumPy Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=vmEHCJofslg" target="_blank">Pandas Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=3Xw6FKYP7e4" target="_blank">Matplotlib & Seaborn – Corey Schafer</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Python%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">Python Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=NumPy%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">NumPy Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Pandas%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">Pandas Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Matplotlib%20%26%20Seaborn%20%E2%80%93%20Corey%20Schafer" target="_blank">Matplotlib & Seaborn – Corey Schafer</a>
                             </div>
                         </div>
                     </div>
@@ -1160,10 +1160,10 @@
                                 <span class="tag">Normalization</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=xi0vhXFPegw" target="_blank">EDA with Python – Ken Jee</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=r-uOLxNrNk8" target="_blank">Feature Engineering – Krish Naik</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=XRBs8oDR5kY" target="_blank">Data Cleaning with Pandas – Keith Galli</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=XItFqbUVWZQ" target="_blank">Web Scraping Python – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=EDA%20with%20Python%20%E2%80%93%20Ken%20Jee" target="_blank">EDA with Python – Ken Jee</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Feature%20Engineering%20%E2%80%93%20Krish%20Naik" target="_blank">Feature Engineering – Krish Naik</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Data%20Cleaning%20with%20Pandas%20%E2%80%93%20Keith%20Galli" target="_blank">Data Cleaning with Pandas – Keith Galli</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Web%20Scraping%20Python%20%E2%80%93%20freeCodeCamp" target="_blank">Web Scraping Python – freeCodeCamp</a>
                             </div>
                         </div>
                     </div>
@@ -1230,11 +1230,11 @@
                                 <span class="tag">Pipelines</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=pqNCD_5r0IU" target="_blank">ML with scikit-learn – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=GwIo3gDZCVQ" target="_blank">StatQuest ML Playlist – StatQuest</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=OtD8wVaFm6E" target="_blank">XGBoost Explained – StatQuest</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Gv9_4yMHFhI" target="_blank">ML Fundamentals – Sentdex</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=ysEN5RaKOlA" target="_blank">ML Pipeline Best Practices – Krish Naik</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=ML%20with%20scikit-learn%20%E2%80%93%20freeCodeCamp" target="_blank">ML with scikit-learn – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=StatQuest%20ML%20Playlist%20%E2%80%93%20StatQuest" target="_blank">StatQuest ML Playlist – StatQuest</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=XGBoost%20Explained%20%E2%80%93%20StatQuest" target="_blank">XGBoost Explained – StatQuest</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=ML%20Fundamentals%20%E2%80%93%20Sentdex" target="_blank">ML Fundamentals – Sentdex</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=ML%20Pipeline%20Best%20Practices%20%E2%80%93%20Krish%20Naik" target="_blank">ML Pipeline Best Practices – Krish Naik</a>
                             </div>
                         </div>
                     </div>
@@ -1268,11 +1268,11 @@
                                 <span class="tag">GPU training</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=V_xro1bcAuA" target="_blank">PyTorch Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=aircAruvnKk" target="_blank">Neural Networks – 3Blue1Brown</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=ySEx_Bqxvvo" target="_blank">CNN Explained – StatQuest</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=4Bdc55j80l8" target="_blank">Transformers Explained – Andrej Karpathy</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=zduSFxRajkE" target="_blank">Hugging Face NLP – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=PyTorch%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">PyTorch Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Neural%20Networks%20%E2%80%93%203Blue1Brown" target="_blank">Neural Networks – 3Blue1Brown</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=CNN%20Explained%20%E2%80%93%20StatQuest" target="_blank">CNN Explained – StatQuest</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Transformers%20Explained%20%E2%80%93%20Andrej%20Karpathy" target="_blank">Transformers Explained – Andrej Karpathy</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Hugging%20Face%20NLP%20%E2%80%93%20freeCodeCamp" target="_blank">Hugging Face NLP – freeCodeCamp</a>
                             </div>
                         </div>
                     </div>
@@ -1379,11 +1379,11 @@
                                 <span class="tag">Ollama / vLLM</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=T-D1OfcDW1M" target="_blank">LLMs from Scratch – Andrej Karpathy</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=sVcwVQRHIc8" target="_blank">RAG Tutorial – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=eTieetk2dSw" target="_blank">Fine-tuning LLMs – Hugging Face</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=aywZrzNaKjs" target="_blank">LangChain Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Yhtjd7yGGGA" target="_blank">Vector Databases Explained – Fireship</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=LLMs%20from%20Scratch%20%E2%80%93%20Andrej%20Karpathy" target="_blank">LLMs from Scratch – Andrej Karpathy</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=RAG%20Tutorial%20%E2%80%93%20freeCodeCamp" target="_blank">RAG Tutorial – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Fine-tuning%20LLMs%20%E2%80%93%20Hugging%20Face" target="_blank">Fine-tuning LLMs – Hugging Face</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=LangChain%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">LangChain Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Vector%20Databases%20Explained%20%E2%80%93%20Fireship" target="_blank">Vector Databases Explained – Fireship</a>
                             </div>
                         </div>
                     </div>
@@ -1415,11 +1415,11 @@
                                 <span class="tag">CI/CD for ML</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=9BgIDqAzfuA" target="_blank">MLflow Tutorial – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=ENrzD9HAZK4" target="_blank">FastAPI for ML – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=3c-iBn73dDE" target="_blank">Docker Full Course – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=LdNWOiSkMVE" target="_blank">MLOps Full Course – DataTalks.Club</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=k1RI5locZE4" target="_blank">AWS SageMaker – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=MLflow%20Tutorial%20%E2%80%93%20freeCodeCamp" target="_blank">MLflow Tutorial – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=FastAPI%20for%20ML%20%E2%80%93%20freeCodeCamp" target="_blank">FastAPI for ML – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Docker%20Full%20Course%20%E2%80%93%20TechWorld%20with%20Nana" target="_blank">Docker Full Course – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=MLOps%20Full%20Course%20%E2%80%93%20DataTalks.Club" target="_blank">MLOps Full Course – DataTalks.Club</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20SageMaker%20%E2%80%93%20freeCodeCamp" target="_blank">AWS SageMaker – freeCodeCamp</a>
                             </div>
                         </div>
                     </div>
@@ -1525,11 +1525,11 @@
                                 <span class="tag">OpenAI Gym</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Z78zbnLlPUA" target="_blank">YOLO Object Detection – Ultralytics</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=DFpAmDL5I_o" target="_blank">OpenCV Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=1pykn-19XCY" target="_blank">BERT Explained – CodeEmporium</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Mut_u40Sqz4" target="_blank">Reinforcement Learning – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=bD6V3rcr_54" target="_blank">Vision Transformers – Yannic Kilcher</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=YOLO%20Object%20Detection%20%E2%80%93%20Ultralytics" target="_blank">YOLO Object Detection – Ultralytics</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=OpenCV%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">OpenCV Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=BERT%20Explained%20%E2%80%93%20CodeEmporium" target="_blank">BERT Explained – CodeEmporium</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Reinforcement%20Learning%20%E2%80%93%20freeCodeCamp" target="_blank">Reinforcement Learning – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Vision%20Transformers%20%E2%80%93%20Yannic%20Kilcher" target="_blank">Vision Transformers – Yannic Kilcher</a>
                             </div>
                         </div>
                     </div>
@@ -1562,10 +1562,10 @@
                                 <span class="tag">AI Safety basics</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=AxnL-cAM2Q8" target="_blank">AI Agents Tutorial – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=pbAd8O1Lvm4" target="_blank">Stable Diffusion Explained – Andrej Karpathy</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=NFgEgqua-fg" target="_blank">SHAP Explainability – CodeEmporium</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=q9MBvgf-QZk" target="_blank">Whisper ASR – Hugging Face</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AI%20Agents%20Tutorial%20%E2%80%93%20freeCodeCamp" target="_blank">AI Agents Tutorial – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Stable%20Diffusion%20Explained%20%E2%80%93%20Andrej%20Karpathy" target="_blank">Stable Diffusion Explained – Andrej Karpathy</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=SHAP%20Explainability%20%E2%80%93%20CodeEmporium" target="_blank">SHAP Explainability – CodeEmporium</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Whisper%20ASR%20%E2%80%93%20Hugging%20Face" target="_blank">Whisper ASR – Hugging Face</a>
                             </div>
                         </div>
                     </div>
@@ -1583,7 +1583,7 @@
                             your domain data. Gets state-of-the-art results with 1% of the training data and compute
                             cost. The most practical ML technique available.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=yofjFQddwHE" target="_blank">Transfer Learning – StatQuest</a>
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Transfer%20Learning%20%E2%80%93%20StatQuest" target="_blank">Transfer Learning – StatQuest</a>
                         </div>
                     </div>
                     <div class="resource-card">
@@ -1592,7 +1592,7 @@
                             knowledge. Eliminates hallucinations, enables enterprise document QA, and keeps models
                             current without expensive retraining. The #1 LLM pattern in production.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=sVcwVQRHIc8" target="_blank">RAG Deep Dive – freeCodeCamp</a>
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=RAG%20Deep%20Dive%20%E2%80%93%20freeCodeCamp" target="_blank">RAG Deep Dive – freeCodeCamp</a>
                         </div>
                     </div>
                     <div class="resource-card">
@@ -1601,7 +1601,7 @@
                             quantization makes 70B models run on consumer GPUs. Essential for production cost
                             optimization and edge deployment.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=v1oHf1KV6kM" target="_blank">Model Quantization – Hugging Face</a>
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Model%20Quantization%20%E2%80%93%20Hugging%20Face" target="_blank">Model Quantization – Hugging Face</a>
                         </div>
                     </div>
                     <div class="resource-card">
@@ -1610,7 +1610,7 @@
                             boosting, and stacking. XGBoost and LightGBM are ensemble methods. Dominated Kaggle for a
                             decade — still relevant for tabular data.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=OtD8wVaFm6E" target="_blank">Ensemble Methods – StatQuest</a>
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Ensemble%20Methods%20%E2%80%93%20StatQuest" target="_blank">Ensemble Methods – StatQuest</a>
                         </div>
                     </div>
                 </div>
@@ -1664,10 +1664,10 @@
                                 <span class="tag">ML system design</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=eTieetk2dSw" target="_blank">ML Interview Prep – Chip Huyen Talk</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=HqN3fHNUKUQ" target="_blank">Kaggle Getting Started – Ken Jee</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=nKW8Ndu7Mjw" target="_blank">ML System Design – Educative</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=UZDiGooFs54" target="_blank">ML Coding Interviews – Patrick Loeber</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=ML%20Interview%20Prep%20%E2%80%93%20Chip%20Huyen%20Talk" target="_blank">ML Interview Prep – Chip Huyen Talk</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Kaggle%20Getting%20Started%20%E2%80%93%20Ken%20Jee" target="_blank">Kaggle Getting Started – Ken Jee</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=ML%20System%20Design%20%E2%80%93%20Educative" target="_blank">ML System Design – Educative</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=ML%20Coding%20Interviews%20%E2%80%93%20Patrick%20Loeber" target="_blank">ML Coding Interviews – Patrick Loeber</a>
                             </div>
                         </div>
                     </div>

--- a/apps/resources/content/backend-engineer-roadmap/index.html
+++ b/apps/resources/content/backend-engineer-roadmap/index.html
@@ -1093,13 +1093,13 @@
                                 <span class="tag">TLS/SSL</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=x3c1ih2NJEg"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=How%20the%20Internet%20Works%20%E2%80%93%20Lesics"
                                     target="_blank">How the Internet Works – Lesics</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=TNQsmPf24go"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=HTTP%20Crash%20Course%20%E2%80%93%20Traversy%20Media"
                                     target="_blank">HTTP Crash Course – Traversy Media</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=dh406O2v_1c"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=TCP%2FIP%20%26%20OSI%20Model%20%E2%80%93%20Professor%20Messer"
                                     target="_blank">TCP/IP & OSI Model – Professor Messer</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=7_LPdttKXPc"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=DNS%20Explained%20%E2%80%93%20ByteByteGo"
                                     target="_blank">DNS Explained – ByteByteGo</a>
                             </div>
                         </div>
@@ -1129,11 +1129,11 @@
                                 <span class="tag">cron jobs</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=ZtqBQ68cfJc"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Linux%20for%20Beginners%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Linux for Beginners – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=RGOj5yH7evk"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Git%20%26%20GitHub%20Full%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Git & GitHub Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=oxuRxtrO2Ag"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Bash%20Scripting%20Crash%20Course%20%E2%80%93%20Traversy"
                                     target="_blank">Bash Scripting Crash Course – Traversy</a>
                             </div>
                         </div>
@@ -1162,13 +1162,13 @@
                                 <span class="tag">Testing basics</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=un6ZyFkqFKo" target="_blank">Go
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Go%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">Go
                                     Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=rfscVS0vtbw"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Python%20Full%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Python Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=TlB_eWDSMt4"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Node.js%20Crash%20Course%20%E2%80%93%20Traversy%20Media"
                                     target="_blank">Node.js Crash Course – Traversy Media</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=ysEN5RaKOlA" target="_blank">Go
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Go%20Concurrency%20Explained%20%E2%80%93%20TechWorld" target="_blank">Go
                                     Concurrency Explained – TechWorld</a>
                             </div>
                         </div>
@@ -1232,15 +1232,15 @@
                                 <span class="tag">OpenAPI / Swagger</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=pKd0Rpw7O48"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=REST%20API%20Design%20%E2%80%93%20Traversy%20Media"
                                     target="_blank">REST API Design – Traversy Media</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=ENrzD9HAZK4"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=FastAPI%20Crash%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">FastAPI Crash Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Qqmwm3rFSEc"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Express.js%20Full%20Course%20%E2%80%93%20Dave%20Gray"
                                     target="_blank">Express.js Full Course – Dave Gray</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=ed8SzALpx1Q"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=GraphQL%20Full%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">GraphQL Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=7YcW25PHnAA"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=REST%20API%20Best%20Practices%20%E2%80%93%20Fireship"
                                     target="_blank">REST API Best Practices – Fireship</a>
                             </div>
                         </div>
@@ -1273,15 +1273,15 @@
                                 <span class="tag">Migrations</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=qw--VYLpxG4"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=PostgreSQL%20Full%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">PostgreSQL Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Cz3WcZLRaWc"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=MongoDB%20Crash%20Course%20%E2%80%93%20Traversy%20Media"
                                     target="_blank">MongoDB Crash Course – Traversy Media</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=eMIxuk0TV9M"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=SQL%20Indexing%20Deep%20Dive%20%E2%80%93%20Arjan%20Codes"
                                     target="_blank">SQL Indexing Deep Dive – Arjan Codes</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=a4yX7RUgTxI"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Redis%20Crash%20Course%20%E2%80%93%20Traversy%20Media"
                                     target="_blank">Redis Crash Course – Traversy Media</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=W2Z7fbCLSTw"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Database%20Design%20%E2%80%93%20Caleb%20Curry"
                                     target="_blank">Database Design – Caleb Curry</a>
                             </div>
                         </div>
@@ -1387,13 +1387,13 @@
                                 <span class="tag">Secrets management</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=7Q17ubqLfaM"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=JWT%20Auth%20Explained%20%E2%80%93%20Web%20Dev%20Simplified"
                                     target="_blank">JWT Auth Explained – Web Dev Simplified</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=996OiexHze0"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=OAuth%202.0%20Full%20Guide%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">OAuth 2.0 Full Guide – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=eAdkSlFCJjk"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=OWASP%20Top%2010%20%E2%80%93%20David%20Bombal"
                                     target="_blank">OWASP Top 10 – David Bombal</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=AcYF18oGn6Y"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=API%20Security%20Best%20Practices%20%E2%80%93%20Fireship"
                                     target="_blank">API Security Best Practices – Fireship</a>
                             </div>
                         </div>
@@ -1426,15 +1426,15 @@
                                 <span class="tag">Terraform intro</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=3c-iBn73dDE"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Docker%20Full%20Course%20%E2%80%93%20TechWorld%20with%20Nana"
                                     target="_blank">Docker Full Course – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=R8_veQiYBjI"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=GitHub%20Actions%20CI%2FCD%20%E2%80%93%20TechWorld%20with%20Nana"
                                     target="_blank">GitHub Actions CI/CD – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=k1RI5locZE4"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20Full%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">AWS Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=X48VuDVv0do"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Kubernetes%20Full%20Course%20%E2%80%93%20TechWorld%20with%20Nana"
                                     target="_blank">Kubernetes Full Course – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=7xngnjfIlK4"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Nginx%20Crash%20Course%20%E2%80%93%20Traversy%20Media"
                                     target="_blank">Nginx Crash Course – Traversy Media</a>
                             </div>
                         </div>
@@ -1542,15 +1542,15 @@
                                 <span class="tag">CDN</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=a4yX7RUgTxI"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Redis%20Full%20Course%20%E2%80%93%20Traversy%20Media"
                                     target="_blank">Redis Full Course – Traversy Media</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Ch5r9-7qzmM"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Apache%20Kafka%20Crash%20Course%20%E2%80%93%20TechWorld"
                                     target="_blank">Apache Kafka Crash Course – TechWorld</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=lTAcCNbJ7KE"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Microservices%20Explained%20%E2%80%93%20ByteByteGo"
                                     target="_blank">Microservices Explained – ByteByteGo</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=zt1Bs3QrHaM"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=System%20Design%20for%20Beginners%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">System Design for Beginners – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=i53Gi_K3o7I"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Load%20Balancing%20Deep%20Dive%20%E2%80%93%20ByteByteGo"
                                     target="_blank">Load Balancing Deep Dive – ByteByteGo</a>
                             </div>
                         </div>
@@ -1582,13 +1582,13 @@
                                 <span class="tag">SLOs & SLIs</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Jv2uxzhPFl4"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Testing%20Node.js%20APIs%20%E2%80%93%20The%20Codeholic"
                                     target="_blank">Testing Node.js APIs – The Codeholic</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=h0nxo0QDMU8"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=pytest%20Full%20Course%20%E2%80%93%20Arjan%20Codes"
                                     target="_blank">pytest Full Course – Arjan Codes</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=9TJx7QTrTyo"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Prometheus%20%2B%20Grafana%20%E2%80%93%20TechWorld%20Nana"
                                     target="_blank">Prometheus + Grafana – TechWorld Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=0X9em99Vcl0"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Observability%20Explained%20%E2%80%93%20ByteByteGo"
                                     target="_blank">Observability Explained – ByteByteGo</a>
                             </div>
                         </div>
@@ -1607,7 +1607,7 @@
                             write models for better scalability. Essential for high-traffic applications with complex
                             query requirements.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=DQ3D_Cq-gAY" target="_blank">CQRS
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=CQRS%20Explained%20%E2%80%93%20CodeOpinion" target="_blank">CQRS
                                 Explained – CodeOpinion</a>
                         </div>
                     </div>
@@ -1617,7 +1617,7 @@
                             Enables complete audit trails, time-travel debugging, and event-driven systems at scale.
                         </div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=AUj4M-st3ic" target="_blank">Event
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Event%20Sourcing%20%E2%80%93%20Ambar.cloud" target="_blank">Event
                                 Sourcing – Ambar.cloud</a>
                         </div>
                     </div>
@@ -1627,7 +1627,7 @@
                             downstream service is failing, the circuit opens to stop hammering it and returns graceful
                             fallbacks.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=ADHcBxEXvFA"
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Circuit%20Breaker%20Pattern%20%E2%80%93%20ByteByteGo"
                                 target="_blank">Circuit Breaker Pattern – ByteByteGo</a>
                         </div>
                     </div>
@@ -1637,7 +1637,7 @@
                             scaling and polyglot persistence — critical for teams building at startup or enterprise
                             scale.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=QTdOoKBKies"
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Microservices%20Data%20%E2%80%93%20Sam%20Newman%20Talk"
                                 target="_blank">Microservices Data – Sam Newman Talk</a>
                         </div>
                     </div>
@@ -1690,13 +1690,13 @@
                                 <span class="tag">Technical blogging</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=bUHFg8CZFws"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=System%20Design%20Interview%20Guide%20%E2%80%93%20Exponent"
                                     target="_blank">System Design Interview Guide – Exponent</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=vYquLenfvGE"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Design%20URL%20Shortener%20%E2%80%93%20ByteByteGo"
                                     target="_blank">Design URL Shortener – ByteByteGo</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=UT_-ujJFuIo"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Design%20WhatsApp%20%E2%80%93%20Gaurav%20Sen"
                                     target="_blank">Design WhatsApp – Gaurav Sen</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=o-k7h2G3Gco"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=DSA%20Roadmap%202026%20%E2%80%93%20NeetCode"
                                     target="_blank">DSA Roadmap 2026 – NeetCode</a>
                             </div>
                         </div>

--- a/apps/resources/content/blockchain-engineer-roadmap/index.html
+++ b/apps/resources/content/blockchain-engineer-roadmap/index.html
@@ -933,9 +933,9 @@
             <span class="tag">JSON & APIs</span>
           </div>
           <div class="yt-links">
-            <a class="yt-link" href="https://www.youtube.com/watch?v=ysEN5RaKOlA" target="_blank">CS50 Full Course – freeCodeCamp</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=PkZNo7MFNFg" target="_blank">JavaScript Full Course – freeCodeCamp</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=RGOj5yH7evk" target="_blank">Git & GitHub Crash Course – freeCodeCamp</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=CS50%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">CS50 Full Course – freeCodeCamp</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=JavaScript%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">JavaScript Full Course – freeCodeCamp</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Git%20%26%20GitHub%20Crash%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">Git & GitHub Crash Course – freeCodeCamp</a>
           </div>
         </div>
       </div>
@@ -961,10 +961,10 @@
             <span class="tag">Hashing</span>
           </div>
           <div class="yt-links">
-            <a class="yt-link" href="https://www.youtube.com/watch?v=SSo_EIwHSd4" target="_blank">But how does Bitcoin actually work? – 3Blue1Brown</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=gyMwXuJrbJQ" target="_blank">Blockchain Full Course – freeCodeCamp</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=M576WGiDBdQ" target="_blank">How Ethereum Works – Whiteboard Crypto</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=bBC-nXj3Ng4" target="_blank">But how does Bitcoin work? – 3Blue1Brown</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=But%20how%20does%20Bitcoin%20actually%20work%3F%20%E2%80%93%203Blue1Brown" target="_blank">But how does Bitcoin actually work? – 3Blue1Brown</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Blockchain%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">Blockchain Full Course – freeCodeCamp</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=How%20Ethereum%20Works%20%E2%80%93%20Whiteboard%20Crypto" target="_blank">How Ethereum Works – Whiteboard Crypto</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=But%20how%20does%20Bitcoin%20work%3F%20%E2%80%93%203Blue1Brown" target="_blank">But how does Bitcoin work? – 3Blue1Brown</a>
           </div>
         </div>
       </div>
@@ -1021,10 +1021,10 @@
             <span class="tag">Storage Layout</span>
           </div>
           <div class="yt-links">
-            <a class="yt-link" href="https://www.youtube.com/watch?v=umepbfKp5rI" target="_blank">Solidity Full Course – Patrick Collins</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=M576WGiDBdQ" target="_blank">Solidity Tutorial for Beginners – Dapp University</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=gyMwXuJrbJQ" target="_blank">Smart Contracts Tutorial – freeCodeCamp</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=ipwxYa-F1uY" target="_blank">Build ERC20 Token from scratch – Dapp University</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Solidity%20Full%20Course%20%E2%80%93%20Patrick%20Collins" target="_blank">Solidity Full Course – Patrick Collins</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Solidity%20Tutorial%20for%20Beginners%20%E2%80%93%20Dapp%20University" target="_blank">Solidity Tutorial for Beginners – Dapp University</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Smart%20Contracts%20Tutorial%20%E2%80%93%20freeCodeCamp" target="_blank">Smart Contracts Tutorial – freeCodeCamp</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Build%20ERC20%20Token%20from%20scratch%20%E2%80%93%20Dapp%20University" target="_blank">Build ERC20 Token from scratch – Dapp University</a>
           </div>
         </div>
       </div>
@@ -1051,9 +1051,9 @@
             <span class="tag">Contract Testing</span>
           </div>
           <div class="yt-links">
-            <a class="yt-link" href="https://www.youtube.com/watch?v=9Yh4_8NKiYo" target="_blank">Hardhat Complete Guide – Patrick Collins</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=EhPeHeoKF88" target="_blank">Foundry Full Course – Patrick Collins (Cyfrin)</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=0kx8M4wu-HA" target="_blank">OpenZeppelin Contracts – freeCodeCamp</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Hardhat%20Complete%20Guide%20%E2%80%93%20Patrick%20Collins" target="_blank">Hardhat Complete Guide – Patrick Collins</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Foundry%20Full%20Course%20%E2%80%93%20Patrick%20Collins%20(Cyfrin)" target="_blank">Foundry Full Course – Patrick Collins (Cyfrin)</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=OpenZeppelin%20Contracts%20%E2%80%93%20freeCodeCamp" target="_blank">OpenZeppelin Contracts – freeCodeCamp</a>
           </div>
         </div>
       </div>
@@ -1079,10 +1079,10 @@
             <span class="tag">The Graph</span>
           </div>
           <div class="yt-links">
-            <a class="yt-link" href="https://www.youtube.com/watch?v=a0osIaAOFSE" target="_blank">Build Full-Stack dApp – Dapp University</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=M576WGiDBdQ" target="_blank">ethers.js Tutorial – Dapp University</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=gyMwXuJrbJQ" target="_blank">wagmi + RainbowKit Crash Course – Nader Dabit</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=p36tXHX1JD8" target="_blank">The Graph Protocol Tutorial – Nader Dabit</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Build%20Full-Stack%20dApp%20%E2%80%93%20Dapp%20University" target="_blank">Build Full-Stack dApp – Dapp University</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=ethers.js%20Tutorial%20%E2%80%93%20Dapp%20University" target="_blank">ethers.js Tutorial – Dapp University</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=wagmi%20%2B%20RainbowKit%20Crash%20Course%20%E2%80%93%20Nader%20Dabit" target="_blank">wagmi + RainbowKit Crash Course – Nader Dabit</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=The%20Graph%20Protocol%20Tutorial%20%E2%80%93%20Nader%20Dabit" target="_blank">The Graph Protocol Tutorial – Nader Dabit</a>
           </div>
         </div>
       </div>
@@ -1139,11 +1139,11 @@
             <span class="tag">Price Manipulation</span>
           </div>
           <div class="yt-links">
-            <a class="yt-link" href="https://www.youtube.com/watch?v=qB2Ulx201wY" target="_blank">DeFi Tutorial – Whiteboard Crypto (Deep Dives)</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=0W6hv4bgEiM" target="_blank">Build a DEX like Uniswap – Smart Contract Programmer</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=sTSMBVEaSAc" target="_blank">Flash Loans Explained & Build – Smart Contract Programmer</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=QD9XfCW76mE" target="_blank">Chainlink Oracles Tutorial – Patrick Collins</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=Wn_Kb3MR_cU" target="_blank">Uniswap V3 Deep Dive – Finematics</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=DeFi%20Tutorial%20%E2%80%93%20Whiteboard%20Crypto%20(Deep%20Dives)" target="_blank">DeFi Tutorial – Whiteboard Crypto (Deep Dives)</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Build%20a%20DEX%20like%20Uniswap%20%E2%80%93%20Smart%20Contract%20Programmer" target="_blank">Build a DEX like Uniswap – Smart Contract Programmer</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Flash%20Loans%20Explained%20%26%20Build%20%E2%80%93%20Smart%20Contract%20Programmer" target="_blank">Flash Loans Explained & Build – Smart Contract Programmer</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Chainlink%20Oracles%20Tutorial%20%E2%80%93%20Patrick%20Collins" target="_blank">Chainlink Oracles Tutorial – Patrick Collins</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Uniswap%20V3%20Deep%20Dive%20%E2%80%93%20Finematics" target="_blank">Uniswap V3 Deep Dive – Finematics</a>
           </div>
         </div>
       </div>
@@ -1170,10 +1170,10 @@
             <span class="tag">DeFiHackLabs</span>
           </div>
           <div class="yt-links">
-            <a class="yt-link" href="https://www.youtube.com/watch?v=LLiJK_VeAvQ" target="_blank">Smart Contract Hacking – OpenSense</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=Jm5EC_6l4TA" target="_blank">Reentrancy Attack Explained – Smart Contract Programmer</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=EhPeHeoKF88" target="_blank">Smart Contract Auditing Full Course – Cyfrin (Patrick Collins)</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=sFW3Ra37JRQ" target="_blank">All DeFi Hacks Explained – Finematics</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Smart%20Contract%20Hacking%20%E2%80%93%20OpenSense" target="_blank">Smart Contract Hacking – OpenSense</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Reentrancy%20Attack%20Explained%20%E2%80%93%20Smart%20Contract%20Programmer" target="_blank">Reentrancy Attack Explained – Smart Contract Programmer</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Smart%20Contract%20Auditing%20Full%20Course%20%E2%80%93%20Cyfrin%20(Patrick%20Collins)" target="_blank">Smart Contract Auditing Full Course – Cyfrin (Patrick Collins)</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=All%20DeFi%20Hacks%20Explained%20%E2%80%93%20Finematics" target="_blank">All DeFi Hacks Explained – Finematics</a>
           </div>
         </div>
       </div>
@@ -1262,11 +1262,11 @@
             <span class="tag">Cross-chain messaging</span>
           </div>
           <div class="yt-links">
-            <a class="yt-link" href="https://www.youtube.com/watch?v=7pWxCklcNsU" target="_blank">Layer 2 Explained – Finematics</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=BgCgauWVTs0" target="_blank">ZK Proofs Explained Simply – 3Blue1Brown</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=NkTaHsjK7CA" target="_blank">ZKSync & zkEVM Tutorial – Patrick Collins</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=sTSMBVEaSAc" target="_blank">Solana vs Ethereum – Whiteboard Crypto</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=cizLhxSKrAc" target="_blank">Cross-Chain Bridges – Finematics</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Layer%202%20Explained%20%E2%80%93%20Finematics" target="_blank">Layer 2 Explained – Finematics</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=ZK%20Proofs%20Explained%20Simply%20%E2%80%93%203Blue1Brown" target="_blank">ZK Proofs Explained Simply – 3Blue1Brown</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=ZKSync%20%26%20zkEVM%20Tutorial%20%E2%80%93%20Patrick%20Collins" target="_blank">ZKSync & zkEVM Tutorial – Patrick Collins</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Solana%20vs%20Ethereum%20%E2%80%93%20Whiteboard%20Crypto" target="_blank">Solana vs Ethereum – Whiteboard Crypto</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Cross-Chain%20Bridges%20%E2%80%93%20Finematics" target="_blank">Cross-Chain Bridges – Finematics</a>
           </div>
         </div>
       </div>
@@ -1292,9 +1292,9 @@
             <span class="tag">Twitter/X networking</span>
           </div>
           <div class="yt-links">
-            <a class="yt-link" href="https://www.youtube.com/watch?v=0kx8M4wu-HA" target="_blank">How to Get a Web3 Job in 2026 – Patrick Collins</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=EhPeHeoKF88" target="_blank">How to Win Code4rena Contests – Cyfrin</a>
-            <a class="yt-link" href="https://www.youtube.com/watch?v=9Yh4_8NKiYo" target="_blank">Building Your Web3 Portfolio – Dapp University</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=How%20to%20Get%20a%20Web3%20Job%20in%202026%20%E2%80%93%20Patrick%20Collins" target="_blank">How to Get a Web3 Job in 2026 – Patrick Collins</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=How%20to%20Win%20Code4rena%20Contests%20%E2%80%93%20Cyfrin" target="_blank">How to Win Code4rena Contests – Cyfrin</a>
+            <a class="yt-link" href="https://www.youtube.com/results?search_query=Building%20Your%20Web3%20Portfolio%20%E2%80%93%20Dapp%20University" target="_blank">Building Your Web3 Portfolio – Dapp University</a>
           </div>
         </div>
       </div>

--- a/apps/resources/content/cloud-engineer-roadmap/index.html
+++ b/apps/resources/content/cloud-engineer-roadmap/index.html
@@ -9,7 +9,9 @@
         href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&display=swap"
         rel="stylesheet">
     <style>
-        *, *::before, *::after {
+        *,
+        *::before,
+        *::after {
             box-sizing: border-box;
             margin: 0;
             padding: 0;
@@ -64,19 +66,29 @@
             gap: 8px;
             transition: background 0.2s;
         }
-        .print-btn:hover { background: #e04040; }
-        .print-btn svg { width: 16px; height: 16px; }
+
+        .print-btn:hover {
+            background: #e04040;
+        }
+
+        .print-btn svg {
+            width: 16px;
+            height: 16px;
+        }
 
         .page {
             width: 794px;
             max-width: 100%;
             background: var(--white);
-            box-shadow: 0 4px 40px rgba(0,0,0,0.18);
+            box-shadow: 0 4px 40px rgba(0, 0, 0, 0.18);
             position: relative;
             overflow: visible;
             margin-bottom: 0;
         }
-        .page + .page { margin-top: 2px; }
+
+        .page+.page {
+            margin-top: 2px;
+        }
 
         /* ── COVER ── */
         .cover {
@@ -128,6 +140,7 @@
             align-items: center;
             gap: 10px;
         }
+
         .cover-hook::before {
             content: '';
             display: block;
@@ -144,7 +157,10 @@
             letter-spacing: -0.03em;
             margin-bottom: 16px;
         }
-        .cover-title span { color: var(--red); }
+
+        .cover-title span {
+            color: var(--red);
+        }
 
         .cover-subtitle {
             font-size: 16px;
@@ -164,6 +180,7 @@
             position: relative;
             margin-bottom: 48px;
         }
+
         .cover-quote-block::before {
             content: '"';
             font-size: 80px;
@@ -174,12 +191,14 @@
             left: 24px;
             line-height: 1;
         }
+
         .cover-quote-text {
             font-size: 18px;
             font-weight: 600;
             line-height: 1.5;
             padding-top: 24px;
         }
+
         .cover-quote-sub {
             font-size: 13px;
             color: #aaa;
@@ -187,8 +206,17 @@
             font-family: var(--mono);
         }
 
-        .cover-stats { display: flex; gap: 32px; }
-        .stat-item { display: flex; flex-direction: column; gap: 4px; }
+        .cover-stats {
+            display: flex;
+            gap: 32px;
+        }
+
+        .stat-item {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
         .stat-num {
             font-size: 32px;
             font-weight: 800;
@@ -196,6 +224,7 @@
             font-family: var(--mono);
             line-height: 1;
         }
+
         .stat-label {
             font-size: 12px;
             color: var(--soft);
@@ -223,11 +252,13 @@
             justify-content: space-between;
             align-items: center;
         }
+
         .cover-footer-text {
             font-family: var(--mono);
             font-size: 11px;
             color: var(--soft);
         }
+
         .page-num {
             font-family: var(--mono);
             font-size: 11px;
@@ -251,9 +282,26 @@
             border-bottom: 1px solid var(--border);
             flex-shrink: 0;
         }
-        .page-header img { height: 22px; opacity: 0.7; }
-        .page-header-logo { font-family: var(--mono); font-size: 11px; font-weight: 700; color: var(--soft); }
-        .page-header-title { font-family: var(--mono); font-size: 11px; color: var(--soft); text-transform: uppercase; letter-spacing: 0.08em; }
+
+        .page-header img {
+            height: 22px;
+            opacity: 0.7;
+        }
+
+        .page-header-logo {
+            font-family: var(--mono);
+            font-size: 11px;
+            font-weight: 700;
+            color: var(--soft);
+        }
+
+        .page-header-title {
+            font-family: var(--mono);
+            font-size: 11px;
+            color: var(--soft);
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
 
         .page-body {
             flex: 1;
@@ -283,7 +331,11 @@
             align-items: center;
             gap: 8px;
         }
-        .section-label::before { content: '//'; opacity: 0.5; }
+
+        .section-label::before {
+            content: '//';
+            opacity: 0.5;
+        }
 
         .section-title {
             font-size: 26px;
@@ -295,8 +347,18 @@
         }
 
         /* ── ROADMAP STEPS ── */
-        .roadmap { display: flex; flex-direction: column; gap: 0; }
-        .step { display: flex; gap: 0; position: relative; }
+        .roadmap {
+            display: flex;
+            flex-direction: column;
+            gap: 0;
+        }
+
+        .step {
+            display: flex;
+            gap: 0;
+            position: relative;
+        }
+
         .step-left {
             display: flex;
             flex-direction: column;
@@ -304,6 +366,7 @@
             width: 48px;
             flex-shrink: 0;
         }
+
         .step-dot {
             width: 34px;
             height: 34px;
@@ -320,6 +383,7 @@
             position: relative;
             z-index: 1;
         }
+
         .step-line {
             width: 2px;
             flex: 1;
@@ -327,7 +391,12 @@
             background: var(--border);
             margin: 4px 0;
         }
-        .step-content { flex: 1; padding: 2px 0 18px 20px; }
+
+        .step-content {
+            flex: 1;
+            padding: 2px 0 18px 20px;
+        }
+
         .step-phase {
             font-family: var(--mono);
             font-size: 10px;
@@ -337,9 +406,27 @@
             text-transform: uppercase;
             margin-bottom: 2px;
         }
-        .step-heading { font-size: 15px; font-weight: 700; color: var(--dark); margin-bottom: 4px; }
-        .step-desc { font-size: 12px; color: var(--mid); line-height: 1.6; margin-bottom: 6px; }
-        .step-tags { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 5px; }
+
+        .step-heading {
+            font-size: 15px;
+            font-weight: 700;
+            color: var(--dark);
+            margin-bottom: 4px;
+        }
+
+        .step-desc {
+            font-size: 12px;
+            color: var(--mid);
+            line-height: 1.6;
+            margin-bottom: 6px;
+        }
+
+        .step-tags {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+            margin-bottom: 5px;
+        }
 
         .tag {
             font-family: var(--mono);
@@ -351,6 +438,7 @@
             border-radius: 4px;
             font-weight: 500;
         }
+
         .tag.red {
             background: var(--red-light);
             color: var(--red);
@@ -358,7 +446,13 @@
         }
 
         /* ── YOUTUBE LINKS ── */
-        .yt-links { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 4px; }
+        .yt-links {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+            margin-top: 4px;
+        }
+
         .yt-link {
             display: inline-flex;
             align-items: center;
@@ -374,8 +468,15 @@
             font-weight: 600;
             transition: background 0.15s;
         }
-        .yt-link:hover { background: #ffe0e0; }
-        .yt-link::before { content: '▶'; font-size: 8px; }
+
+        .yt-link:hover {
+            background: #ffe0e0;
+        }
+
+        .yt-link::before {
+            content: '▶';
+            font-size: 8px;
+        }
 
         /* ── TIME BADGE ── */
         .time-badge {
@@ -387,8 +488,10 @@
             color: var(--soft);
             margin-bottom: 3px;
         }
+
         .time-badge span {
-            width: 5px; height: 5px;
+            width: 5px;
+            height: 5px;
             border-radius: 50%;
             background: var(--red);
             display: inline-block;
@@ -405,12 +508,28 @@
             gap: 12px;
             align-items: flex-start;
         }
-        .tip-icon { font-size: 16px; flex-shrink: 0; }
-        .tip-text { font-size: 12px; color: var(--dark); line-height: 1.6; }
-        .tip-text strong { color: var(--red); }
+
+        .tip-icon {
+            font-size: 16px;
+            flex-shrink: 0;
+        }
+
+        .tip-text {
+            font-size: 12px;
+            color: var(--dark);
+            line-height: 1.6;
+        }
+
+        .tip-text strong {
+            color: var(--red);
+        }
 
         /* ── DIVIDER ── */
-        .divider { border: none; border-top: 1px solid var(--border); margin: 14px 0; }
+        .divider {
+            border: none;
+            border-top: 1px solid var(--border);
+            margin: 14px 0;
+        }
 
         /* ── SKILLS TABLE ── */
         .skills-row {
@@ -419,7 +538,13 @@
             gap: 12px;
             margin-bottom: 14px;
         }
-        .skill-col { display: flex; flex-direction: column; gap: 5px; }
+
+        .skill-col {
+            display: flex;
+            flex-direction: column;
+            gap: 5px;
+        }
+
         .skill-col-title {
             font-family: var(--mono);
             font-size: 10px;
@@ -429,6 +554,7 @@
             margin-bottom: 4px;
             font-weight: 700;
         }
+
         .skill-item {
             display: flex;
             align-items: center;
@@ -436,9 +562,11 @@
             font-size: 12px;
             color: var(--dark);
         }
+
         .skill-item::before {
             content: '';
-            width: 5px; height: 5px;
+            width: 5px;
+            height: 5px;
             border-radius: 50%;
             background: var(--red);
             flex-shrink: 0;
@@ -451,6 +579,7 @@
             gap: 10px;
             margin-bottom: 14px;
         }
+
         .resource-card {
             border: 1.5px solid var(--border);
             border-radius: 10px;
@@ -458,18 +587,38 @@
             position: relative;
             overflow: hidden;
         }
+
         .resource-card::before {
             content: '';
             position: absolute;
-            top: 0; left: 0;
-            width: 4px; height: 100%;
+            top: 0;
+            left: 0;
+            width: 4px;
+            height: 100%;
             background: var(--red);
         }
-        .resource-card-name { font-size: 13px; font-weight: 700; color: var(--dark); margin-bottom: 3px; }
-        .resource-card-desc { font-size: 11px; color: var(--mid); line-height: 1.5; margin-bottom: 7px; }
+
+        .resource-card-name {
+            font-size: 13px;
+            font-weight: 700;
+            color: var(--dark);
+            margin-bottom: 3px;
+        }
+
+        .resource-card-desc {
+            font-size: 11px;
+            color: var(--mid);
+            line-height: 1.5;
+            margin-bottom: 7px;
+        }
 
         /* ── CHECKLIST ── */
-        .checklist { display: flex; flex-direction: column; gap: 6px; }
+        .checklist {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
         .check-item {
             display: flex;
             align-items: flex-start;
@@ -478,8 +627,10 @@
             color: var(--dark);
             line-height: 1.5;
         }
+
         .check-box {
-            width: 16px; height: 16px;
+            width: 16px;
+            height: 16px;
             border: 2px solid var(--border);
             border-radius: 4px;
             flex-shrink: 0;
@@ -493,6 +644,7 @@
             gap: 10px;
             margin-top: 10px;
         }
+
         .social-card {
             border: 1px solid var(--border);
             border-radius: 10px;
@@ -500,7 +652,15 @@
             text-align: center;
             text-decoration: none;
         }
-        .social-icon { width: 24px; height: 24px; display: block; margin: 0 auto; margin-bottom: 6px; }
+
+        .social-icon {
+            width: 24px;
+            height: 24px;
+            display: block;
+            margin: 0 auto;
+            margin-bottom: 6px;
+        }
+
         .social-name {
             font-family: var(--mono);
             font-size: 10px;
@@ -510,7 +670,12 @@
             display: block;
             margin-bottom: 2px;
         }
-        .social-handle { font-size: 11px; font-weight: 600; color: var(--dark); }
+
+        .social-handle {
+            font-size: 11px;
+            font-weight: 600;
+            color: var(--dark);
+        }
 
         /* ── CTA ── */
         .cta-block {
@@ -521,17 +686,35 @@
             position: relative;
             overflow: hidden;
         }
+
         .cta-block::before {
             content: '';
             position: absolute;
-            width: 200px; height: 200px;
+            width: 200px;
+            height: 200px;
             border-radius: 50%;
-            background: radial-gradient(circle, rgba(255,87,87,0.3) 0%, transparent 70%);
-            top: -60px; right: -60px;
+            background: radial-gradient(circle, rgba(255, 87, 87, 0.3) 0%, transparent 70%);
+            top: -60px;
+            right: -60px;
             pointer-events: none;
         }
-        .cta-title { font-size: 20px; font-weight: 800; color: white; margin-bottom: 6px; position: relative; }
-        .cta-sub { font-size: 13px; color: #aaa; margin-bottom: 14px; line-height: 1.5; position: relative; }
+
+        .cta-title {
+            font-size: 20px;
+            font-weight: 800;
+            color: white;
+            margin-bottom: 6px;
+            position: relative;
+        }
+
+        .cta-sub {
+            font-size: 13px;
+            color: #aaa;
+            margin-bottom: 14px;
+            line-height: 1.5;
+            position: relative;
+        }
+
         .cta-link {
             display: inline-block;
             background: var(--red);
@@ -552,6 +735,7 @@
             font-size: 12px;
             margin-bottom: 14px;
         }
+
         .stack-table th {
             background: var(--bg);
             color: var(--soft);
@@ -564,13 +748,18 @@
             border-bottom: 2px solid var(--border);
             font-weight: 700;
         }
+
         .stack-table td {
             padding: 8px 12px;
             border-bottom: 1px solid var(--border);
             color: var(--dark);
             line-height: 1.4;
         }
-        .stack-table tr:last-child td { border-bottom: none; }
+
+        .stack-table tr:last-child td {
+            border-bottom: none;
+        }
+
         .stack-table td:first-child {
             font-family: var(--mono);
             font-size: 11px;
@@ -586,6 +775,7 @@
                 width: 100%;
                 align-items: stretch;
             }
+
             .print-bar {
                 width: 100%;
                 padding: 12px 16px;
@@ -594,9 +784,14 @@
                 position: sticky;
                 top: 0;
                 z-index: 100;
-                box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+                box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
             }
-            .print-btn { width: 100%; justify-content: center; }
+
+            .print-btn {
+                width: 100%;
+                justify-content: center;
+            }
+
             .page {
                 width: 100%;
                 max-width: 100%;
@@ -604,859 +799,1326 @@
                 border-radius: 0;
                 overflow: visible;
             }
-            .page + .page { margin-top: 8px; }
-            .cover { height: auto; min-height: unset; }
-            .cover-header { padding: 20px 20px 0; }
-            .cover-hero { padding: 28px 20px 28px; justify-content: flex-start; }
-            .cover-title { font-size: 36px; }
-            .cover-subtitle { font-size: 13px; max-width: 100%; }
-            .cover-quote-block { padding: 20px; max-width: 100%; }
-            .cover-quote-text { font-size: 14px; }
-            .cover-stats { gap: 16px; flex-wrap: wrap; }
-            .stat-num { font-size: 24px; }
-            .cover-footer { padding: 14px 20px; flex-wrap: wrap; }
-            .inner-page { height: auto; }
-            .page-header { padding: 14px 20px 12px; }
-            .page-body { padding: 20px 20px; }
-            .page-footer { padding: 12px 20px; }
-            .section-title { font-size: 20px; }
-            .step-content { padding: 2px 0 16px 12px; }
-            .skills-row { grid-template-columns: 1fr; gap: 16px; }
-            .resource-grid { grid-template-columns: 1fr; }
-            .socials-grid { grid-template-columns: repeat(3, 1fr); gap: 8px; }
-            .social-card { padding: 10px 8px; }
-            .page-num { display: none; }
-            .cover-decoration { width: 140px; height: 140px; right: -30px; top: 20px; transform: none; }
-            .stack-table { font-size: 11px; }
-            .stack-table th, .stack-table td { padding: 6px 8px; }
-            .page-header-title { display: none; }
+
+            .page+.page {
+                margin-top: 8px;
+            }
+
+            .cover {
+                height: auto;
+                min-height: unset;
+            }
+
+            .cover-header {
+                padding: 20px 20px 0;
+            }
+
+            .cover-hero {
+                padding: 28px 20px 28px;
+                justify-content: flex-start;
+            }
+
+            .cover-title {
+                font-size: 36px;
+            }
+
+            .cover-subtitle {
+                font-size: 13px;
+                max-width: 100%;
+            }
+
+            .cover-quote-block {
+                padding: 20px;
+                max-width: 100%;
+            }
+
+            .cover-quote-text {
+                font-size: 14px;
+            }
+
+            .cover-stats {
+                gap: 16px;
+                flex-wrap: wrap;
+            }
+
+            .stat-num {
+                font-size: 24px;
+            }
+
+            .cover-footer {
+                padding: 14px 20px;
+                flex-wrap: wrap;
+            }
+
+            .inner-page {
+                height: auto;
+            }
+
+            .page-header {
+                padding: 14px 20px 12px;
+            }
+
+            .page-body {
+                padding: 20px 20px;
+            }
+
+            .page-footer {
+                padding: 12px 20px;
+            }
+
+            .section-title {
+                font-size: 20px;
+            }
+
+            .step-content {
+                padding: 2px 0 16px 12px;
+            }
+
+            .skills-row {
+                grid-template-columns: 1fr;
+                gap: 16px;
+            }
+
+            .resource-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .socials-grid {
+                grid-template-columns: repeat(3, 1fr);
+                gap: 8px;
+            }
+
+            .social-card {
+                padding: 10px 8px;
+            }
+
+            .page-num {
+                display: none;
+            }
+
+            .cover-decoration {
+                width: 140px;
+                height: 140px;
+                right: -30px;
+                top: 20px;
+                transform: none;
+            }
+
+            .stack-table {
+                font-size: 11px;
+            }
+
+            .stack-table th,
+            .stack-table td {
+                padding: 6px 8px;
+            }
+
+            .page-header-title {
+                display: none;
+            }
         }
 
         @media print {
-            @page { size: A4 portrait; margin: 0; }
+            @page {
+                size: A4 portrait;
+                margin: 0;
+            }
+
             .resource-viewer {
-                margin: 0; padding: 0;
+                margin: 0;
+                padding: 0;
                 background: white;
                 display: block;
                 width: 210mm;
             }
-            .print-bar { display: none !important; }
+
+            .print-bar {
+                display: none !important;
+            }
+
             .page {
                 width: 210mm;
                 height: 297mm;
                 max-width: none;
                 box-shadow: none;
-                margin: 0; padding: 0;
+                margin: 0;
+                padding: 0;
                 page-break-after: always;
                 break-after: page;
                 overflow: hidden;
             }
-            .page + .page { margin-top: 0; }
-            .cover { height: 297mm; min-height: unset; }
-            .inner-page { height: 297mm; min-height: unset; }
-            .page-body { overflow: hidden; }
+
+            .page+.page {
+                margin-top: 0;
+            }
+
+            .cover {
+                height: 297mm;
+                min-height: unset;
+            }
+
+            .inner-page {
+                height: 297mm;
+                min-height: unset;
+            }
+
+            .page-body {
+                overflow: hidden;
+            }
+
             * {
                 -webkit-print-color-adjust: exact !important;
                 print-color-adjust: exact !important;
             }
-            .page:last-child { page-break-after: avoid; break-after: avoid; }
+
+            .page:last-child {
+                page-break-after: avoid;
+                break-after: avoid;
+            }
         }
     </style>
 </head>
 
 <body>
-<div class="resource-viewer">
+    <div class="resource-viewer">
 
-    <!-- PRINT BAR -->
-    <div class="print-bar">
-        <button class="print-btn" onclick="window.print()">
-            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-                <path d="M6 9V2h12v7M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2M6 14h12v8H6z"/>
-            </svg>
-            Save as PDF
-        </button>
-    </div>
-
-    <!-- ══════════════════════ PAGE 1 — COVER ══════════════════════ -->
-    <div class="page cover">
-        <div class="cover-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="cover-badge">2026 Edition</span>
+        <!-- PRINT BAR -->
+        <div class="print-bar">
+            <button class="print-btn" onclick="window.print()">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                    <path
+                        d="M6 9V2h12v7M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2M6 14h12v8H6z" />
+                </svg>
+                Save as PDF
+            </button>
         </div>
-        <div class="cover-hero">
-            <div class="cover-decoration"></div>
-            <div class="cover-hook">From zero to cloud-native — no shortcuts</div>
-            <h1 class="cover-title">
-                Cloud<br><span>Engineer</span><br>Roadmap
-            </h1>
-            <p class="cover-subtitle">
-                From Linux basics to architecting multi-cloud production systems in 2026. Networking, IaC, containers, Kubernetes, DevOps, security, and cost engineering — everything you need with free YouTube resources for every phase.
-            </p>
-            <div class="cover-quote-block">
-                <div class="cover-quote-text">
-                    "Every company runs on cloud infrastructure. The engineer who can design, automate, secure, and scale that infrastructure — reliably, at any size — will never be out of work. Cloud is the foundation everything else is built on."
-                </div>
-                <div class="cover-quote-sub">— The Boring Education Team</div>
+
+        <!-- ══════════════════════ PAGE 1 — COVER ══════════════════════ -->
+        <div class="page cover">
+            <div class="cover-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="cover-badge">2026 Edition</span>
             </div>
-            <div class="cover-stats">
-                <div class="stat-item">
-                    <div class="stat-num">10–16</div>
-                    <div class="stat-label">Months to job-ready</div>
+            <div class="cover-hero">
+                <div class="cover-decoration"></div>
+                <div class="cover-hook">From zero to cloud-native — no shortcuts</div>
+                <h1 class="cover-title">
+                    Cloud<br><span>Engineer</span><br>Roadmap
+                </h1>
+                <p class="cover-subtitle">
+                    From Linux basics to architecting multi-cloud production systems in 2026. Networking, IaC,
+                    containers, Kubernetes, DevOps, security, and cost engineering — everything you need with free
+                    YouTube resources for every phase.
+                </p>
+                <div class="cover-quote-block">
+                    <div class="cover-quote-text">
+                        "Every company runs on cloud infrastructure. The engineer who can design, automate, secure, and
+                        scale that infrastructure — reliably, at any size — will never be out of work. Cloud is the
+                        foundation everything else is built on."
+                    </div>
+                    <div class="cover-quote-sub">— The Boring Education Team</div>
                 </div>
-                <div class="stat-item">
-                    <div class="stat-num">11</div>
-                    <div class="stat-label">Phases to master</div>
-                </div>
-                <div class="stat-item">
-                    <div class="stat-num">50+</div>
-                    <div class="stat-label">Free YT resources</div>
-                </div>
-                <div class="stat-item">
-                    <div class="stat-num">∞</div>
-                    <div class="stat-label">Career ceiling</div>
+                <div class="cover-stats">
+                    <div class="stat-item">
+                        <div class="stat-num">10–16</div>
+                        <div class="stat-label">Months to job-ready</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-num">11</div>
+                        <div class="stat-label">Phases to master</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-num">50+</div>
+                        <div class="stat-label">Free YT resources</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-num">∞</div>
+                        <div class="stat-label">Career ceiling</div>
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="cover-footer">
-            <span class="cover-footer-text">theboringeducation.com &nbsp;·&nbsp; Free Tech Education for Everyone</span>
-            <span class="page-num">01</span>
-        </div>
-    </div>
-
-    <!-- ══════════════════════ PAGE 2 — PHASES 1–2 ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
-            <span class="page-num">02</span>
-        </div>
-        <div class="page-body">
-            <div class="section-label">Foundation Layer</div>
-            <h2 class="section-title">Start Here — Linux, Networking & Scripting</h2>
-            <div class="roadmap">
-
-                <!-- PHASE 1 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">1</div>
-                        <div class="step-line"></div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 1–5</div>
-                        <div class="step-phase">Phase 01 · Linux Fundamentals</div>
-                        <div class="step-heading">Linux — The Operating System of the Cloud</div>
-                        <div class="step-desc">Every cloud server runs Linux. You cannot be a cloud engineer without fluency in the command line. Master the <strong>Linux file system hierarchy</strong>: /, /etc, /var, /home, /usr. Learn essential commands: <strong>ls, cd, grep, find, awk, sed, ps, top, df, du, chmod, chown, ssh</strong>. Understand <strong>file permissions and ownership</strong> — critical for security. Learn <strong>process management</strong>: systemd, journalctl, cron jobs. Study <strong>package management</strong>: apt (Ubuntu/Debian), yum/dnf (RHEL/Amazon Linux). Master <strong>shell scripting with Bash</strong>: variables, loops, conditionals, functions — you'll write these daily for automation. Understand <strong>environment variables</strong>, stdin/stdout/stderr, pipes, and redirects. Practice everything on Ubuntu — it's the most common cloud distro.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Non-negotiable</span>
-                            <span class="tag">Linux CLI</span>
-                            <span class="tag">Bash scripting</span>
-                            <span class="tag">File permissions</span>
-                            <span class="tag">systemd / cron</span>
-                            <span class="tag">ssh / scp</span>
-                            <span class="tag">grep / awk / sed</span>
-                            <span class="tag">apt / yum</span>
-                        </div>
-                        <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=ZtqBQ68cfJc" target="_blank">Linux Full Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=GtovwKDemnI" target="_blank">Linux Command Line Basics – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=v-a3QTeSoJk" target="_blank">Bash Scripting Full Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=oxuRxtrO2Ag" target="_blank">Linux for Cloud Engineers – NetworkChuck</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=wBp0Rb-ZJak" target="_blank">Linux Permissions Explained – TechWorld with Nana</a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- PHASE 2 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">2</div>
-                        <div class="step-line"></div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 3–8</div>
-                        <div class="step-phase">Phase 02 · Networking Fundamentals</div>
-                        <div class="step-heading">Networking — The Invisible Backbone of Cloud</div>
-                        <div class="step-desc">Cloud is fundamentally distributed computing over networks. Without networking knowledge you'll be stuck debugging VPC issues for hours. Master the <strong>OSI model</strong> — know which layer each problem lives at. Understand <strong>TCP/IP, UDP, DNS, DHCP, HTTP/S, SSH, FTP</strong>. Learn <strong>IP addressing and subnetting</strong> — CIDR notation (/16, /24, /32) is used everywhere in VPC design. Study <strong>routing and switching concepts</strong>: default gateways, route tables, NAT. Understand <strong>firewalls and security groups</strong>: inbound/outbound rules, stateful vs stateless. Learn <strong>load balancing</strong>: L4 vs L7, round-robin, health checks. Study <strong>CDN principles</strong> and <strong>DNS record types</strong> (A, CNAME, MX, TXT, NS). These concepts map directly to AWS VPC, Security Groups, ELB, and Route 53.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Cloud backbone</span>
-                            <span class="tag">OSI model</span>
-                            <span class="tag">TCP/IP</span>
-                            <span class="tag">CIDR / subnetting</span>
-                            <span class="tag">DNS record types</span>
-                            <span class="tag">NAT / routing</span>
-                            <span class="tag">Load balancing</span>
-                            <span class="tag">Firewalls / SGs</span>
-                        </div>
-                        <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=IPvYjXCsTg8" target="_blank">Computer Networking Full Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=3QhU9jd03a0" target="_blank">Subnetting & CIDR – NetworkChuck</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=Wn7i4GMBwBE" target="_blank">DNS Explained – NetworkChuck</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=ueVnSz_lXEs" target="_blank">Load Balancer Explained – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=7_LPdttKXPc" target="_blank">How the Internet Works – Fireship</a>
-                        </div>
-                    </div>
-                </div>
-
+            <div class="cover-footer">
+                <span class="cover-footer-text">theboringeducation.com &nbsp;·&nbsp; Free Tech Education for
+                    Everyone</span>
+                <span class="page-num">01</span>
             </div>
-            <div style="margin-top:16px;">
+        </div>
+
+        <!-- ══════════════════════ PAGE 2 — PHASES 1–2 ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
+                <span class="page-num">02</span>
+            </div>
+            <div class="page-body">
+                <div class="section-label">Foundation Layer</div>
+                <h2 class="section-title">Start Here — Linux, Networking & Scripting</h2>
+                <div class="roadmap">
+
+                    <!-- PHASE 1 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">1</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 1–5</div>
+                            <div class="step-phase">Phase 01 · Linux Fundamentals</div>
+                            <div class="step-heading">Linux — The Operating System of the Cloud</div>
+                            <div class="step-desc">Every cloud server runs Linux. You cannot be a cloud engineer without
+                                fluency in the command line. Master the <strong>Linux file system hierarchy</strong>: /,
+                                /etc, /var, /home, /usr. Learn essential commands: <strong>ls, cd, grep, find, awk, sed,
+                                    ps, top, df, du, chmod, chown, ssh</strong>. Understand <strong>file permissions and
+                                    ownership</strong> — critical for security. Learn <strong>process
+                                    management</strong>: systemd, journalctl, cron jobs. Study <strong>package
+                                    management</strong>: apt (Ubuntu/Debian), yum/dnf (RHEL/Amazon Linux). Master
+                                <strong>shell scripting with Bash</strong>: variables, loops, conditionals, functions —
+                                you'll write these daily for automation. Understand <strong>environment
+                                    variables</strong>, stdin/stdout/stderr, pipes, and redirects. Practice everything
+                                on Ubuntu — it's the most common cloud distro.
+                            </div>
+                            <div class="step-tags">
+                                <span class="tag red">Non-negotiable</span>
+                                <span class="tag">Linux CLI</span>
+                                <span class="tag">Bash scripting</span>
+                                <span class="tag">File permissions</span>
+                                <span class="tag">systemd / cron</span>
+                                <span class="tag">ssh / scp</span>
+                                <span class="tag">grep / awk / sed</span>
+                                <span class="tag">apt / yum</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Linux%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Linux Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Linux%20Command%20Line%20Basics%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Linux Command Line Basics – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Bash%20Scripting%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Bash Scripting Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Linux%20for%20Cloud%20Engineers%20%E2%80%93%20NetworkChuck"
+                                    target="_blank">Linux for Cloud Engineers – NetworkChuck</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Linux%20Permissions%20Explained%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Linux Permissions Explained – TechWorld with Nana</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- PHASE 2 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">2</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 3–8</div>
+                            <div class="step-phase">Phase 02 · Networking Fundamentals</div>
+                            <div class="step-heading">Networking — The Invisible Backbone of Cloud</div>
+                            <div class="step-desc">Cloud is fundamentally distributed computing over networks. Without
+                                networking knowledge you'll be stuck debugging VPC issues for hours. Master the
+                                <strong>OSI model</strong> — know which layer each problem lives at. Understand
+                                <strong>TCP/IP, UDP, DNS, DHCP, HTTP/S, SSH, FTP</strong>. Learn <strong>IP addressing
+                                    and subnetting</strong> — CIDR notation (/16, /24, /32) is used everywhere in VPC
+                                design. Study <strong>routing and switching concepts</strong>: default gateways, route
+                                tables, NAT. Understand <strong>firewalls and security groups</strong>: inbound/outbound
+                                rules, stateful vs stateless. Learn <strong>load balancing</strong>: L4 vs L7,
+                                round-robin, health checks. Study <strong>CDN principles</strong> and <strong>DNS record
+                                    types</strong> (A, CNAME, MX, TXT, NS). These concepts map directly to AWS VPC,
+                                Security Groups, ELB, and Route 53.
+                            </div>
+                            <div class="step-tags">
+                                <span class="tag red">Cloud backbone</span>
+                                <span class="tag">OSI model</span>
+                                <span class="tag">TCP/IP</span>
+                                <span class="tag">CIDR / subnetting</span>
+                                <span class="tag">DNS record types</span>
+                                <span class="tag">NAT / routing</span>
+                                <span class="tag">Load balancing</span>
+                                <span class="tag">Firewalls / SGs</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Computer%20Networking%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Computer Networking Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Subnetting%20%26%20CIDR%20%E2%80%93%20NetworkChuck"
+                                    target="_blank">Subnetting & CIDR – NetworkChuck</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=DNS%20Explained%20%E2%80%93%20NetworkChuck"
+                                    target="_blank">DNS Explained – NetworkChuck</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Load%20Balancer%20Explained%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Load Balancer Explained – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=How%20the%20Internet%20Works%20%E2%80%93%20Fireship"
+                                    target="_blank">How the Internet Works – Fireship</a>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+                <div style="margin-top:16px;">
+                    <div class="tip-block">
+                        <div class="tip-icon">🐧</div>
+                        <div class="tip-text"><strong>Spin up a Linux VM and live in the terminal.</strong> Don't just
+                            watch tutorials — install Ubuntu in VirtualBox or WSL2, delete your GUI, and do everything
+                            from the command line for 30 days. AWS EC2, GCP Compute Engine, and Azure VMs are all Linux.
+                            If you can't navigate Linux confidently, you'll be slow at everything cloud-related.</div>
+                    </div>
+                </div>
+            </div>
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">02 / 09</span>
+            </div>
+        </div>
+
+        <!-- ══════════════════════ PAGE 3 — PHASES 3–4 ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
+                <span class="page-num">03</span>
+            </div>
+            <div class="page-body">
+                <div class="section-label">Cloud Platforms & Core Services</div>
+                <h2 class="section-title">AWS / GCP / Azure & Cloud Fundamentals</h2>
+                <div class="roadmap">
+
+                    <!-- PHASE 3 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">3</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 6–14</div>
+                            <div class="step-phase">Phase 03 · AWS Core Services</div>
+                            <div class="step-heading">Amazon Web Services — The Cloud You Must Know First</div>
+                            <div class="step-desc">AWS has 33% of the cloud market — start here. Deeply learn:
+                                <strong>EC2</strong> (virtual machines): instance types, AMIs, key pairs, EBS volumes,
+                                Auto Scaling Groups, Launch Templates. <strong>S3</strong>: buckets, storage classes,
+                                lifecycle policies, versioning, presigned URLs, static website hosting.
+                                <strong>VPC</strong>: subnets (public/private), Internet Gateway, NAT Gateway, Route
+                                Tables, Security Groups, NACLs, VPC Peering. <strong>IAM</strong>: users, groups, roles,
+                                policies (identity-based vs resource-based), MFA — this is the most important security
+                                service. <strong>RDS &amp; DynamoDB</strong>: managed relational and NoSQL databases.
+                                <strong>Lambda</strong>: serverless functions, event triggers, cold starts.
+                                <strong>ELB</strong>: ALB vs NLB, target groups, listener rules. <strong>Route
+                                    53</strong>: DNS hosting, health checks, routing policies.
+                                <strong>CloudWatch</strong>: metrics, logs, alarms, dashboards. Earn <strong>AWS
+                                    Solutions Architect Associate</strong> certification — it validates all of this.
+                            </div>
+                            <div class="step-tags">
+                                <span class="tag red">Market leader — start here</span>
+                                <span class="tag">EC2 + Auto Scaling</span>
+                                <span class="tag">S3 + lifecycle</span>
+                                <span class="tag">VPC + subnets</span>
+                                <span class="tag">IAM roles/policies</span>
+                                <span class="tag">RDS / DynamoDB</span>
+                                <span class="tag">Lambda</span>
+                                <span class="tag">CloudWatch</span>
+                                <span class="tag">AWS SAA-C03 cert</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">AWS Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20SAA%20Prep%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">AWS SAA Prep – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20VPC%20Explained%20%E2%80%93%20Tiny%20Technical%20Tutorials"
+                                    target="_blank">AWS VPC Explained –
+                                    Tiny Technical Tutorials</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20IAM%20Deep%20Dive%20%E2%80%93%20Tiny%20Technical%20Tutorials"
+                                    target="_blank">AWS IAM Deep Dive –
+                                    Tiny Technical Tutorials</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20Lambda%20Full%20Course%20%E2%80%93%20Digital%20Cloud%20Training"
+                                    target="_blank">AWS Lambda Full Course –
+                                    Digital Cloud Training</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- PHASE 4 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">4</div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 12–18</div>
+                            <div class="step-phase">Phase 04 · GCP & Azure (Secondary Cloud)</div>
+                            <div class="step-heading">Google Cloud & Azure — Be Multi-Cloud Capable</div>
+                            <div class="step-desc">Most enterprises use 2+ clouds. Learn the AWS equivalents on GCP and
+                                Azure to be a versatile hire. <strong>GCP focus</strong>: Compute Engine (EC2 equiv.),
+                                Cloud Storage (S3), GKE — Google Kubernetes Engine (the best managed K8s), BigQuery
+                                (data warehousing), Cloud Run (serverless containers), Cloud IAM, and VPC networking.
+                                GCP is dominant in data engineering and ML workloads. <strong>Azure focus</strong>:
+                                Azure VMs, Azure Blob Storage, AKS (Kubernetes), Azure Active Directory / Entra ID
+                                (critical for enterprise — AD integration is a key differentiator), Azure DevOps, App
+                                Service, and Azure Networking (VNets, NSGs). Earn <strong>Google Associate Cloud
+                                    Engineer</strong> or <strong>Azure AZ-900/AZ-104</strong> as secondary certs.
+                                Understanding the concept mapping across clouds (VPC ↔ VNet ↔ VPC) makes you a fast
+                                learner on any platform.</div>
+                            <div class="step-tags">
+                                <span class="tag red">Multi-cloud</span>
+                                <span class="tag">GKE (best K8s)</span>
+                                <span class="tag">BigQuery</span>
+                                <span class="tag">Cloud Run</span>
+                                <span class="tag">Azure AD / Entra ID</span>
+                                <span class="tag">Azure DevOps</span>
+                                <span class="tag">AKS</span>
+                                <span class="tag">ACE / AZ-104 cert</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=GCP%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">GCP Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Azure%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Azure Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=GCP%20vs%20AWS%20vs%20Azure%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">GCP vs AWS vs Azure – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Azure%20AZ-900%20Prep%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Azure AZ-900 Prep – freeCodeCamp</a>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+                <hr class="divider">
+                <div class="section-label">Cloud Provider Comparison</div>
+                <table class="stack-table">
+                    <thead>
+                        <tr>
+                            <th>Service Type</th>
+                            <th>AWS</th>
+                            <th>Google Cloud</th>
+                            <th>Azure</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Compute VMs</td>
+                            <td>EC2</td>
+                            <td>Compute Engine</td>
+                            <td>Azure Virtual Machines</td>
+                        </tr>
+                        <tr>
+                            <td>Object Storage</td>
+                            <td>S3</td>
+                            <td>Cloud Storage</td>
+                            <td>Blob Storage</td>
+                        </tr>
+                        <tr>
+                            <td>Managed K8s</td>
+                            <td>EKS</td>
+                            <td>GKE ⭐ (best)</td>
+                            <td>AKS</td>
+                        </tr>
+                        <tr>
+                            <td>Serverless</td>
+                            <td>Lambda</td>
+                            <td>Cloud Functions / Run</td>
+                            <td>Azure Functions</td>
+                        </tr>
+                        <tr>
+                            <td>DNS</td>
+                            <td>Route 53</td>
+                            <td>Cloud DNS</td>
+                            <td>Azure DNS</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">03 / 09</span>
+            </div>
+        </div>
+
+        <!-- ══════════════════════ PAGE 4 — PHASES 5–6 ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
+                <span class="page-num">04</span>
+            </div>
+            <div class="page-body">
+                <div class="section-label">Containers & Orchestration</div>
+                <h2 class="section-title">Docker, Kubernetes & Container Ecosystem</h2>
+                <div class="roadmap">
+
+                    <!-- PHASE 5 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">5</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 10–18</div>
+                            <div class="step-phase">Phase 05 · Docker & Containerization</div>
+                            <div class="step-heading">Docker — Package Anything, Run Anywhere</div>
+                            <div class="step-desc">Containers are the unit of deployment in modern cloud. Master Docker
+                                completely. Understand <strong>container vs VM</strong>: containers share the host
+                                kernel, VMs have separate OS — containers are faster, lighter, portable. Learn to write
+                                production-quality <strong>Dockerfiles</strong>: multi-stage builds, layer caching,
+                                minimal base images (alpine, distroless), non-root users, .dockerignore. Master
+                                <strong>Docker Compose</strong> for multi-container local development: services,
+                                networks, volumes, environment files. Understand <strong>container registries</strong>:
+                                Docker Hub, Amazon ECR, Google Artifact Registry — tagging, pushing, pulling images.
+                                Learn <strong>container networking</strong>: bridge, host, overlay networks. Understand
+                                <strong>container security</strong>: image scanning with Trivy, running as non-root,
+                                read-only filesystems, secrets management. Learn <strong>Docker volumes</strong> for
+                                persistent data. Know the difference between COPY vs ADD, CMD vs ENTRYPOINT —
+                                interviewers love this.
+                            </div>
+                            <div class="step-tags">
+                                <span class="tag red">Modern deployment unit</span>
+                                <span class="tag">Dockerfile best practices</span>
+                                <span class="tag">Multi-stage builds</span>
+                                <span class="tag">Docker Compose</span>
+                                <span class="tag">ECR / Artifact Registry</span>
+                                <span class="tag">Trivy image scanning</span>
+                                <span class="tag">Container networking</span>
+                                <span class="tag">Volumes / secrets</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Docker%20Full%20Course%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Docker Full Course – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Docker%20Tutorial%20for%20Beginners%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Docker Tutorial for Beginners – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Docker%20Compose%20Full%20Course%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Docker Compose Full Course – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Docker%20Security%20Best%20Practices%20%E2%80%93%20Fireship"
+                                    target="_blank">Docker Security Best Practices – Fireship</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Multi-stage%20Docker%20Builds%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Multi-stage Docker Builds – TechWorld with Nana</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- PHASE 6 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">6</div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 16–26</div>
+                            <div class="step-phase">Phase 06 · Kubernetes</div>
+                            <div class="step-heading">Kubernetes — The Operating System of the Cloud-Native World</div>
+                            <div class="step-desc">Kubernetes (K8s) is the most important technology in cloud
+                                engineering today. It orchestrates containers at scale. Master the core objects:
+                                <strong>Pods</strong> (smallest unit), <strong>Deployments</strong> (declarative
+                                rollouts, replicas, rolling updates), <strong>Services</strong> (ClusterIP, NodePort,
+                                LoadBalancer — how pods are exposed), <strong>ConfigMaps &amp; Secrets</strong>,
+                                <strong>PersistentVolumes &amp; PVCs</strong>, <strong>Namespaces</strong>. Learn
+                                <strong>Ingress controllers</strong> (nginx, Traefik) — routing external HTTP traffic.
+                                Study <strong>resource requests and limits</strong> — critical for stability and cost.
+                                Master <strong>kubectl</strong> inside-out: get, describe, logs, exec, apply, rollout.
+                                Learn <strong>Helm</strong>: the package manager for K8s — install and write charts.
+                                Study <strong>RBAC</strong> for access control. Understand <strong>Horizontal Pod
+                                    Autoscaler (HPA)</strong> and <strong>cluster autoscaler</strong>. Learn managed
+                                K8s: <strong>EKS, GKE, AKS</strong>. Earn the <strong>CKA (Certified Kubernetes
+                                    Administrator)</strong> — one of the most valuable certs in cloud engineering.
+                            </div>
+                            <div class="step-tags">
+                                <span class="tag red">Most important cloud skill</span>
+                                <span class="tag">Pods / Deployments</span>
+                                <span class="tag">Services / Ingress</span>
+                                <span class="tag">Helm charts</span>
+                                <span class="tag">RBAC</span>
+                                <span class="tag">HPA / cluster autoscaler</span>
+                                <span class="tag">EKS / GKE / AKS</span>
+                                <span class="tag">CKA certification</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Kubernetes%20Full%20Course%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Kubernetes Full Course – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Kubernetes%20Crash%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Kubernetes Crash Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Helm%20Full%20Course%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Helm Full Course – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=CKA%20Exam%20Prep%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">CKA Exam Prep – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Kubernetes%20Networking%20Explained%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Kubernetes Networking Explained – TechWorld with Nana</a>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+                <hr class="divider">
                 <div class="tip-block">
-                    <div class="tip-icon">🐧</div>
-                    <div class="tip-text"><strong>Spin up a Linux VM and live in the terminal.</strong> Don't just watch tutorials — install Ubuntu in VirtualBox or WSL2, delete your GUI, and do everything from the command line for 30 days. AWS EC2, GCP Compute Engine, and Azure VMs are all Linux. If you can't navigate Linux confidently, you'll be slow at everything cloud-related.</div>
+                    <div class="tip-icon">⚙️</div>
+                    <div class="tip-text"><strong>Run K8s locally before touching EKS/GKE.</strong> Use minikube or kind
+                        (Kubernetes in Docker) on your laptop. Break things, fix them, understand what YAML is actually
+                        doing. When you pay $0.10/hr for an EKS cluster you'll want to already understand what's going
+                        on. Use k9s as your terminal UI — it makes working with K8s 10x faster.</div>
                 </div>
             </div>
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">04 / 09</span>
+            </div>
         </div>
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">02 / 09</span>
+
+        <!-- ══════════════════════ PAGE 5 — PHASES 7–8 ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
+                <span class="page-num">05</span>
+            </div>
+            <div class="page-body">
+                <div class="section-label">Infrastructure as Code & DevOps</div>
+                <h2 class="section-title">Terraform, CI/CD & the DevOps Toolchain</h2>
+                <div class="roadmap">
+
+                    <!-- PHASE 7 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">7</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 18–26</div>
+                            <div class="step-phase">Phase 07 · Infrastructure as Code</div>
+                            <div class="step-heading">Terraform & IaC — Infrastructure Is Just Code Now</div>
+                            <div class="step-desc">Clicking around the AWS console is not cloud engineering — it's a
+                                recipe for undocumented, irreproducible infrastructure. Infrastructure as Code is the
+                                professional standard. Master <strong>Terraform</strong> deeply: providers, resources,
+                                variables, outputs, data sources, locals, modules (reusable infrastructure components),
+                                and state management. Understand <strong>Terraform state</strong>: local vs remote (S3 +
+                                DynamoDB for locking), state locking, state import. Learn <strong>Terraform
+                                    workspaces</strong> for multi-environment (dev/staging/prod) management. Study
+                                <strong>Terraform best practices</strong>: DRY modules, variable validation, sensitive
+                                outputs. Learn <strong>Terragrunt</strong> for managing Terraform at scale across many
+                                modules. Understand <strong>AWS CDK</strong> (Cloud Development Kit) — define
+                                infrastructure in TypeScript/Python. Study <strong>Pulumi</strong> as a modern IaC
+                                alternative. Also learn <strong>AWS CloudFormation</strong> basics for legacy system
+                                compatibility. Earn the <strong>HashiCorp Terraform Associate</strong> cert.
+                            </div>
+                            <div class="step-tags">
+                                <span class="tag red">Professional standard</span>
+                                <span class="tag">Terraform HCL</span>
+                                <span class="tag">Remote state (S3)</span>
+                                <span class="tag">Terraform modules</span>
+                                <span class="tag">Terragrunt</span>
+                                <span class="tag">AWS CDK</span>
+                                <span class="tag">Pulumi</span>
+                                <span class="tag">Terraform Associate cert</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Terraform%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Terraform Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Terraform%20for%20Beginners%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Terraform for Beginners – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Terraform%20Modules%20%26%20Best%20Practices%20%E2%80%93%20Anton%20Babenko"
+                                    target="_blank">Terraform Modules & Best Practices – Anton Babenko</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Terraform%20State%20Management%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Terraform State Management – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20CDK%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">AWS CDK Full Course – freeCodeCamp</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- PHASE 8 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">8</div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 20–30</div>
+                            <div class="step-phase">Phase 08 · CI/CD Pipelines</div>
+                            <div class="step-heading">CI/CD — Automate Every Deploy, Every Time</div>
+                            <div class="step-desc">Manual deployments don't scale. CI/CD is how professional teams ship
+                                code safely and fast. Master <strong>GitHub Actions</strong> completely: workflows,
+                                triggers (push, PR, schedule), jobs, steps, matrix builds, secrets, environments, and
+                                reusable workflows. This is the most widely used CI tool in 2026. Learn <strong>GitLab
+                                    CI/CD</strong>: .gitlab-ci.yml, stages, pipelines, runners, artifacts — common in
+                                enterprise. Study <strong>Jenkins</strong> for legacy enterprise environments:
+                                Jenkinsfile, declarative pipelines, agents, shared libraries. Understand
+                                <strong>pipeline stages</strong>: lint → test → build (Docker) → push (ECR) → deploy
+                                (kubectl/Helm/Terraform). Learn <strong>deployment strategies</strong>: rolling update,
+                                blue/green deployment, canary releases with traffic splitting. Master
+                                <strong>ArgoCD</strong>: GitOps for Kubernetes — sync K8s cluster state from Git
+                                automatically. Learn <strong>Flux CD</strong> as an alternative GitOps tool. Study
+                                <strong>SAST/DAST</strong> integration in pipelines for security.
+                            </div>
+                            <div class="step-tags">
+                                <span class="tag red">Ship code safely</span>
+                                <span class="tag">GitHub Actions</span>
+                                <span class="tag">GitLab CI</span>
+                                <span class="tag">Jenkins</span>
+                                <span class="tag">ArgoCD (GitOps)</span>
+                                <span class="tag">Flux CD</span>
+                                <span class="tag">Blue/green deploys</span>
+                                <span class="tag">Canary releases</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=GitHub%20Actions%20Full%20Course%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">GitHub Actions Full Course – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=CI%2FCD%20Pipeline%20Tutorial%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">CI/CD Pipeline Tutorial – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=ArgoCD%20Full%20Course%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">ArgoCD Full Course – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=GitLab%20CI%2FCD%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">GitLab CI/CD – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Jenkins%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Jenkins Full Course – freeCodeCamp</a>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+                <hr class="divider">
+                <div class="tip-block">
+                    <div class="tip-icon">🔁</div>
+                    <div class="tip-text"><strong>Adopt GitOps from day one.</strong> GitOps means your Git repo is the
+                        single source of truth for both application code AND infrastructure state. ArgoCD watches Git
+                        and auto-syncs your Kubernetes cluster. Any manual kubectl apply is a red flag. This pattern
+                        prevents configuration drift and makes rollbacks instant — just revert the Git commit.</div>
+                </div>
+            </div>
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">05 / 09</span>
+            </div>
         </div>
+
+        <!-- ══════════════════════ PAGE 6 — PHASES 9–10 ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
+                <span class="page-num">06</span>
+            </div>
+            <div class="page-body">
+                <div class="section-label">Security, Observability & Cost Engineering</div>
+                <h2 class="section-title">Cloud Security, Monitoring & FinOps</h2>
+                <div class="roadmap">
+
+                    <!-- PHASE 9 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">9</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 24–34</div>
+                            <div class="step-phase">Phase 09 · Cloud Security</div>
+                            <div class="step-heading">Cloud Security — The Skill That Keeps Systems Alive</div>
+                            <div class="step-desc">Security breaches in cloud cost companies millions. Cloud security is
+                                a multiplier skill — good engineers know it, great engineers live by it. Master
+                                <strong>IAM best practices</strong>: principle of least privilege, no root access in
+                                production, IAM roles over static credentials, cross-account roles. Understand
+                                <strong>AWS security services</strong>: GuardDuty (threat detection), Security Hub
+                                (posture management), AWS Config (compliance), CloudTrail (API audit logs — always
+                                enable this), Macie (S3 data discovery), Inspector (vulnerability scanning), WAF &amp;
+                                Shield (DDoS). Learn <strong>Secrets management</strong>: AWS Secrets Manager, HashiCorp
+                                Vault — never hardcode credentials. Understand <strong>encryption</strong>: KMS for key
+                                management, encryption at rest (S3 SSE, EBS encryption) and in transit (TLS). Study
+                                <strong>network security</strong>: private subnets, VPC endpoints (no internet for
+                                sensitive traffic), VPN vs Direct Connect. Learn <strong>container security</strong>:
+                                image scanning, Pod Security Standards, OPA/Gatekeeper policies. Study <strong>CSPM
+                                    tools</strong>: Wiz, Prisma Cloud for cloud posture. Earn <strong>AWS Security
+                                    Specialty</strong> cert for senior roles.
+                            </div>
+                            <div class="step-tags">
+                                <span class="tag red">Keeps systems alive</span>
+                                <span class="tag">IAM least privilege</span>
+                                <span class="tag">GuardDuty / Security Hub</span>
+                                <span class="tag">CloudTrail (always on)</span>
+                                <span class="tag">AWS Secrets Manager</span>
+                                <span class="tag">KMS encryption</span>
+                                <span class="tag">VPC endpoints</span>
+                                <span class="tag">OPA / Gatekeeper</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20Security%20Deep%20Dive%20%E2%80%93%20NetworkChuck"
+                                    target="_blank">AWS Security Deep Dive – NetworkChuck</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=HashiCorp%20Vault%20Tutorial%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">HashiCorp Vault Tutorial – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Cloud%20Security%20Best%20Practices%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Cloud Security Best Practices – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20GuardDuty%20%26%20Security%20Hub%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">AWS GuardDuty & Security Hub – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Kubernetes%20Security%20%26%20OPA%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Kubernetes Security & OPA – TechWorld with Nana</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- PHASE 10 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">10</div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Weeks 26–36</div>
+                            <div class="step-phase">Phase 10 · Observability & FinOps</div>
+                            <div class="step-heading">Monitoring, Logging, Tracing & Cloud Cost Engineering</div>
+                            <div class="step-desc">You can't manage what you can't measure. Build observability into
+                                everything. Learn the <strong>three pillars</strong>: <strong>Metrics</strong>
+                                (Prometheus + Grafana — the industry standard), <strong>Logs</strong> (ELK Stack /
+                                OpenSearch, Loki, CloudWatch Logs), <strong>Traces</strong> (Jaeger, Tempo, AWS X-Ray —
+                                distributed tracing for microservices). Understand <strong>alerting</strong>:
+                                Alertmanager with Prometheus, PagerDuty/OpsGenie for on-call. Study the
+                                <strong>OpenTelemetry (OTel)</strong> standard — vendor-neutral instrumentation that all
+                                modern tools support. Master <strong>Grafana dashboards</strong>: PromQL queries,
+                                panels, alerts. Learn <strong>FinOps (Cloud Cost Engineering)</strong>: AWS Cost
+                                Explorer, Budgets and alerts, Reserved Instances vs Savings Plans vs Spot Instances
+                                (save 60–90%), right-sizing EC2 instances, S3 lifecycle policies to move to cheaper
+                                tiers, Compute Optimizer. Study <strong>Kubecost</strong> for K8s cost visibility. An
+                                unmonitored cloud bill will bankrupt a startup in weeks.
+                            </div>
+                            <div class="step-tags">
+                                <span class="tag red">Production-grade observability</span>
+                                <span class="tag">Prometheus + Grafana</span>
+                                <span class="tag">ELK / Loki</span>
+                                <span class="tag">Jaeger / X-Ray</span>
+                                <span class="tag">OpenTelemetry</span>
+                                <span class="tag">AWS Cost Explorer</span>
+                                <span class="tag">Savings Plans / Spot</span>
+                                <span class="tag">Kubecost</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Prometheus%20%2B%20Grafana%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Prometheus + Grafana – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=ELK%20Stack%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">ELK Stack Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=OpenTelemetry%20Explained%20%E2%80%93%20Fireship"
+                                    target="_blank">OpenTelemetry Explained – Fireship</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20Cost%20Optimization%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">AWS Cost Optimization – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=FinOps%20for%20Engineers%20%E2%80%93%20CloudHealth"
+                                    target="_blank">FinOps for Engineers – CloudHealth</a>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">06 / 09</span>
+            </div>
+        </div>
+
+        <!-- ══════════════════════ PAGE 7 — PHASE 11 + ARCHITECTURE ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
+                <span class="page-num">07</span>
+            </div>
+            <div class="page-body">
+                <div class="section-label">Advanced Architecture</div>
+                <h2 class="section-title">Cloud-Native Architecture, Serverless & System Design</h2>
+                <div class="roadmap">
+                    <!-- PHASE 11 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">11</div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Month 8–14 (Architecture Mastery)</div>
+                            <div class="step-phase">Phase 11 · Cloud Architecture & System Design</div>
+                            <div class="step-heading">Designing Scalable, Resilient, Cost-Efficient Cloud Systems</div>
+                            <div class="step-desc">This is what separates a cloud operator from a cloud architect. Learn
+                                the <strong>AWS Well-Architected Framework</strong>: 6 pillars — Operational Excellence,
+                                Security, Reliability, Performance Efficiency, Cost Optimization, Sustainability. Study
+                                <strong>serverless architecture patterns</strong>: event-driven systems with Lambda +
+                                SQS/SNS + EventBridge + API Gateway — zero servers to manage. Learn
+                                <strong>microservices patterns</strong>: service mesh (Istio, AWS App Mesh), sidecar
+                                pattern, API Gateway pattern. Understand <strong>database architecture</strong>: read
+                                replicas, Multi-AZ RDS, Aurora serverless, DynamoDB global tables, ElastiCache (Redis)
+                                for caching. Study <strong>messaging systems</strong>: SQS (queues), SNS (pub/sub),
+                                Kafka (MSK), Kinesis (real-time streaming). Learn <strong>high availability and disaster
+                                    recovery</strong>: RTO vs RPO, active-active vs active-passive, multi-region
+                                deployments. Understand <strong>the 12-factor app</strong> methodology. Study
+                                <strong>cloud-native storage</strong>: EFS vs EBS vs S3 vs FSx — when to use each.
+                                Practice cloud system design interviews: design YouTube, design Twitter, design a URL
+                                shortener on AWS. This is what's tested at FAANG cloud interviews.
+                            </div>
+                            <div class="step-tags">
+                                <span class="tag red">Architecture mastery</span>
+                                <span class="tag">Well-Architected Framework</span>
+                                <span class="tag">Event-driven (SQS/SNS)</span>
+                                <span class="tag">Service mesh (Istio)</span>
+                                <span class="tag">Aurora / DynamoDB global</span>
+                                <span class="tag">Kafka / Kinesis</span>
+                                <span class="tag">Multi-region HA</span>
+                                <span class="tag">Cloud system design</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20Well-Architected%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">AWS Well-Architected – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Serverless%20Architecture%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Serverless Architecture – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Kafka%20Full%20Course%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">Kafka Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Istio%20Service%20Mesh%20%E2%80%93%20TechWorld%20with%20Nana"
+                                    target="_blank">Istio Service Mesh – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=System%20Design%20Interview%20%E2%80%93%20Alex%20Xu"
+                                    target="_blank">System Design Interview – Alex Xu</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Cloud%20Architecture%20Patterns%20%E2%80%93%20AWS"
+                                    target="_blank">Cloud Architecture Patterns – AWS</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <hr class="divider">
+                <div class="section-label">Cloud Architecture Patterns — The Patterns Every Engineer Must Know</div>
+                <div class="resource-grid">
+                    <div class="resource-card">
+                        <div class="resource-card-name">☁️ Serverless Event-Driven</div>
+                        <div class="resource-card-desc">Lambda + SQS + SNS + EventBridge + API Gateway. Zero server
+                            management. Pay per invocation. Scales to 0 automatically. Best for variable, spiky
+                            workloads. Not for long-running tasks.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Event-Driven%20Architecture%20%E2%80%93%20freeCodeCamp"
+                                target="_blank">Event-Driven Architecture – freeCodeCamp</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">🔵 Blue/Green Deployment</div>
+                        <div class="resource-card-desc">Run two identical environments (blue=live, green=new). Switch
+                            traffic instantly with zero downtime. Instant rollback — just flip traffic back to blue.
+                            Used with ALB weighted target groups or Route 53.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Deployment%20Strategies%20%E2%80%93%20TechWorld"
+                                target="_blank">Deployment Strategies – TechWorld</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">🌍 Multi-Region Active-Active</div>
+                        <div class="resource-card-desc">Deploy across 2+ regions simultaneously. Route 53 latency
+                            routing sends users to the nearest region. DynamoDB Global Tables replicate data. 99.99%+
+                            availability. Used by Netflix, Amazon, Google.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Multi-Region%20Architecture%20%E2%80%93%20AWS"
+                                target="_blank">Multi-Region Architecture – AWS</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">🔒 Zero-Trust Networking</div>
+                        <div class="resource-card-desc">Never trust, always verify. Everything inside the VPC is also
+                            untrusted by default. Workloads authenticate with short-lived tokens. Service-to-service
+                            mTLS via Istio. Replaces perimeter-based security models.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Zero%20Trust%20with%20Istio%20%E2%80%93%20TechWorld" target="_blank">Zero
+                                Trust with Istio – TechWorld</a>
+                        </div>
+                    </div>
+                </div>
+
+                <hr class="divider">
+                <div class="section-label">Certifications Roadmap — In Priority Order</div>
+                <table class="stack-table">
+                    <thead>
+                        <tr>
+                            <th>Certification</th>
+                            <th>Provider</th>
+                            <th>Level</th>
+                            <th>When to Take</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>AWS SAA-C03</td>
+                            <td>Amazon Web Services</td>
+                            <td>Associate</td>
+                            <td>Month 4–6 — first cert, highest ROI</td>
+                        </tr>
+                        <tr>
+                            <td>CKA</td>
+                            <td>Linux Foundation</td>
+                            <td>Professional</td>
+                            <td>Month 7–9 — after K8s mastery</td>
+                        </tr>
+                        <tr>
+                            <td>Terraform Associate</td>
+                            <td>HashiCorp</td>
+                            <td>Associate</td>
+                            <td>Month 6–8 — after IaC phase</td>
+                        </tr>
+                        <tr>
+                            <td>AWS DevOps Pro</td>
+                            <td>Amazon Web Services</td>
+                            <td>Professional</td>
+                            <td>Month 10–12 — senior level</td>
+                        </tr>
+                        <tr>
+                            <td>Google ACE</td>
+                            <td>Google Cloud</td>
+                            <td>Associate</td>
+                            <td>Month 8–10 — multi-cloud</td>
+                        </tr>
+                        <tr>
+                            <td>AWS Security Specialty</td>
+                            <td>Amazon Web Services</td>
+                            <td>Specialty</td>
+                            <td>Month 12+ — high salary boost</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">07 / 09</span>
+            </div>
+        </div>
+
+        <!-- ══════════════════════ PAGE 8 — SKILL MAP + PROJECTS ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
+                <span class="page-num">08</span>
+            </div>
+            <div class="page-body">
+                <div class="section-label">Skill Map & Projects</div>
+                <h2 class="section-title">Full Timeline, Portfolio Projects & Daily Routine</h2>
+
+                <div class="skills-row">
+                    <div class="skill-col">
+                        <div class="skill-col-title">🟥 Month 1–4</div>
+                        <div class="skill-item">Linux CLI + Bash scripting</div>
+                        <div class="skill-item">Networking fundamentals</div>
+                        <div class="skill-item">AWS core (EC2, S3, VPC, IAM)</div>
+                        <div class="skill-item">AWS SAA-C03 certification</div>
+                        <div class="skill-item">Docker fundamentals</div>
+                        <div class="skill-item">Git + GitHub workflows</div>
+                        <div class="skill-item">Python for automation scripts</div>
+                    </div>
+                    <div class="skill-col">
+                        <div class="skill-col-title">🟧 Month 5–9</div>
+                        <div class="skill-item">Kubernetes (CKA prep)</div>
+                        <div class="skill-item">Terraform + remote state</div>
+                        <div class="skill-item">GitHub Actions CI/CD</div>
+                        <div class="skill-item">ArgoCD / GitOps</div>
+                        <div class="skill-item">Prometheus + Grafana</div>
+                        <div class="skill-item">AWS security services</div>
+                        <div class="skill-item">ELK / Loki logging</div>
+                    </div>
+                    <div class="skill-col">
+                        <div class="skill-col-title">🟩 Month 10–16</div>
+                        <div class="skill-item">Multi-cloud (GCP/Azure)</div>
+                        <div class="skill-item">Service mesh (Istio)</div>
+                        <div class="skill-item">Kafka / Kinesis streaming</div>
+                        <div class="skill-item">FinOps + cost engineering</div>
+                        <div class="skill-item">Cloud system design</div>
+                        <div class="skill-item">AWS DevOps Pro / Security</div>
+                        <div class="skill-item">Published projects + blog</div>
+                    </div>
+                </div>
+
+                <hr class="divider">
+
+                <div class="section-label">Portfolio Projects — Build These 5 to Get Hired</div>
+                <div class="resource-grid">
+                    <div class="resource-card">
+                        <div class="resource-card-name">🏗️ 3-Tier AWS App (IaC)</div>
+                        <div class="resource-card-desc">Deploy a full 3-tier web app (frontend on S3+CloudFront, backend
+                            on EC2/ECS, RDS database) using 100% Terraform. VPC with public/private subnets, ALB, Auto
+                            Scaling Groups, RDS Multi-AZ. Zero manual console clicks. The classic cloud portfolio
+                            project.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Terraform%20AWS%20%E2%80%93%20freeCodeCamp"
+                                target="_blank">Terraform AWS – freeCodeCamp</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">☸️ K8s App + Full GitOps</div>
+                        <div class="resource-card-desc">Containerize a microservices app (3+ services), deploy on EKS or
+                            GKE with Helm charts, set up ArgoCD GitOps, Prometheus+Grafana monitoring, cert-manager for
+                            TLS, and a GitHub Actions pipeline that builds, pushes, and auto-deploys on merge to main.
+                        </div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=ArgoCD%20Full%20Course%20%E2%80%93%20TechWorld" target="_blank">ArgoCD
+                                Full Course – TechWorld</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">🔒 Secure Landing Zone</div>
+                        <div class="resource-card-desc">Build an AWS multi-account landing zone with AWS Organizations,
+                            SCPs, CloudTrail across all accounts, GuardDuty, Security Hub, IAM Identity Center (SSO),
+                            and a centralized logging account. Shows enterprise-grade security thinking.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20Control%20Tower%20Landing%20Zone%20%E2%80%93%20AWS" target="_blank">AWS
+                                Control Tower Landing Zone – AWS</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">⚡ Serverless Data Pipeline</div>
+                        <div class="resource-card-desc">Build an event-driven pipeline: S3 upload triggers Lambda →
+                            processes data → writes to DynamoDB → SNS notification. Add API Gateway REST endpoint.
+                            Deploy everything with CDK or SAM. Monitor with X-Ray tracing and CloudWatch dashboards.
+                        </div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20Lambda%20Full%20Course" target="_blank">AWS
+                                Lambda Full Course</a>
+                        </div>
+                    </div>
+                </div>
+
+                <hr class="divider">
+
+                <div class="section-label">Daily Routine</div>
+                <div style="font-size:14px; font-weight:700; color:var(--dark); margin-bottom:10px;">The Boring Cloud
+                    Engineering Routine That Works</div>
+                <div class="checklist">
+                    <div class="check-item">
+                        <div class="check-box"></div> Spin up and destroy one AWS resource with Terraform — muscle
+                        memory for IaC
+                    </div>
+                    <div class="check-item">
+                        <div class="check-box"></div> Read one AWS/GCP blog post, re:Invent talk, or architecture case
+                        study
+                    </div>
+                    <div class="check-item">
+                        <div class="check-box"></div> Practice 1 kubectl command or Linux task you're not fluent in yet
+                    </div>
+                    <div class="check-item">
+                        <div class="check-box"></div> Check your AWS cost dashboard — know where every dollar is going
+                    </div>
+                    <div class="check-item">
+                        <div class="check-box"></div> Push one GitHub commit on your portfolio project or cert study
+                        notes
+                    </div>
+                    <div class="check-item">
+                        <div class="check-box"></div> Share one cloud tip, architecture diagram, or project update on
+                        LinkedIn
+                    </div>
+                </div>
+            </div>
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">08 / 09</span>
+            </div>
+        </div>
+
+        <!-- ══════════════════════ PAGE 9 — RESOURCES + CTA ══════════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
+                <span class="page-num">09</span>
+            </div>
+            <div class="page-body">
+                <div class="section-label">Master Resource List</div>
+                <h2 class="section-title">Best Free YouTube Channels for Cloud Engineering</h2>
+
+                <div class="resource-grid">
+                    <div class="resource-card">
+                        <div class="resource-card-name">📺 TechWorld with Nana</div>
+                        <div class="resource-card-desc">The single best cloud and DevOps YouTube channel. Covers Docker,
+                            Kubernetes, Terraform, Jenkins, GitLab CI, ArgoCD, Prometheus, and more — all in exceptional
+                            depth with real projects. Watch this channel first.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/@TechWorldwithNana"
+                                target="_blank">@TechWorldwithNana</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">📺 NetworkChuck</div>
+                        <div class="resource-card-desc">Makes networking and cloud genuinely exciting. Best for Linux,
+                            networking fundamentals, AWS, and home lab projects. His energy and hands-on approach makes
+                            dense technical content stick. Great for visual learners.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/@NetworkChuck"
+                                target="_blank">@NetworkChuck</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">📺 freeCodeCamp</div>
+                        <div class="resource-card-desc">Full-length courses on AWS, GCP, Azure, Terraform, Kubernetes,
+                            Docker, Jenkins, and every cloud tool. Completely free. The go-to for long-form,
+                            project-based learning covering every phase of this roadmap.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/@freecodecamp"
+                                target="_blank">@freecodecamp</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">📺 Fireship</div>
+                        <div class="resource-card-desc">Fast, dense, highly accurate 5–10 minute explainers. Best for
+                            getting oriented on new cloud concepts quickly — Docker, K8s, serverless, DNS, networking.
+                            Watch a Fireship video first, then go deep with TechWorld with Nana.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/@Fireship" target="_blank">@Fireship</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">📺 AWS Official Channel</div>
+                        <div class="resource-card-desc">Direct from the source. re:Invent conference talks are gold —
+                            the "300-level" architecture talks show how companies like Netflix, NASA, and Airbnb use AWS
+                            at scale. Essential viewing for senior cloud roles.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/@amazonwebservices"
+                                target="_blank">@amazonwebservices</a>
+                        </div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">📺 Anton Babenko</div>
+                        <div class="resource-card-desc">The foremost Terraform expert on YouTube. Covers Terraform
+                            modules, registry, best practices, Terragrunt, and advanced IaC patterns. If you want to
+                            write production-quality Terraform, follow every video he posts.</div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://www.youtube.com/@AntonBabenko"
+                                target="_blank">@AntonBabenko</a>
+                        </div>
+                    </div>
+                </div>
+
+                <hr class="divider">
+
+                <div class="section-label">Tools by TBE — Use These</div>
+                <div style="display:flex; gap:8px; flex-wrap:wrap; margin-bottom:14px;">
+                    <span class="tag red">DSA Yatra — Daily practice</span>
+                    <span class="tag red">Prep Yatra — Interview tracker</span>
+                    <span class="tag red">Tech Yatra — Learning roadmaps</span>
+                    <span class="tag red">Resume Yatra — ATS-ready resume</span>
+                    <span class="tag">Shiksha — Free courses</span>
+                    <span class="tag">YouFocus — Distraction-free YT</span>
+                    <span class="tag">Interview Prep — Question banks</span>
+                    <span class="tag">Community — Peer learning</span>
+                </div>
+
+                <div class="cta-block">
+                    <div class="cta-title">The Cloud Is Where Careers Are Built ☁️</div>
+                    <div class="cta-sub">Every startup, every enterprise, every government — they all run on cloud
+                        infrastructure.<br>The engineer who can build, secure, and scale that infrastructure will never
+                        run out of opportunities.</div>
+                    <a href="https://www.theboringeducation.com" class="cta-link" target="_blank">→
+                        theboringeducation.com</a>
+                </div>
+
+                <hr class="divider">
+
+                <div class="section-label">Find Us Everywhere</div>
+                <div class="socials-grid">
+                    <a class="social-card" href="https://instagram.com/theboringeducation" target="_blank">
+                        <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/2111/2111463.png"
+                            alt="Instagram">
+                        <span class="social-name">Instagram</span>
+                        <div class="social-handle">@theboringeducation</div>
+                    </a>
+                    <a class="social-card" href="https://linkedin.com/company/the-boring-education" target="_blank">
+                        <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png"
+                            alt="LinkedIn">
+                        <span class="social-name">LinkedIn</span>
+                        <div class="social-handle">The Boring Education</div>
+                    </a>
+                    <a class="social-card" href="https://github.com/The-Boring-Education" target="_blank">
+                        <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/733/733609.png"
+                            alt="GitHub">
+                        <span class="social-name">GitHub</span>
+                        <div class="social-handle">The-Boring-Education</div>
+                    </a>
+                </div>
+            </div>
+            <div class="page-footer">
+                <span class="cover-footer-text">© 2026 The Boring Education · Free Tech Education for Everyone</span>
+                <span class="page-num">09 / 09</span>
+            </div>
+        </div>
+
     </div>
-
-    <!-- ══════════════════════ PAGE 3 — PHASES 3–4 ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
-            <span class="page-num">03</span>
-        </div>
-        <div class="page-body">
-            <div class="section-label">Cloud Platforms & Core Services</div>
-            <h2 class="section-title">AWS / GCP / Azure & Cloud Fundamentals</h2>
-            <div class="roadmap">
-
-                <!-- PHASE 3 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">3</div>
-                        <div class="step-line"></div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 6–14</div>
-                        <div class="step-phase">Phase 03 · AWS Core Services</div>
-                        <div class="step-heading">Amazon Web Services — The Cloud You Must Know First</div>
-                        <div class="step-desc">AWS has 33% of the cloud market — start here. Deeply learn: <strong>EC2</strong> (virtual machines): instance types, AMIs, key pairs, EBS volumes, Auto Scaling Groups, Launch Templates. <strong>S3</strong>: buckets, storage classes, lifecycle policies, versioning, presigned URLs, static website hosting. <strong>VPC</strong>: subnets (public/private), Internet Gateway, NAT Gateway, Route Tables, Security Groups, NACLs, VPC Peering. <strong>IAM</strong>: users, groups, roles, policies (identity-based vs resource-based), MFA — this is the most important security service. <strong>RDS &amp; DynamoDB</strong>: managed relational and NoSQL databases. <strong>Lambda</strong>: serverless functions, event triggers, cold starts. <strong>ELB</strong>: ALB vs NLB, target groups, listener rules. <strong>Route 53</strong>: DNS hosting, health checks, routing policies. <strong>CloudWatch</strong>: metrics, logs, alarms, dashboards. Earn <strong>AWS Solutions Architect Associate</strong> certification — it validates all of this.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Market leader — start here</span>
-                            <span class="tag">EC2 + Auto Scaling</span>
-                            <span class="tag">S3 + lifecycle</span>
-                            <span class="tag">VPC + subnets</span>
-                            <span class="tag">IAM roles/policies</span>
-                            <span class="tag">RDS / DynamoDB</span>
-                            <span class="tag">Lambda</span>
-                            <span class="tag">CloudWatch</span>
-                            <span class="tag">AWS SAA-C03 cert</span>
-                        </div>
-                        <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=3hLmDS179YE" target="_blank">AWS Full Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=k1RI5locZE4" target="_blank">AWS SAA Prep – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=sonEFrnmNOw" target="_blank">AWS VPC Explained – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=iF9fs8Rw4Uo" target="_blank">AWS IAM Deep Dive – NetworkChuck</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=8I4wimquMEk" target="_blank">AWS Lambda Full Course – freeCodeCamp</a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- PHASE 4 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">4</div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 12–18</div>
-                        <div class="step-phase">Phase 04 · GCP & Azure (Secondary Cloud)</div>
-                        <div class="step-heading">Google Cloud & Azure — Be Multi-Cloud Capable</div>
-                        <div class="step-desc">Most enterprises use 2+ clouds. Learn the AWS equivalents on GCP and Azure to be a versatile hire. <strong>GCP focus</strong>: Compute Engine (EC2 equiv.), Cloud Storage (S3), GKE — Google Kubernetes Engine (the best managed K8s), BigQuery (data warehousing), Cloud Run (serverless containers), Cloud IAM, and VPC networking. GCP is dominant in data engineering and ML workloads. <strong>Azure focus</strong>: Azure VMs, Azure Blob Storage, AKS (Kubernetes), Azure Active Directory / Entra ID (critical for enterprise — AD integration is a key differentiator), Azure DevOps, App Service, and Azure Networking (VNets, NSGs). Earn <strong>Google Associate Cloud Engineer</strong> or <strong>Azure AZ-900/AZ-104</strong> as secondary certs. Understanding the concept mapping across clouds (VPC ↔ VNet ↔ VPC) makes you a fast learner on any platform.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Multi-cloud</span>
-                            <span class="tag">GKE (best K8s)</span>
-                            <span class="tag">BigQuery</span>
-                            <span class="tag">Cloud Run</span>
-                            <span class="tag">Azure AD / Entra ID</span>
-                            <span class="tag">Azure DevOps</span>
-                            <span class="tag">AKS</span>
-                            <span class="tag">ACE / AZ-104 cert</span>
-                        </div>
-                        <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=M988_fsOSWo" target="_blank">GCP Full Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=pxp7uYUjH_M" target="_blank">Azure Full Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=7xngnjfIlK4" target="_blank">GCP vs AWS vs Azure – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=I3OWMDjopRI" target="_blank">Azure AZ-900 Prep – freeCodeCamp</a>
-                        </div>
-                    </div>
-                </div>
-
-            </div>
-            <hr class="divider">
-            <div class="section-label">Cloud Provider Comparison</div>
-            <table class="stack-table">
-                <thead>
-                    <tr><th>Service Type</th><th>AWS</th><th>Google Cloud</th><th>Azure</th></tr>
-                </thead>
-                <tbody>
-                    <tr><td>Compute VMs</td><td>EC2</td><td>Compute Engine</td><td>Azure Virtual Machines</td></tr>
-                    <tr><td>Object Storage</td><td>S3</td><td>Cloud Storage</td><td>Blob Storage</td></tr>
-                    <tr><td>Managed K8s</td><td>EKS</td><td>GKE ⭐ (best)</td><td>AKS</td></tr>
-                    <tr><td>Serverless</td><td>Lambda</td><td>Cloud Functions / Run</td><td>Azure Functions</td></tr>
-                    <tr><td>DNS</td><td>Route 53</td><td>Cloud DNS</td><td>Azure DNS</td></tr>
-                </tbody>
-            </table>
-        </div>
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">03 / 09</span>
-        </div>
-    </div>
-
-    <!-- ══════════════════════ PAGE 4 — PHASES 5–6 ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
-            <span class="page-num">04</span>
-        </div>
-        <div class="page-body">
-            <div class="section-label">Containers & Orchestration</div>
-            <h2 class="section-title">Docker, Kubernetes & Container Ecosystem</h2>
-            <div class="roadmap">
-
-                <!-- PHASE 5 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">5</div>
-                        <div class="step-line"></div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 10–18</div>
-                        <div class="step-phase">Phase 05 · Docker & Containerization</div>
-                        <div class="step-heading">Docker — Package Anything, Run Anywhere</div>
-                        <div class="step-desc">Containers are the unit of deployment in modern cloud. Master Docker completely. Understand <strong>container vs VM</strong>: containers share the host kernel, VMs have separate OS — containers are faster, lighter, portable. Learn to write production-quality <strong>Dockerfiles</strong>: multi-stage builds, layer caching, minimal base images (alpine, distroless), non-root users, .dockerignore. Master <strong>Docker Compose</strong> for multi-container local development: services, networks, volumes, environment files. Understand <strong>container registries</strong>: Docker Hub, Amazon ECR, Google Artifact Registry — tagging, pushing, pulling images. Learn <strong>container networking</strong>: bridge, host, overlay networks. Understand <strong>container security</strong>: image scanning with Trivy, running as non-root, read-only filesystems, secrets management. Learn <strong>Docker volumes</strong> for persistent data. Know the difference between COPY vs ADD, CMD vs ENTRYPOINT — interviewers love this.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Modern deployment unit</span>
-                            <span class="tag">Dockerfile best practices</span>
-                            <span class="tag">Multi-stage builds</span>
-                            <span class="tag">Docker Compose</span>
-                            <span class="tag">ECR / Artifact Registry</span>
-                            <span class="tag">Trivy image scanning</span>
-                            <span class="tag">Container networking</span>
-                            <span class="tag">Volumes / secrets</span>
-                        </div>
-                        <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=3c-iBn73dDE" target="_blank">Docker Full Course – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=pg19Z8LL06w" target="_blank">Docker Tutorial for Beginners – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=HG6yIjZapSA" target="_blank">Docker Compose Full Course – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=zt_RBDHE9JE" target="_blank">Docker Security Best Practices – Fireship</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=9zUHg7xjIqQ" target="_blank">Multi-stage Docker Builds – TechWorld with Nana</a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- PHASE 6 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">6</div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 16–26</div>
-                        <div class="step-phase">Phase 06 · Kubernetes</div>
-                        <div class="step-heading">Kubernetes — The Operating System of the Cloud-Native World</div>
-                        <div class="step-desc">Kubernetes (K8s) is the most important technology in cloud engineering today. It orchestrates containers at scale. Master the core objects: <strong>Pods</strong> (smallest unit), <strong>Deployments</strong> (declarative rollouts, replicas, rolling updates), <strong>Services</strong> (ClusterIP, NodePort, LoadBalancer — how pods are exposed), <strong>ConfigMaps &amp; Secrets</strong>, <strong>PersistentVolumes &amp; PVCs</strong>, <strong>Namespaces</strong>. Learn <strong>Ingress controllers</strong> (nginx, Traefik) — routing external HTTP traffic. Study <strong>resource requests and limits</strong> — critical for stability and cost. Master <strong>kubectl</strong> inside-out: get, describe, logs, exec, apply, rollout. Learn <strong>Helm</strong>: the package manager for K8s — install and write charts. Study <strong>RBAC</strong> for access control. Understand <strong>Horizontal Pod Autoscaler (HPA)</strong> and <strong>cluster autoscaler</strong>. Learn managed K8s: <strong>EKS, GKE, AKS</strong>. Earn the <strong>CKA (Certified Kubernetes Administrator)</strong> — one of the most valuable certs in cloud engineering.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Most important cloud skill</span>
-                            <span class="tag">Pods / Deployments</span>
-                            <span class="tag">Services / Ingress</span>
-                            <span class="tag">Helm charts</span>
-                            <span class="tag">RBAC</span>
-                            <span class="tag">HPA / cluster autoscaler</span>
-                            <span class="tag">EKS / GKE / AKS</span>
-                            <span class="tag">CKA certification</span>
-                        </div>
-                        <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=X48VuDVv0do" target="_blank">Kubernetes Full Course – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=s_o8dwzRlu4" target="_blank">Kubernetes Crash Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=-ybKrlIENTI" target="_blank">Helm Full Course – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=7wTaEaFUSyc" target="_blank">CKA Exam Prep – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=NChhdOZV2x4" target="_blank">Kubernetes Networking Explained – TechWorld with Nana</a>
-                        </div>
-                    </div>
-                </div>
-
-            </div>
-            <hr class="divider">
-            <div class="tip-block">
-                <div class="tip-icon">⚙️</div>
-                <div class="tip-text"><strong>Run K8s locally before touching EKS/GKE.</strong> Use minikube or kind (Kubernetes in Docker) on your laptop. Break things, fix them, understand what YAML is actually doing. When you pay $0.10/hr for an EKS cluster you'll want to already understand what's going on. Use k9s as your terminal UI — it makes working with K8s 10x faster.</div>
-            </div>
-        </div>
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">04 / 09</span>
-        </div>
-    </div>
-
-    <!-- ══════════════════════ PAGE 5 — PHASES 7–8 ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
-            <span class="page-num">05</span>
-        </div>
-        <div class="page-body">
-            <div class="section-label">Infrastructure as Code & DevOps</div>
-            <h2 class="section-title">Terraform, CI/CD & the DevOps Toolchain</h2>
-            <div class="roadmap">
-
-                <!-- PHASE 7 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">7</div>
-                        <div class="step-line"></div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 18–26</div>
-                        <div class="step-phase">Phase 07 · Infrastructure as Code</div>
-                        <div class="step-heading">Terraform & IaC — Infrastructure Is Just Code Now</div>
-                        <div class="step-desc">Clicking around the AWS console is not cloud engineering — it's a recipe for undocumented, irreproducible infrastructure. Infrastructure as Code is the professional standard. Master <strong>Terraform</strong> deeply: providers, resources, variables, outputs, data sources, locals, modules (reusable infrastructure components), and state management. Understand <strong>Terraform state</strong>: local vs remote (S3 + DynamoDB for locking), state locking, state import. Learn <strong>Terraform workspaces</strong> for multi-environment (dev/staging/prod) management. Study <strong>Terraform best practices</strong>: DRY modules, variable validation, sensitive outputs. Learn <strong>Terragrunt</strong> for managing Terraform at scale across many modules. Understand <strong>AWS CDK</strong> (Cloud Development Kit) — define infrastructure in TypeScript/Python. Study <strong>Pulumi</strong> as a modern IaC alternative. Also learn <strong>AWS CloudFormation</strong> basics for legacy system compatibility. Earn the <strong>HashiCorp Terraform Associate</strong> cert.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Professional standard</span>
-                            <span class="tag">Terraform HCL</span>
-                            <span class="tag">Remote state (S3)</span>
-                            <span class="tag">Terraform modules</span>
-                            <span class="tag">Terragrunt</span>
-                            <span class="tag">AWS CDK</span>
-                            <span class="tag">Pulumi</span>
-                            <span class="tag">Terraform Associate cert</span>
-                        </div>
-                        <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=SLB_c_ayRMo" target="_blank">Terraform Full Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=7xngnjfIlK4" target="_blank">Terraform for Beginners – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=V53AHWun17s" target="_blank">Terraform Modules & Best Practices – Anton Babenko</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=POPP2WTJ8es" target="_blank">Terraform State Management – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=ZLpnt-Ba0B0" target="_blank">AWS CDK Full Course – freeCodeCamp</a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- PHASE 8 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">8</div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 20–30</div>
-                        <div class="step-phase">Phase 08 · CI/CD Pipelines</div>
-                        <div class="step-heading">CI/CD — Automate Every Deploy, Every Time</div>
-                        <div class="step-desc">Manual deployments don't scale. CI/CD is how professional teams ship code safely and fast. Master <strong>GitHub Actions</strong> completely: workflows, triggers (push, PR, schedule), jobs, steps, matrix builds, secrets, environments, and reusable workflows. This is the most widely used CI tool in 2026. Learn <strong>GitLab CI/CD</strong>: .gitlab-ci.yml, stages, pipelines, runners, artifacts — common in enterprise. Study <strong>Jenkins</strong> for legacy enterprise environments: Jenkinsfile, declarative pipelines, agents, shared libraries. Understand <strong>pipeline stages</strong>: lint → test → build (Docker) → push (ECR) → deploy (kubectl/Helm/Terraform). Learn <strong>deployment strategies</strong>: rolling update, blue/green deployment, canary releases with traffic splitting. Master <strong>ArgoCD</strong>: GitOps for Kubernetes — sync K8s cluster state from Git automatically. Learn <strong>Flux CD</strong> as an alternative GitOps tool. Study <strong>SAST/DAST</strong> integration in pipelines for security.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Ship code safely</span>
-                            <span class="tag">GitHub Actions</span>
-                            <span class="tag">GitLab CI</span>
-                            <span class="tag">Jenkins</span>
-                            <span class="tag">ArgoCD (GitOps)</span>
-                            <span class="tag">Flux CD</span>
-                            <span class="tag">Blue/green deploys</span>
-                            <span class="tag">Canary releases</span>
-                        </div>
-                        <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=mFFXuXjVgkU" target="_blank">GitHub Actions Full Course – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=qP8kir2GUgo" target="_blank">CI/CD Pipeline Tutorial – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=f5EpcWp0THw" target="_blank">ArgoCD Full Course – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=tBkuMDi1t6U" target="_blank">GitLab CI/CD – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=7KCS70sCoK0" target="_blank">Jenkins Full Course – freeCodeCamp</a>
-                        </div>
-                    </div>
-                </div>
-
-            </div>
-            <hr class="divider">
-            <div class="tip-block">
-                <div class="tip-icon">🔁</div>
-                <div class="tip-text"><strong>Adopt GitOps from day one.</strong> GitOps means your Git repo is the single source of truth for both application code AND infrastructure state. ArgoCD watches Git and auto-syncs your Kubernetes cluster. Any manual kubectl apply is a red flag. This pattern prevents configuration drift and makes rollbacks instant — just revert the Git commit.</div>
-            </div>
-        </div>
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">05 / 09</span>
-        </div>
-    </div>
-
-    <!-- ══════════════════════ PAGE 6 — PHASES 9–10 ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
-            <span class="page-num">06</span>
-        </div>
-        <div class="page-body">
-            <div class="section-label">Security, Observability & Cost Engineering</div>
-            <h2 class="section-title">Cloud Security, Monitoring & FinOps</h2>
-            <div class="roadmap">
-
-                <!-- PHASE 9 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">9</div>
-                        <div class="step-line"></div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 24–34</div>
-                        <div class="step-phase">Phase 09 · Cloud Security</div>
-                        <div class="step-heading">Cloud Security — The Skill That Keeps Systems Alive</div>
-                        <div class="step-desc">Security breaches in cloud cost companies millions. Cloud security is a multiplier skill — good engineers know it, great engineers live by it. Master <strong>IAM best practices</strong>: principle of least privilege, no root access in production, IAM roles over static credentials, cross-account roles. Understand <strong>AWS security services</strong>: GuardDuty (threat detection), Security Hub (posture management), AWS Config (compliance), CloudTrail (API audit logs — always enable this), Macie (S3 data discovery), Inspector (vulnerability scanning), WAF &amp; Shield (DDoS). Learn <strong>Secrets management</strong>: AWS Secrets Manager, HashiCorp Vault — never hardcode credentials. Understand <strong>encryption</strong>: KMS for key management, encryption at rest (S3 SSE, EBS encryption) and in transit (TLS). Study <strong>network security</strong>: private subnets, VPC endpoints (no internet for sensitive traffic), VPN vs Direct Connect. Learn <strong>container security</strong>: image scanning, Pod Security Standards, OPA/Gatekeeper policies. Study <strong>CSPM tools</strong>: Wiz, Prisma Cloud for cloud posture. Earn <strong>AWS Security Specialty</strong> cert for senior roles.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Keeps systems alive</span>
-                            <span class="tag">IAM least privilege</span>
-                            <span class="tag">GuardDuty / Security Hub</span>
-                            <span class="tag">CloudTrail (always on)</span>
-                            <span class="tag">AWS Secrets Manager</span>
-                            <span class="tag">KMS encryption</span>
-                            <span class="tag">VPC endpoints</span>
-                            <span class="tag">OPA / Gatekeeper</span>
-                        </div>
-                        <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=iF9fs8Rw4Uo" target="_blank">AWS Security Deep Dive – NetworkChuck</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=Ia-UEYYR44s" target="_blank">HashiCorp Vault Tutorial – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=M6mbUPl0c9Q" target="_blank">Cloud Security Best Practices – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=pxp7uYUjH_M" target="_blank">AWS GuardDuty & Security Hub – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=wbHOS_6MKDY" target="_blank">Kubernetes Security & OPA – TechWorld with Nana</a>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- PHASE 10 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">10</div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Weeks 26–36</div>
-                        <div class="step-phase">Phase 10 · Observability & FinOps</div>
-                        <div class="step-heading">Monitoring, Logging, Tracing & Cloud Cost Engineering</div>
-                        <div class="step-desc">You can't manage what you can't measure. Build observability into everything. Learn the <strong>three pillars</strong>: <strong>Metrics</strong> (Prometheus + Grafana — the industry standard), <strong>Logs</strong> (ELK Stack / OpenSearch, Loki, CloudWatch Logs), <strong>Traces</strong> (Jaeger, Tempo, AWS X-Ray — distributed tracing for microservices). Understand <strong>alerting</strong>: Alertmanager with Prometheus, PagerDuty/OpsGenie for on-call. Study the <strong>OpenTelemetry (OTel)</strong> standard — vendor-neutral instrumentation that all modern tools support. Master <strong>Grafana dashboards</strong>: PromQL queries, panels, alerts. Learn <strong>FinOps (Cloud Cost Engineering)</strong>: AWS Cost Explorer, Budgets and alerts, Reserved Instances vs Savings Plans vs Spot Instances (save 60–90%), right-sizing EC2 instances, S3 lifecycle policies to move to cheaper tiers, Compute Optimizer. Study <strong>Kubecost</strong> for K8s cost visibility. An unmonitored cloud bill will bankrupt a startup in weeks.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Production-grade observability</span>
-                            <span class="tag">Prometheus + Grafana</span>
-                            <span class="tag">ELK / Loki</span>
-                            <span class="tag">Jaeger / X-Ray</span>
-                            <span class="tag">OpenTelemetry</span>
-                            <span class="tag">AWS Cost Explorer</span>
-                            <span class="tag">Savings Plans / Spot</span>
-                            <span class="tag">Kubecost</span>
-                        </div>
-                        <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=h4Sl21AKiDg" target="_blank">Prometheus + Grafana – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=tDWBQDaCFB8" target="_blank">ELK Stack Full Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=sSMwBwNuW5Q" target="_blank">OpenTelemetry Explained – Fireship</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=znIjk-7ZuqI" target="_blank">AWS Cost Optimization – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=Dg0GUm_DQCI" target="_blank">FinOps for Engineers – CloudHealth</a>
-                        </div>
-                    </div>
-                </div>
-
-            </div>
-        </div>
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">06 / 09</span>
-        </div>
-    </div>
-
-    <!-- ══════════════════════ PAGE 7 — PHASE 11 + ARCHITECTURE ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
-            <span class="page-num">07</span>
-        </div>
-        <div class="page-body">
-            <div class="section-label">Advanced Architecture</div>
-            <h2 class="section-title">Cloud-Native Architecture, Serverless & System Design</h2>
-            <div class="roadmap">
-                <!-- PHASE 11 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">11</div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Month 8–14 (Architecture Mastery)</div>
-                        <div class="step-phase">Phase 11 · Cloud Architecture & System Design</div>
-                        <div class="step-heading">Designing Scalable, Resilient, Cost-Efficient Cloud Systems</div>
-                        <div class="step-desc">This is what separates a cloud operator from a cloud architect. Learn the <strong>AWS Well-Architected Framework</strong>: 6 pillars — Operational Excellence, Security, Reliability, Performance Efficiency, Cost Optimization, Sustainability. Study <strong>serverless architecture patterns</strong>: event-driven systems with Lambda + SQS/SNS + EventBridge + API Gateway — zero servers to manage. Learn <strong>microservices patterns</strong>: service mesh (Istio, AWS App Mesh), sidecar pattern, API Gateway pattern. Understand <strong>database architecture</strong>: read replicas, Multi-AZ RDS, Aurora serverless, DynamoDB global tables, ElastiCache (Redis) for caching. Study <strong>messaging systems</strong>: SQS (queues), SNS (pub/sub), Kafka (MSK), Kinesis (real-time streaming). Learn <strong>high availability and disaster recovery</strong>: RTO vs RPO, active-active vs active-passive, multi-region deployments. Understand <strong>the 12-factor app</strong> methodology. Study <strong>cloud-native storage</strong>: EFS vs EBS vs S3 vs FSx — when to use each. Practice cloud system design interviews: design YouTube, design Twitter, design a URL shortener on AWS. This is what's tested at FAANG cloud interviews.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Architecture mastery</span>
-                            <span class="tag">Well-Architected Framework</span>
-                            <span class="tag">Event-driven (SQS/SNS)</span>
-                            <span class="tag">Service mesh (Istio)</span>
-                            <span class="tag">Aurora / DynamoDB global</span>
-                            <span class="tag">Kafka / Kinesis</span>
-                            <span class="tag">Multi-region HA</span>
-                            <span class="tag">Cloud system design</span>
-                        </div>
-                        <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=a9__D53WsUs" target="_blank">AWS Well-Architected – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=ExcRbA7fy_A" target="_blank">Serverless Architecture – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=m9Hp8AqCGWc" target="_blank">Kafka Full Course – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=F2FmTdLtb_4" target="_blank">Istio Service Mesh – TechWorld with Nana</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=REB_eGHK_P4" target="_blank">System Design Interview – Alex Xu</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=ZgdS0EUmn70" target="_blank">Cloud Architecture Patterns – AWS</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <hr class="divider">
-            <div class="section-label">Cloud Architecture Patterns — The Patterns Every Engineer Must Know</div>
-            <div class="resource-grid">
-                <div class="resource-card">
-                    <div class="resource-card-name">☁️ Serverless Event-Driven</div>
-                    <div class="resource-card-desc">Lambda + SQS + SNS + EventBridge + API Gateway. Zero server management. Pay per invocation. Scales to 0 automatically. Best for variable, spiky workloads. Not for long-running tasks.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=8I4wimquMEk" target="_blank">AWS Lambda Full Course</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">🔵 Blue/Green Deployment</div>
-                    <div class="resource-card-desc">Run two identical environments (blue=live, green=new). Switch traffic instantly with zero downtime. Instant rollback — just flip traffic back to blue. Used with ALB weighted target groups or Route 53.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=qP8kir2GUgo" target="_blank">Deployment Strategies – TechWorld</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">🌍 Multi-Region Active-Active</div>
-                    <div class="resource-card-desc">Deploy across 2+ regions simultaneously. Route 53 latency routing sends users to the nearest region. DynamoDB Global Tables replicate data. 99.99%+ availability. Used by Netflix, Amazon, Google.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=a9__D53WsUs" target="_blank">Multi-Region Architecture – AWS</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">🔒 Zero-Trust Networking</div>
-                    <div class="resource-card-desc">Never trust, always verify. Everything inside the VPC is also untrusted by default. Workloads authenticate with short-lived tokens. Service-to-service mTLS via Istio. Replaces perimeter-based security models.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=F2FmTdLtb_4" target="_blank">Zero Trust with Istio – TechWorld</a>
-                    </div>
-                </div>
-            </div>
-
-            <hr class="divider">
-            <div class="section-label">Certifications Roadmap — In Priority Order</div>
-            <table class="stack-table">
-                <thead>
-                    <tr><th>Certification</th><th>Provider</th><th>Level</th><th>When to Take</th></tr>
-                </thead>
-                <tbody>
-                    <tr><td>AWS SAA-C03</td><td>Amazon Web Services</td><td>Associate</td><td>Month 4–6 — first cert, highest ROI</td></tr>
-                    <tr><td>CKA</td><td>Linux Foundation</td><td>Professional</td><td>Month 7–9 — after K8s mastery</td></tr>
-                    <tr><td>Terraform Associate</td><td>HashiCorp</td><td>Associate</td><td>Month 6–8 — after IaC phase</td></tr>
-                    <tr><td>AWS DevOps Pro</td><td>Amazon Web Services</td><td>Professional</td><td>Month 10–12 — senior level</td></tr>
-                    <tr><td>Google ACE</td><td>Google Cloud</td><td>Associate</td><td>Month 8–10 — multi-cloud</td></tr>
-                    <tr><td>AWS Security Specialty</td><td>Amazon Web Services</td><td>Specialty</td><td>Month 12+ — high salary boost</td></tr>
-                </tbody>
-            </table>
-        </div>
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">07 / 09</span>
-        </div>
-    </div>
-
-    <!-- ══════════════════════ PAGE 8 — SKILL MAP + PROJECTS ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
-            <span class="page-num">08</span>
-        </div>
-        <div class="page-body">
-            <div class="section-label">Skill Map & Projects</div>
-            <h2 class="section-title">Full Timeline, Portfolio Projects & Daily Routine</h2>
-
-            <div class="skills-row">
-                <div class="skill-col">
-                    <div class="skill-col-title">🟥 Month 1–4</div>
-                    <div class="skill-item">Linux CLI + Bash scripting</div>
-                    <div class="skill-item">Networking fundamentals</div>
-                    <div class="skill-item">AWS core (EC2, S3, VPC, IAM)</div>
-                    <div class="skill-item">AWS SAA-C03 certification</div>
-                    <div class="skill-item">Docker fundamentals</div>
-                    <div class="skill-item">Git + GitHub workflows</div>
-                    <div class="skill-item">Python for automation scripts</div>
-                </div>
-                <div class="skill-col">
-                    <div class="skill-col-title">🟧 Month 5–9</div>
-                    <div class="skill-item">Kubernetes (CKA prep)</div>
-                    <div class="skill-item">Terraform + remote state</div>
-                    <div class="skill-item">GitHub Actions CI/CD</div>
-                    <div class="skill-item">ArgoCD / GitOps</div>
-                    <div class="skill-item">Prometheus + Grafana</div>
-                    <div class="skill-item">AWS security services</div>
-                    <div class="skill-item">ELK / Loki logging</div>
-                </div>
-                <div class="skill-col">
-                    <div class="skill-col-title">🟩 Month 10–16</div>
-                    <div class="skill-item">Multi-cloud (GCP/Azure)</div>
-                    <div class="skill-item">Service mesh (Istio)</div>
-                    <div class="skill-item">Kafka / Kinesis streaming</div>
-                    <div class="skill-item">FinOps + cost engineering</div>
-                    <div class="skill-item">Cloud system design</div>
-                    <div class="skill-item">AWS DevOps Pro / Security</div>
-                    <div class="skill-item">Published projects + blog</div>
-                </div>
-            </div>
-
-            <hr class="divider">
-
-            <div class="section-label">Portfolio Projects — Build These 5 to Get Hired</div>
-            <div class="resource-grid">
-                <div class="resource-card">
-                    <div class="resource-card-name">🏗️ 3-Tier AWS App (IaC)</div>
-                    <div class="resource-card-desc">Deploy a full 3-tier web app (frontend on S3+CloudFront, backend on EC2/ECS, RDS database) using 100% Terraform. VPC with public/private subnets, ALB, Auto Scaling Groups, RDS Multi-AZ. Zero manual console clicks. The classic cloud portfolio project.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=SLB_c_ayRMo" target="_blank">Terraform AWS – freeCodeCamp</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">☸️ K8s App + Full GitOps</div>
-                    <div class="resource-card-desc">Containerize a microservices app (3+ services), deploy on EKS or GKE with Helm charts, set up ArgoCD GitOps, Prometheus+Grafana monitoring, cert-manager for TLS, and a GitHub Actions pipeline that builds, pushes, and auto-deploys on merge to main.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=f5EpcWp0THw" target="_blank">ArgoCD Full Course – TechWorld</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">🔒 Secure Landing Zone</div>
-                    <div class="resource-card-desc">Build an AWS multi-account landing zone with AWS Organizations, SCPs, CloudTrail across all accounts, GuardDuty, Security Hub, IAM Identity Center (SSO), and a centralized logging account. Shows enterprise-grade security thinking.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=iF9fs8Rw4Uo" target="_blank">AWS Security Deep Dive</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">⚡ Serverless Data Pipeline</div>
-                    <div class="resource-card-desc">Build an event-driven pipeline: S3 upload triggers Lambda → processes data → writes to DynamoDB → SNS notification. Add API Gateway REST endpoint. Deploy everything with CDK or SAM. Monitor with X-Ray tracing and CloudWatch dashboards.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/watch?v=8I4wimquMEk" target="_blank">AWS Lambda Full Course</a>
-                    </div>
-                </div>
-            </div>
-
-            <hr class="divider">
-
-            <div class="section-label">Daily Routine</div>
-            <div style="font-size:14px; font-weight:700; color:var(--dark); margin-bottom:10px;">The Boring Cloud Engineering Routine That Works</div>
-            <div class="checklist">
-                <div class="check-item"><div class="check-box"></div> Spin up and destroy one AWS resource with Terraform — muscle memory for IaC</div>
-                <div class="check-item"><div class="check-box"></div> Read one AWS/GCP blog post, re:Invent talk, or architecture case study</div>
-                <div class="check-item"><div class="check-box"></div> Practice 1 kubectl command or Linux task you're not fluent in yet</div>
-                <div class="check-item"><div class="check-box"></div> Check your AWS cost dashboard — know where every dollar is going</div>
-                <div class="check-item"><div class="check-box"></div> Push one GitHub commit on your portfolio project or cert study notes</div>
-                <div class="check-item"><div class="check-box"></div> Share one cloud tip, architecture diagram, or project update on LinkedIn</div>
-            </div>
-        </div>
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">08 / 09</span>
-        </div>
-    </div>
-
-    <!-- ══════════════════════ PAGE 9 — RESOURCES + CTA ══════════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">Cloud Engineer Roadmap · 2026</span>
-            <span class="page-num">09</span>
-        </div>
-        <div class="page-body">
-            <div class="section-label">Master Resource List</div>
-            <h2 class="section-title">Best Free YouTube Channels for Cloud Engineering</h2>
-
-            <div class="resource-grid">
-                <div class="resource-card">
-                    <div class="resource-card-name">📺 TechWorld with Nana</div>
-                    <div class="resource-card-desc">The single best cloud and DevOps YouTube channel. Covers Docker, Kubernetes, Terraform, Jenkins, GitLab CI, ArgoCD, Prometheus, and more — all in exceptional depth with real projects. Watch this channel first.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/@TechWorldwithNana" target="_blank">@TechWorldwithNana</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">📺 NetworkChuck</div>
-                    <div class="resource-card-desc">Makes networking and cloud genuinely exciting. Best for Linux, networking fundamentals, AWS, and home lab projects. His energy and hands-on approach makes dense technical content stick. Great for visual learners.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/@NetworkChuck" target="_blank">@NetworkChuck</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">📺 freeCodeCamp</div>
-                    <div class="resource-card-desc">Full-length courses on AWS, GCP, Azure, Terraform, Kubernetes, Docker, Jenkins, and every cloud tool. Completely free. The go-to for long-form, project-based learning covering every phase of this roadmap.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/@freecodecamp" target="_blank">@freecodecamp</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">📺 Fireship</div>
-                    <div class="resource-card-desc">Fast, dense, highly accurate 5–10 minute explainers. Best for getting oriented on new cloud concepts quickly — Docker, K8s, serverless, DNS, networking. Watch a Fireship video first, then go deep with TechWorld with Nana.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/@Fireship" target="_blank">@Fireship</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">📺 AWS Official Channel</div>
-                    <div class="resource-card-desc">Direct from the source. re:Invent conference talks are gold — the "300-level" architecture talks show how companies like Netflix, NASA, and Airbnb use AWS at scale. Essential viewing for senior cloud roles.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/@amazonwebservices" target="_blank">@amazonwebservices</a>
-                    </div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">📺 Anton Babenko</div>
-                    <div class="resource-card-desc">The foremost Terraform expert on YouTube. Covers Terraform modules, registry, best practices, Terragrunt, and advanced IaC patterns. If you want to write production-quality Terraform, follow every video he posts.</div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://www.youtube.com/@AntonBabenko" target="_blank">@AntonBabenko</a>
-                    </div>
-                </div>
-            </div>
-
-            <hr class="divider">
-
-            <div class="section-label">Tools by TBE — Use These</div>
-            <div style="display:flex; gap:8px; flex-wrap:wrap; margin-bottom:14px;">
-                <span class="tag red">DSA Yatra — Daily practice</span>
-                <span class="tag red">Prep Yatra — Interview tracker</span>
-                <span class="tag red">Tech Yatra — Learning roadmaps</span>
-                <span class="tag red">Resume Yatra — ATS-ready resume</span>
-                <span class="tag">Shiksha — Free courses</span>
-                <span class="tag">YouFocus — Distraction-free YT</span>
-                <span class="tag">Interview Prep — Question banks</span>
-                <span class="tag">Community — Peer learning</span>
-            </div>
-
-            <div class="cta-block">
-                <div class="cta-title">The Cloud Is Where Careers Are Built ☁️</div>
-                <div class="cta-sub">Every startup, every enterprise, every government — they all run on cloud infrastructure.<br>The engineer who can build, secure, and scale that infrastructure will never run out of opportunities.</div>
-                <a href="https://www.theboringeducation.com" class="cta-link" target="_blank">→ theboringeducation.com</a>
-            </div>
-
-            <hr class="divider">
-
-            <div class="section-label">Find Us Everywhere</div>
-            <div class="socials-grid">
-                <a class="social-card" href="https://instagram.com/theboringeducation" target="_blank">
-                    <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/2111/2111463.png" alt="Instagram">
-                    <span class="social-name">Instagram</span>
-                    <div class="social-handle">@theboringeducation</div>
-                </a>
-                <a class="social-card" href="https://linkedin.com/company/the-boring-education" target="_blank">
-                    <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png" alt="LinkedIn">
-                    <span class="social-name">LinkedIn</span>
-                    <div class="social-handle">The Boring Education</div>
-                </a>
-                <a class="social-card" href="https://github.com/The-Boring-Education" target="_blank">
-                    <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/733/733609.png" alt="GitHub">
-                    <span class="social-name">GitHub</span>
-                    <div class="social-handle">The-Boring-Education</div>
-                </a>
-            </div>
-        </div>
-        <div class="page-footer">
-            <span class="cover-footer-text">© 2026 The Boring Education · Free Tech Education for Everyone</span>
-            <span class="page-num">09 / 09</span>
-        </div>
-    </div>
-
-</div>
 </body>
+
 </html>

--- a/apps/resources/content/cyber-security-engineer-roadmap/index.html
+++ b/apps/resources/content/cyber-security-engineer-roadmap/index.html
@@ -1146,10 +1146,10 @@
                                 <span class="tag">Protocols</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=qiQR5rTSshw" target="_blank">Computer Networking Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=IPvYjXCsTg8" target="_blank">OSI Model Explained – NetworkChuck</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=jH-5oGgImxc" target="_blank">Subnetting Mastery – Professor Messer</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=lb1Dw0elw0Q" target="_blank">Wireshark Tutorial – David Bombal</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Computer%20Networking%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">Computer Networking Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=OSI%20Model%20Explained%20%E2%80%93%20NetworkChuck" target="_blank">OSI Model Explained – NetworkChuck</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Subnetting%20Mastery%20%E2%80%93%20Professor%20Messer" target="_blank">Subnetting Mastery – Professor Messer</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Wireshark%20Tutorial%20%E2%80%93%20David%20Bombal" target="_blank">Wireshark Tutorial – David Bombal</a>
                             </div>
                         </div>
                     </div>
@@ -1176,10 +1176,10 @@
                                 <span class="tag">SSH</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=ZtqBQ68cfJc" target="_blank">Linux Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=lZAoFs75_cs" target="_blank">Kali Linux for Beginners – NetworkChuck</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=oxuRxtrO2Ag" target="_blank">Bash Scripting – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=MUR1LHnmKB0" target="_blank">Home Lab Setup – John Hammond</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Linux%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">Linux Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Kali%20Linux%20for%20Beginners%20%E2%80%93%20NetworkChuck" target="_blank">Kali Linux for Beginners – NetworkChuck</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Bash%20Scripting%20%E2%80%93%20freeCodeCamp" target="_blank">Bash Scripting – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Home%20Lab%20Setup%20%E2%80%93%20John%20Hammond" target="_blank">Home Lab Setup – John Hammond</a>
                             </div>
                         </div>
                     </div>
@@ -1205,10 +1205,10 @@
                                 <span class="tag">Zero-trust</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=AQDCe585Lnc" target="_blank">Cryptography Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=j9QmMEWmcfo" target="_blank">OWASP Top 10 Explained – David Bombal</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=T4Df5_cojAs" target="_blank">TLS & PKI Explained – Professor Messer</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=6WZ6S-qmtqY" target="_blank">Zero Trust Security – NetworkChuck</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Cryptography%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">Cryptography Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=OWASP%20Top%2010%20Explained%20%E2%80%93%20David%20Bombal" target="_blank">OWASP Top 10 Explained – David Bombal</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=TLS%20%26%20PKI%20Explained%20%E2%80%93%20Professor%20Messer" target="_blank">TLS & PKI Explained – Professor Messer</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Zero%20Trust%20Security%20%E2%80%93%20NetworkChuck" target="_blank">Zero Trust Security – NetworkChuck</a>
                             </div>
                         </div>
                     </div>
@@ -1265,11 +1265,11 @@
                                 <span class="tag">Privilege escalation</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=3Kq1MIfTWCE" target="_blank">Ethical Hacking Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=G3NE1b0AaCA" target="_blank">Metasploit Tutorial – David Bombal</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=G3NE1b0AaGA" target="_blank">Burp Suite Full Course – TCM Security</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=2_lswM1S264" target="_blank">HackTheBox Getting Started – IppSec</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=WnN6dbos5u8" target="_blank">Nmap for Hackers – NetworkChuck</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Ethical%20Hacking%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">Ethical Hacking Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Metasploit%20Tutorial%20%E2%80%93%20David%20Bombal" target="_blank">Metasploit Tutorial – David Bombal</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Burp%20Suite%20Full%20Course%20%E2%80%93%20TCM%20Security" target="_blank">Burp Suite Full Course – TCM Security</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=HackTheBox%20Getting%20Started%20%E2%80%93%20IppSec" target="_blank">HackTheBox Getting Started – IppSec</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Nmap%20for%20Hackers%20%E2%80%93%20NetworkChuck" target="_blank">Nmap for Hackers – NetworkChuck</a>
                             </div>
                         </div>
                     </div>
@@ -1295,11 +1295,11 @@
                                 <span class="tag">Threat intelligence</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=wbN_f5_UO5o" target="_blank">Splunk Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=hpPeKzCBRaA" target="_blank">MITRE ATT&CK Framework – John Hammond</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=FIFrfQN8Yl0" target="_blank">Incident Response Tutorial – Gerald Auger</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Yn9oemFCBHE" target="_blank">SOC Analyst Full Course – TCM Security</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Bqd3cqjZ7ig" target="_blank">Digital Forensics – 13Cubed</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Splunk%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">Splunk Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=MITRE%20ATT%26CK%20Framework%20%E2%80%93%20John%20Hammond" target="_blank">MITRE ATT&CK Framework – John Hammond</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Incident%20Response%20Tutorial%20%E2%80%93%20Gerald%20Auger" target="_blank">Incident Response Tutorial – Gerald Auger</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=SOC%20Analyst%20Full%20Course%20%E2%80%93%20TCM%20Security" target="_blank">SOC Analyst Full Course – TCM Security</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Digital%20Forensics%20%E2%80%93%2013Cubed" target="_blank">Digital Forensics – 13Cubed</a>
                             </div>
                         </div>
                     </div>
@@ -1396,11 +1396,11 @@
                                 <span class="tag">CSPM tools</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=ulprqHHWlng" target="_blank">AWS Security Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=4ZP7GR1cQ5c" target="_blank">Cloud Pentesting – HackerSploit</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=g2JOHLHh4rI" target="_blank">AWS IAM Deep Dive – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=7xngnjfIlK4" target="_blank">Terraform for Security – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=n2h8TEDOIQU" target="_blank">Azure Security Center – John Savill</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20Security%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">AWS Security Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Cloud%20Pentesting%20%E2%80%93%20HackerSploit" target="_blank">Cloud Pentesting – HackerSploit</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20IAM%20Deep%20Dive%20%E2%80%93%20TechWorld%20with%20Nana" target="_blank">AWS IAM Deep Dive – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Terraform%20for%20Security%20%E2%80%93%20freeCodeCamp" target="_blank">Terraform for Security – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Azure%20Security%20Center%20%E2%80%93%20John%20Savill" target="_blank">Azure Security Center – John Savill</a>
                             </div>
                         </div>
                     </div>
@@ -1426,11 +1426,11 @@
                                 <span class="tag">GitHub Actions</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=F5KJVuii0Yw" target="_blank">DevSecOps Pipeline – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=pYXSaVp8m4I" target="_blank">Docker Security – HackerSploit</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=ltrV-Qmh3oY" target="_blank">Kubernetes Security – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=oYzFAecPVZY" target="_blank">HashiCorp Vault Tutorial – NetworkChuck</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=YV3pDZ_k6R4" target="_blank">OWASP ZAP Tutorial – David Bombal</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=DevSecOps%20Pipeline%20%E2%80%93%20TechWorld%20with%20Nana" target="_blank">DevSecOps Pipeline – TechWorld with Nana</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Docker%20Security%20%E2%80%93%20HackerSploit" target="_blank">Docker Security – HackerSploit</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Kubernetes%20Security%20%E2%80%93%20freeCodeCamp" target="_blank">Kubernetes Security – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=HashiCorp%20Vault%20Tutorial%20%E2%80%93%20NetworkChuck" target="_blank">HashiCorp Vault Tutorial – NetworkChuck</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=OWASP%20ZAP%20Tutorial%20%E2%80%93%20David%20Bombal" target="_blank">OWASP ZAP Tutorial – David Bombal</a>
                             </div>
                         </div>
                     </div>
@@ -1527,11 +1527,11 @@
                                 <span class="tag">AnyRun</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Sv8yu12y5zM" target="_blank">Malware Analysis – OALabs</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=_Dz0NKPJSOA" target="_blank">Ghidra Full Course – HackTheBox</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=BysvfBFq74A" target="_blank">Reverse Engineering – LiveOverflow</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=1KGQpn_sFV4" target="_blank">YARA Rules Tutorial – 13Cubed</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=aN1PVXL5H1A" target="_blank">Assembly for Hackers – OpenSecurityTraining</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Malware%20Analysis%20%E2%80%93%20OALabs" target="_blank">Malware Analysis – OALabs</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Ghidra%20Full%20Course%20%E2%80%93%20HackTheBox" target="_blank">Ghidra Full Course – HackTheBox</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Reverse%20Engineering%20%E2%80%93%20LiveOverflow" target="_blank">Reverse Engineering – LiveOverflow</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=YARA%20Rules%20Tutorial%20%E2%80%93%2013Cubed" target="_blank">YARA Rules Tutorial – 13Cubed</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Assembly%20for%20Hackers%20%E2%80%93%20OpenSecurityTraining" target="_blank">Assembly for Hackers – OpenSecurityTraining</a>
                             </div>
                         </div>
                     </div>
@@ -1557,10 +1557,10 @@
                                 <span class="tag">ISO 27001 / NIST</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=lT6Px9zJM3s" target="_blank">Active Directory Attacks – TCM Security</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=4lNDq0z3BkQ" target="_blank">BloodHound Tutorial – The Cyber Mentor</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=SMEuBUpNGUE" target="_blank">OSINT Techniques – IntelTechniques</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=yNqmq7XDXW0" target="_blank">AI Security & Prompt Injection – Simon Willison</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Active%20Directory%20Attacks%20%E2%80%93%20TCM%20Security" target="_blank">Active Directory Attacks – TCM Security</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=BloodHound%20Tutorial%20%E2%80%93%20The%20Cyber%20Mentor" target="_blank">BloodHound Tutorial – The Cyber Mentor</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=OSINT%20Techniques%20%E2%80%93%20IntelTechniques" target="_blank">OSINT Techniques – IntelTechniques</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AI%20Security%20%26%20Prompt%20Injection%20%E2%80%93%20Simon%20Willison" target="_blank">AI Security & Prompt Injection – Simon Willison</a>
                             </div>
                         </div>
                     </div>
@@ -1645,10 +1645,10 @@
                                 <span class="tag">LinkedIn presence</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=aFGT9H_vT-w" target="_blank">Bug Bounty for Beginners – NahamSec</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=pzyDFmOSBMo" target="_blank">Security Interview Prep – TCM Security</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=TI99QQmgJZg" target="_blank">How to Write CTF Writeups – John Hammond</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=lt0EffLfR5g" target="_blank">Landing Your First Cyber Job – Gerald Auger</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Bug%20Bounty%20for%20Beginners%20%E2%80%93%20NahamSec" target="_blank">Bug Bounty for Beginners – NahamSec</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Security%20Interview%20Prep%20%E2%80%93%20TCM%20Security" target="_blank">Security Interview Prep – TCM Security</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=How%20to%20Write%20CTF%20Writeups%20%E2%80%93%20John%20Hammond" target="_blank">How to Write CTF Writeups – John Hammond</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Landing%20Your%20First%20Cyber%20Job%20%E2%80%93%20Gerald%20Auger" target="_blank">Landing Your First Cyber Job – Gerald Auger</a>
                             </div>
                         </div>
                     </div>

--- a/apps/resources/content/devops-engineer-roadmap/index.html
+++ b/apps/resources/content/devops-engineer-roadmap/index.html
@@ -1130,13 +1130,13 @@
                                 <span class="tag">Package managers</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=ZtqBQ68cfJc"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Linux%20Full%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Linux Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=oxuRxtrO2Ag"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Bash%20Scripting%20%E2%80%93%20NetworkChuck"
                                     target="_blank">Bash Scripting – NetworkChuck</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=GtovwKDemnI"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Linux%20for%20DevOps%20%E2%80%93%20TechWorld%20with%20Nana"
                                     target="_blank">Linux for DevOps – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=sWbUDq4S6Y8"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Linux%20Commands%20Cheatsheet%20%E2%80%93%20Fireship"
                                     target="_blank">Linux Commands Cheatsheet – Fireship</a>
                             </div>
                         </div>
@@ -1171,13 +1171,13 @@
                                 <span class="tag">Firewalls</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=qiQR5rTSshw"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Computer%20Networks%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Computer Networks – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=3QhU9jd03a0"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Networking%20for%20DevOps%20%E2%80%93%20TechWorld%20with%20Nana"
                                     target="_blank">Networking for DevOps – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=7_LPdttKXPc"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Nginx%20Full%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Nginx Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=RjMpGXXAfV8"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=DNS%20Explained%20%E2%80%93%20ByteByteGo"
                                     target="_blank">DNS Explained – ByteByteGo</a>
                             </div>
                         </div>
@@ -1212,13 +1212,13 @@
                                 <span class="tag">Trunk-based dev</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=RGOj5yH7evk"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Git%20%26%20GitHub%20Full%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Git & GitHub Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Uszj_k0DGsg"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Git%20for%20Professionals%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Git for Professionals – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=e9lnsKot_SQ"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=GitFlow%20Explained%20%E2%80%93%20Atlassian"
                                     target="_blank">GitFlow Explained – Atlassian</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=f0EjtzuW1nc"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Git%20Hooks%20Tutorial%20%E2%80%93%20Corey%20Schafer"
                                     target="_blank">Git Hooks Tutorial – Corey Schafer</a>
                             </div>
                         </div>
@@ -1287,15 +1287,15 @@
                                 <span class="tag">Container registries</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=3c-iBn73dDE"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Docker%20Full%20Course%20%E2%80%93%20TechWorld%20with%20Nana"
                                     target="_blank">Docker Full Course – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=fqMOX6JJhGo"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Docker%20Compose%20Tutorial%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Docker Compose Tutorial – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=RqTEHSBrYFw"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Docker%20Security%20%E2%80%93%20Snyk"
                                     target="_blank">Docker Security – Snyk</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=pg19Z8LL06w"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Docker%20for%20Beginners%20%E2%80%93%20Fireship"
                                     target="_blank">Docker for Beginners – Fireship</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Gjnup-PuquQ"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Multi-stage%20Docker%20Builds%20%E2%80%93%20TechWorld"
                                     target="_blank">Multi-stage Docker Builds – TechWorld</a>
                             </div>
                         </div>
@@ -1330,15 +1330,15 @@
                                 <span class="tag">SAST / DAST scanning</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=R8_veQiYBjI"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=GitHub%20Actions%20Full%20Course%20%E2%80%93%20TechWorld%20with%20Nana"
                                     target="_blank">GitHub Actions Full Course – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=HSV-Kky9N5E"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=GitLab%20CI%2FCD%20%E2%80%93%20TechWorld%20with%20Nana"
                                     target="_blank">GitLab CI/CD – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=6YZvp2GwT0A"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Jenkins%20Full%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Jenkins Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=MeU5_k9ssrs"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=ArgoCD%20Tutorial%20%E2%80%93%20TechWorld%20with%20Nana"
                                     target="_blank">ArgoCD Tutorial – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=CQL-B4SB8YU"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=CI%2FCD%20Best%20Practices%20%E2%80%93%20DevOps%20Toolkit"
                                     target="_blank">CI/CD Best Practices – DevOps Toolkit</a>
                             </div>
                         </div>
@@ -1448,15 +1448,15 @@
                                 <span class="tag">EKS / GKE / AKS</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=X48VuDVv0do"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Kubernetes%20Full%20Course%20%E2%80%93%20TechWorld%20with%20Nana"
                                     target="_blank">Kubernetes Full Course – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=s_o8dwzRlu4"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Kubernetes%20Crash%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Kubernetes Crash Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=-ybHF_p9oEg"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Helm%20Full%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Helm Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=7bA0gTroJkQ"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=CKA%20Prep%20%E2%80%93%20KodeKloud"
                                     target="_blank">CKA Prep – KodeKloud</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=PziYflu8cB8"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=K8s%20Networking%20Deep%20Dive%20%E2%80%93%20Cilium"
                                     target="_blank">K8s Networking Deep Dive – Cilium</a>
                             </div>
                         </div>
@@ -1491,15 +1491,15 @@
                                 <span class="tag">Policy as code</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=7xngnjfIlK4"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Terraform%20Full%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Terraform Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=KuiAiGfCZjk"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Ansible%20Full%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Ansible Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=SLB_c_ayRMo"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Terraform%20for%20Beginners%20%E2%80%93%20TechWorld%20with%20Nana"
                                     target="_blank">Terraform for Beginners – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=wgQ3rHFTM4E"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Terraform%20Best%20Practices%20%E2%80%93%20Anton%20Babenko"
                                     target="_blank">Terraform Best Practices – Anton Babenko</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Qen1BMglZos"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Pulumi%20Overview%20%E2%80%93%20Pulumi"
                                     target="_blank">Pulumi Overview – Pulumi</a>
                             </div>
                         </div>
@@ -1610,13 +1610,13 @@
                                 <span class="tag">Alertmanager</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=h4Sl21AKiDg"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Prometheus%20%26%20Grafana%20%E2%80%93%20TechWorld%20with%20Nana"
                                     target="_blank">Prometheus & Grafana – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=MpNZ4Yl-p0U"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=ELK%20Stack%20Full%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">ELK Stack Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=r8UvWSX3KA8"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=OpenTelemetry%20Full%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">OpenTelemetry Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=9TJx7QTrTyo"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=SRE%20Fundamentals%20%E2%80%93%20Google%20SRE%20Book%20Walkthrough"
                                     target="_blank">SRE Fundamentals – Google SRE Book Walkthrough</a>
                             </div>
                         </div>
@@ -1652,13 +1652,13 @@
                                 <span class="tag">SOC 2 basics</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=VYfl-DpZ5wM"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=HashiCorp%20Vault%20Tutorial%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">HashiCorp Vault Tutorial – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=N8lcedBQ5hI"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=DevSecOps%20Pipeline%20%E2%80%93%20TechWorld%20with%20Nana"
                                     target="_blank">DevSecOps Pipeline – TechWorld with Nana</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=1nf3bwVkvlo"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Kubernetes%20Security%20%E2%80%93%20KodeKloud"
                                     target="_blank">Kubernetes Security – KodeKloud</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=k_ckJ6R1TcI"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=OPA%2FGatekeeper%20%E2%80%93%20Cloud%20Native%20Computing"
                                     target="_blank">OPA/Gatekeeper – Cloud Native Computing</a>
                             </div>
                         </div>
@@ -1677,7 +1677,7 @@
                             app configs. Every change goes through a PR — ArgoCD or Flux syncs the cluster to
                             match the repo. Self-healing, auditable, and dramatically safer than kubectl apply.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=MeU5_k9ssrs" target="_blank">GitOps
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=GitOps%20with%20ArgoCD%20%E2%80%93%20TechWorld%20with%20Nana" target="_blank">GitOps
                                 with ArgoCD – TechWorld with Nana</a>
                         </div>
                     </div>
@@ -1687,7 +1687,7 @@
                             management, circuit breaking, and observability at the network layer. Essential for
                             microservices at scale where service-to-service security and reliability matter.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=16fgzklcF7Y" target="_blank">Istio
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Istio%20Service%20Mesh%20%E2%80%93%20TechWorld%20with%20Nana" target="_blank">Istio
                                 Service Mesh – TechWorld with Nana</a>
                         </div>
                     </div>
@@ -1698,7 +1698,7 @@
                             discipline that Netflix pioneered and that separates mature SRE teams from everyone
                             else.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=vfBTDRgaG5o" target="_blank">Chaos
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Chaos%20Engineering%20%E2%80%93%20LitmusChaos" target="_blank">Chaos
                                 Engineering – LitmusChaos</a>
                         </div>
                     </div>
@@ -1709,7 +1709,7 @@
                             with guardrails. The evolution of DevOps: enabling hundreds of developers to deploy
                             safely without tickets.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=CLEe2Zs7oCE"
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Platform%20Engineering%20%E2%80%93%20CNCF"
                                 target="_blank">Platform Engineering – CNCF</a>
                         </div>
                     </div>
@@ -1766,13 +1766,13 @@
                                 <span class="tag">Bash / Python scripting</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=7bA0gTroJkQ"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=CKA%20Full%20Course%20%E2%80%93%20KodeKloud"
                                     target="_blank">CKA Full Course – KodeKloud</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=SOTamWNgDKc"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AWS%20SAA%20Course%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">AWS SAA Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=V4waklkBC38"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Terraform%20Associate%20%E2%80%93%20freeCodeCamp"
                                     target="_blank">Terraform Associate – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=nKW8Ndu7Mjw"
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=DevOps%20Interview%20Questions%20%E2%80%93%20TechWorld%20with%20Nana"
                                     target="_blank">DevOps Interview Questions – TechWorld with Nana</a>
                             </div>
                         </div>

--- a/apps/resources/content/dsa-escape-plan-2026/index.html
+++ b/apps/resources/content/dsa-escape-plan-2026/index.html
@@ -1272,884 +1272,969 @@
 <body>
     <div class="resource-viewer">
 
-    <!-- PRINT BAR -->
-    <div class="print-bar">
-        <button class="print-btn" onclick="window.print()">
-            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-                <path
-                    d="M6 9V2h12v7M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2M6 14h12v8H6z" />
-            </svg>
-            Save as PDF
-        </button>
-    </div>
-
-    <!-- ══════════════════ PAGE 1 — COVER ══════════════════ -->
-    <div class="page cover">
-        <div class="cover-header">
-            <img class="cover-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="cover-badge">DSA Escape Plan 2026</span>
+        <!-- PRINT BAR -->
+        <div class="print-bar">
+            <button class="print-btn" onclick="window.print()">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                    <path
+                        d="M6 9V2h12v7M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2M6 14h12v8H6z" />
+                </svg>
+                Save as PDF
+            </button>
         </div>
 
-        <div class="cover-hero">
-            <div class="cover-decoration"></div>
+        <!-- ══════════════════ PAGE 1 — COVER ══════════════════ -->
+        <div class="page cover">
+            <div class="cover-header">
+                <img class="cover-logo" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="cover-badge">DSA Escape Plan 2026</span>
+            </div>
 
-            <div class="cover-hook">Stop watching. Start solving.</div>
+            <div class="cover-hero">
+                <div class="cover-decoration"></div>
 
-            <h1 class="cover-title">
-                Stuck in<br><span>Tutorial</span><br>Hell?
-            </h1>
+                <div class="cover-hook">Stop watching. Start solving.</div>
 
-            <p class="cover-subtitle">
-                You've watched 47 videos on arrays. You're back at arrays again. This guide breaks the cycle — with the
-                exact DSA topics, practice strategy, and DSA Yatra plan that actually gets you hired.
-            </p>
+                <h1 class="cover-title">
+                    Stuck in<br><span>Tutorial</span><br>Hell?
+                </h1>
 
-            <div class="hell-block">
-                <div class="hell-block-label">⚠ You might be in tutorial hell if...</div>
-                <div class="hell-block-title">"I understand the concept, but I can't solve problems on my own."</div>
-                <div class="hell-symptoms">
-                    <div class="hell-symptom">
-                        <div class="hell-symptom-dot"></div>You've rewatched the same DSA playlist 3+ times but still
-                        blank on LeetCode
+                <p class="cover-subtitle">
+                    You've watched 47 videos on arrays. You're back at arrays again. This guide breaks the cycle — with
+                    the
+                    exact DSA topics, practice strategy, and DSA Yatra plan that actually gets you hired.
+                </p>
+
+                <div class="hell-block">
+                    <div class="hell-block-label">⚠ You might be in tutorial hell if...</div>
+                    <div class="hell-block-title">"I understand the concept, but I can't solve problems on my own."
                     </div>
-                    <div class="hell-symptom">
-                        <div class="hell-symptom-dot"></div>You take notes during videos but can't code from a blank
-                        file
+                    <div class="hell-symptoms">
+                        <div class="hell-symptom">
+                            <div class="hell-symptom-dot"></div>You've rewatched the same DSA playlist 3+ times but
+                            still
+                            blank on LeetCode
+                        </div>
+                        <div class="hell-symptom">
+                            <div class="hell-symptom-dot"></div>You take notes during videos but can't code from a blank
+                            file
+                        </div>
+                        <div class="hell-symptom">
+                            <div class="hell-symptom-dot"></div>You feel "almost ready" to start practicing — for the
+                            past 4
+                            months
+                        </div>
+                        <div class="hell-symptom">
+                            <div class="hell-symptom-dot"></div>You switch topics every time you get stuck instead of
+                            sitting with it
+                        </div>
+                        <div class="hell-symptom">
+                            <div class="hell-symptom-dot"></div>Your GitHub has zero commits but your YouTube watch
+                            history
+                            is a PhD
+                        </div>
                     </div>
-                    <div class="hell-symptom">
-                        <div class="hell-symptom-dot"></div>You feel "almost ready" to start practicing — for the past 4
-                        months
+                </div>
+
+                <div class="cover-stats">
+                    <div class="stat-item">
+                        <div class="stat-num">90%</div>
+                        <div class="stat-label">of learners never escape</div>
                     </div>
-                    <div class="hell-symptom">
-                        <div class="hell-symptom-dot"></div>You switch topics every time you get stuck instead of
-                        sitting with it
+                    <div class="stat-item">
+                        <div class="stat-num">8</div>
+                        <div class="stat-label">Core DSA topics</div>
                     </div>
-                    <div class="hell-symptom">
-                        <div class="hell-symptom-dot"></div>Your GitHub has zero commits but your YouTube watch history
-                        is a PhD
+                    <div class="stat-item">
+                        <div class="stat-num">2/day</div>
+                        <div class="stat-label">Problems. Non-negotiable</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-num">90</div>
+                        <div class="stat-label">Days to interview-ready</div>
                     </div>
                 </div>
             </div>
 
-            <div class="cover-stats">
-                <div class="stat-item">
-                    <div class="stat-num">90%</div>
-                    <div class="stat-label">of learners never escape</div>
-                </div>
-                <div class="stat-item">
-                    <div class="stat-num">8</div>
-                    <div class="stat-label">Core DSA topics</div>
-                </div>
-                <div class="stat-item">
-                    <div class="stat-num">2/day</div>
-                    <div class="stat-label">Problems. Non-negotiable</div>
-                </div>
-                <div class="stat-item">
-                    <div class="stat-num">90</div>
-                    <div class="stat-label">Days to interview-ready</div>
-                </div>
+            <div class="cover-footer">
+                <span class="cover-footer-text">theboringeducation.com &nbsp;·&nbsp; DSA Yatra — Practice.
+                    Everyday.</span>
+                <span class="page-num">01</span>
             </div>
         </div>
 
-        <div class="cover-footer">
-            <span class="cover-footer-text">theboringeducation.com &nbsp;·&nbsp; DSA Yatra — Practice. Everyday.</span>
-            <span class="page-num">01</span>
-        </div>
-    </div>
-
-    <!-- ══════════════════ PAGE 2 — THE ESCAPE PLAN + PHASE 1–2 ══════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo-img" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">DSA Escape Plan · The Boring Education</span>
-            <span class="page-num">02</span>
-        </div>
-
-        <div class="page-body">
-
-            <div class="reality-box">
-                <div class="reality-box-title">🔥 The Hard Truth First</div>
-                <div class="reality-box-text">
-                    Watching someone solve a problem does <strong>NOT</strong> mean you can solve it. The brain tricks
-                    you into "recognition" — you see the steps, nod along, and feel like you understand. But
-                    understanding ≠ solving. <strong>The only way out is to close the video, open a blank file, and
-                        suffer productively.</strong> This document is your structured suffering plan.
-                </div>
+        <!-- ══════════════════ PAGE 2 — THE ESCAPE PLAN + PHASE 1–2 ══════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo-img" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">DSA Escape Plan · The Boring Education</span>
+                <span class="page-num">02</span>
             </div>
 
-            <div class="section-label">The Escape Framework</div>
-            <h2 class="section-title">Phase-by-Phase Breakout Plan</h2>
+            <div class="page-body">
 
-            <div class="roadmap">
-
-                <!-- PHASE 1 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">1</div>
-                        <div class="step-line"></div>
+                <div class="reality-box">
+                    <div class="reality-box-title">🔥 The Hard Truth First</div>
+                    <div class="reality-box-text">
+                        Watching someone solve a problem does <strong>NOT</strong> mean you can solve it. The brain
+                        tricks
+                        you into "recognition" — you see the steps, nod along, and feel like you understand. But
+                        understanding ≠ solving. <strong>The only way out is to close the video, open a blank file, and
+                            suffer productively.</strong> This document is your structured suffering plan.
                     </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Week 1–2 · The Reset</div>
-                        <div class="step-phase">Phase 01 · Stop the Loop</div>
-                        <div class="step-heading">Delete Your Playlist. Open DSA Yatra. Now.</div>
-                        <div class="step-desc">The first move is drastic: stop consuming. No new videos until you've
-                            attempted 20 problems on DSA Yatra — even if you fail all 20. Failure is the curriculum. Set
-                            a 25-minute timer per problem (Pomodoro). If you can't solve it in 25 minutes, read only the
-                            hint — not the full solution. Attempt again. Then and only then, look at the solution.
-                            Understand the pattern, not just the answer. Write the pattern name in your notebook.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Do this first</span>
-                            <span class="tag">DSA Yatra daily</span>
-                            <span class="tag">25-min timer rule</span>
-                            <span class="tag">Hint-first, not solution-first</span>
-                            <span class="tag">Pattern journaling</span>
+                </div>
+
+                <div class="section-label">The Escape Framework</div>
+                <h2 class="section-title">Phase-by-Phase Breakout Plan</h2>
+
+                <div class="roadmap">
+
+                    <!-- PHASE 1 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">1</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Week 1–2 · The Reset</div>
+                            <div class="step-phase">Phase 01 · Stop the Loop</div>
+                            <div class="step-heading">Delete Your Playlist. Open DSA Yatra. Now.</div>
+                            <div class="step-desc">The first move is drastic: stop consuming. No new videos until you've
+                                attempted 20 problems on DSA Yatra — even if you fail all 20. Failure is the curriculum.
+                                Set
+                                a 25-minute timer per problem (Pomodoro). If you can't solve it in 25 minutes, read only
+                                the
+                                hint — not the full solution. Attempt again. Then and only then, look at the solution.
+                                Understand the pattern, not just the answer. Write the pattern name in your notebook.
+                            </div>
+                            <div class="step-tags">
+                                <span class="tag red">Do this first</span>
+                                <span class="tag">DSA Yatra daily</span>
+                                <span class="tag">25-min timer rule</span>
+                                <span class="tag">Hint-first, not solution-first</span>
+                                <span class="tag">Pattern journaling</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">DSA
+                                    Yatra
+                                    — Start Here</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=NeetCode%20DSA%20Roadmap"
+                                    target="_blank">NeetCode DSA Roadmap</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- PHASE 2 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">2</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Week 2–4 · Arrays & Hashing</div>
+                            <div class="step-phase">Phase 02 · Back to Arrays (The Right Way)</div>
+                            <div class="step-heading">"Back to arrays again" — but this time, you're solving, not
+                                watching
+                            </div>
+                            <div class="step-desc">Arrays are not boring — you just never truly solved them. The real
+                                skill
+                                isn't knowing what an array is; it's pattern recognition. Master <strong>Two
+                                    Pointers</strong>, <strong>Sliding Window</strong>, and <strong>Prefix Sum</strong>
+                                on
+                                arrays before moving anywhere. These three patterns solve 60% of array problems. Do 15
+                                array
+                                problems on DSA Yatra — sorted by difficulty. Every problem you solve, tag the pattern
+                                used.
+                            </div>
+                            <div class="step-tags">
+                                <span class="tag red">Most important topic</span>
+                                <span class="tag">Two Pointers</span>
+                                <span class="tag">Sliding Window</span>
+                                <span class="tag">Prefix Sum</span>
+                                <span class="tag">Hash Maps</span>
+                                <span class="tag">Frequency counting</span>
+                                <span class="tag">Sorting tricks</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Two%20Pointers%20%E2%80%93%20NeetCode"
+                                    target="_blank">Two
+                                    Pointers – NeetCode</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Sliding%20Window%20%E2%80%93%20NeetCode"
+                                    target="_blank">Sliding Window – NeetCode</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Prefix%20Sum%20Explained%20%E2%80%93%20Greg%20Hogg"
+                                    target="_blank">Prefix
+                                    Sum Explained – Greg Hogg</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Arrays%20%26%20Hashing%20%E2%80%93%20NeetCode"
+                                    target="_blank">Arrays
+                                    & Hashing – NeetCode</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- PHASE 3 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">3</div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Week 3–5 · Strings</div>
+                            <div class="step-phase">Phase 03 · Strings are Just Char Arrays</div>
+                            <div class="step-heading">"Why is this string problem hard?" — because you skipped patterns
+                            </div>
+                            <div class="step-desc">Strings share patterns with arrays but have gotchas: immutability,
+                                Unicode, anagram detection, palindromes, and substring problems. Master <strong>sliding
+                                    window on strings</strong>, <strong>two pointers for palindromes</strong>, and
+                                <strong>character frequency maps</strong>. Build a mental model: every string problem is
+                                either a window problem, a sorting trick, or a map problem. Do 10 string problems on DSA
+                                Yatra — identify which of the 3 buckets each falls into.
+                            </div>
+                            <div class="step-tags">
+                                <span class="tag red">Tied to arrays</span>
+                                <span class="tag">Anagram detection</span>
+                                <span class="tag">Palindrome</span>
+                                <span class="tag">Substring search</span>
+                                <span class="tag">Character maps</span>
+                                <span class="tag">String DP intro</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=String%20Problems%20%E2%80%93%20NeetCode"
+                                    target="_blank">String
+                                    Problems – NeetCode</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Sliding%20Window%20on%20Strings%20%E2%80%93%20Errichto"
+                                    target="_blank">Sliding Window on Strings – Errichto</a>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+
+                <div class="tip-block">
+                    <div class="tip-icon">🧠</div>
+                    <div class="tip-text"><strong>The Pattern Journal Rule:</strong> After every solved problem, write:
+                        (1)
+                        topic, (2) pattern name, (3) why you were stuck, (4) the key insight. After 50 problems, you'll
+                        see
+                        the matrix — 80% of problems are 10 patterns in disguise. DSA Yatra helps you track this
+                        automatically.</div>
+                </div>
+            </div>
+
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">02 / 06</span>
+            </div>
+        </div>
+
+        <!-- ══════════════════ PAGE 3 — DSA TOPIC DEEP DIVE ══════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo-img" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">DSA Escape Plan · The Boring Education</span>
+                <span class="page-num">03</span>
+            </div>
+
+            <div class="page-body">
+                <div class="section-label">Critical DSA Topics</div>
+                <h2 class="section-title">The 8 Topics That Decide Your Interview</h2>
+
+                <div class="topic-grid">
+
+                    <div class="topic-card">
+                        <span class="topic-card-icon">🔢</span>
+                        <div class="topic-card-name">Arrays & Hashing</div>
+                        <div class="topic-card-hook">"I know what an array is" ≠ knowing how to use it</div>
+                        <div class="topic-card-desc">Foundation of everything. Master prefix sums, two-pointer, sliding
+                            window, and frequency maps before moving on.</div>
+                        <div class="topic-card-problems">
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Two Sum · Best Time to Buy Stock
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Contains Duplicate · Product of Array
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Longest Consecutive Sequence
+                            </div>
                         </div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">DSA Yatra
-                                — Start Here</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=o-k7h2G3Gco"
-                                target="_blank">NeetCode DSA Roadmap</a>
+                            <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice
+                                on
+                                DSA Yatra</a>
                         </div>
                     </div>
-                </div>
 
-                <!-- PHASE 2 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">2</div>
-                        <div class="step-line"></div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Week 2–4 · Arrays & Hashing</div>
-                        <div class="step-phase">Phase 02 · Back to Arrays (The Right Way)</div>
-                        <div class="step-heading">"Back to arrays again" — but this time, you're solving, not watching
-                        </div>
-                        <div class="step-desc">Arrays are not boring — you just never truly solved them. The real skill
-                            isn't knowing what an array is; it's pattern recognition. Master <strong>Two
-                                Pointers</strong>, <strong>Sliding Window</strong>, and <strong>Prefix Sum</strong> on
-                            arrays before moving anywhere. These three patterns solve 60% of array problems. Do 15 array
-                            problems on DSA Yatra — sorted by difficulty. Every problem you solve, tag the pattern used.
-                        </div>
-                        <div class="step-tags">
-                            <span class="tag red">Most important topic</span>
-                            <span class="tag">Two Pointers</span>
-                            <span class="tag">Sliding Window</span>
-                            <span class="tag">Prefix Sum</span>
-                            <span class="tag">Hash Maps</span>
-                            <span class="tag">Frequency counting</span>
-                            <span class="tag">Sorting tricks</span>
+                    <div class="topic-card">
+                        <span class="topic-card-icon">📚</span>
+                        <div class="topic-card-name">Stack & Queue</div>
+                        <div class="topic-card-hook">"It's just push and pop" — until it's not</div>
+                        <div class="topic-card-desc">Monotonic stacks are the hidden gem here. They power 10+ hard
+                            problems
+                            that look impossible until you see the pattern.</div>
+                        <div class="topic-card-problems">
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Valid Parentheses · Min Stack
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Daily Temperatures · Next Greater Element
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Largest Rectangle in Histogram
+                            </div>
                         </div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=GcW4mgmgSbw" target="_blank">Two
-                                Pointers – NeetCode</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=MK-NZ4hN7rs"
-                                target="_blank">Sliding Window – NeetCode</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=7pJo_rM0z_s" target="_blank">Prefix
-                                Sum Explained – Greg Hogg</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=9YkT5_EOAEM" target="_blank">Arrays
-                                & Hashing – NeetCode</a>
+                            <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice
+                                on
+                                DSA Yatra</a>
                         </div>
                     </div>
-                </div>
 
-                <!-- PHASE 3 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">3</div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Week 3–5 · Strings</div>
-                        <div class="step-phase">Phase 03 · Strings are Just Char Arrays</div>
-                        <div class="step-heading">"Why is this string problem hard?" — because you skipped patterns
-                        </div>
-                        <div class="step-desc">Strings share patterns with arrays but have gotchas: immutability,
-                            Unicode, anagram detection, palindromes, and substring problems. Master <strong>sliding
-                                window on strings</strong>, <strong>two pointers for palindromes</strong>, and
-                            <strong>character frequency maps</strong>. Build a mental model: every string problem is
-                            either a window problem, a sorting trick, or a map problem. Do 10 string problems on DSA
-                            Yatra — identify which of the 3 buckets each falls into.</div>
-                        <div class="step-tags">
-                            <span class="tag red">Tied to arrays</span>
-                            <span class="tag">Anagram detection</span>
-                            <span class="tag">Palindrome</span>
-                            <span class="tag">Substring search</span>
-                            <span class="tag">Character maps</span>
-                            <span class="tag">String DP intro</span>
+                    <div class="topic-card">
+                        <span class="topic-card-icon">🔗</span>
+                        <div class="topic-card-name">Linked Lists</div>
+                        <div class="topic-card-hook">"I'll draw it on paper... and still get it wrong"</div>
+                        <div class="topic-card-desc">Slow & fast pointers (Floyd's cycle detection) solve 80% of linked
+                            list
+                            problems. Reversal and merging are the other 20%.</div>
+                        <div class="topic-card-problems">
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Reverse Linked List · Merge Two Sorted
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Linked List Cycle · Middle of LL
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Reorder List · LRU Cache
+                            </div>
                         </div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=qbeV31GCBQQ" target="_blank">String
-                                Problems – NeetCode</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=jSto0O4AJbM"
-                                target="_blank">Sliding Window on Strings – Errichto</a>
+                            <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice
+                                on
+                                DSA Yatra</a>
                         </div>
                     </div>
-                </div>
 
-            </div>
-
-            <div class="tip-block">
-                <div class="tip-icon">🧠</div>
-                <div class="tip-text"><strong>The Pattern Journal Rule:</strong> After every solved problem, write: (1)
-                    topic, (2) pattern name, (3) why you were stuck, (4) the key insight. After 50 problems, you'll see
-                    the matrix — 80% of problems are 10 patterns in disguise. DSA Yatra helps you track this
-                    automatically.</div>
-            </div>
-        </div>
-
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">02 / 06</span>
-        </div>
-    </div>
-
-    <!-- ══════════════════ PAGE 3 — DSA TOPIC DEEP DIVE ══════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo-img" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">DSA Escape Plan · The Boring Education</span>
-            <span class="page-num">03</span>
-        </div>
-
-        <div class="page-body">
-            <div class="section-label">Critical DSA Topics</div>
-            <h2 class="section-title">The 8 Topics That Decide Your Interview</h2>
-
-            <div class="topic-grid">
-
-                <div class="topic-card">
-                    <span class="topic-card-icon">🔢</span>
-                    <div class="topic-card-name">Arrays & Hashing</div>
-                    <div class="topic-card-hook">"I know what an array is" ≠ knowing how to use it</div>
-                    <div class="topic-card-desc">Foundation of everything. Master prefix sums, two-pointer, sliding
-                        window, and frequency maps before moving on.</div>
-                    <div class="topic-card-problems">
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Two Sum · Best Time to Buy Stock
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Contains Duplicate · Product of Array
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Longest Consecutive Sequence
-                        </div>
-                    </div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice on
-                            DSA Yatra</a>
-                    </div>
-                </div>
-
-                <div class="topic-card">
-                    <span class="topic-card-icon">📚</span>
-                    <div class="topic-card-name">Stack & Queue</div>
-                    <div class="topic-card-hook">"It's just push and pop" — until it's not</div>
-                    <div class="topic-card-desc">Monotonic stacks are the hidden gem here. They power 10+ hard problems
-                        that look impossible until you see the pattern.</div>
-                    <div class="topic-card-problems">
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Valid Parentheses · Min Stack
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Daily Temperatures · Next Greater Element
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Largest Rectangle in Histogram
-                        </div>
-                    </div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice on
-                            DSA Yatra</a>
-                    </div>
-                </div>
-
-                <div class="topic-card">
-                    <span class="topic-card-icon">🔗</span>
-                    <div class="topic-card-name">Linked Lists</div>
-                    <div class="topic-card-hook">"I'll draw it on paper... and still get it wrong"</div>
-                    <div class="topic-card-desc">Slow & fast pointers (Floyd's cycle detection) solve 80% of linked list
-                        problems. Reversal and merging are the other 20%.</div>
-                    <div class="topic-card-problems">
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Reverse Linked List · Merge Two Sorted
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Linked List Cycle · Middle of LL
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Reorder List · LRU Cache
-                        </div>
-                    </div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice on
-                            DSA Yatra</a>
-                    </div>
-                </div>
-
-                <div class="topic-card">
-                    <span class="topic-card-icon">🌲</span>
-                    <div class="topic-card-name">Trees & BST</div>
-                    <div class="topic-card-hook">"Recursion makes no sense to me"</div>
-                    <div class="topic-card-desc">Trees ARE recursion in disguise. Once you see "left + right + root =
-                        answer" as a template, trees click instantly. DFS and BFS are everything.</div>
-                    <div class="topic-card-problems">
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Invert Binary Tree · Max Depth
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Level Order Traversal · Diameter
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Lowest Common Ancestor · Serialize
-                        </div>
-                    </div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice on
-                            DSA Yatra</a>
-                    </div>
-                </div>
-
-                <div class="topic-card">
-                    <span class="topic-card-icon">🗺️</span>
-                    <div class="topic-card-name">Graphs</div>
-                    <div class="topic-card-hook">"This looks scary" — it's just trees with cycles</div>
-                    <div class="topic-card-desc">Graphs are the senior-level topic. BFS for shortest path, DFS for
-                        connected components, Union-Find for grouping. Most graph problems are one of these 3.</div>
-                    <div class="topic-card-problems">
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Number of Islands · Clone Graph
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Course Schedule · Pacific Atlantic
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Dijkstra's shortest path
-                        </div>
-                    </div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice on
-                            DSA Yatra</a>
-                    </div>
-                </div>
-
-                <div class="topic-card">
-                    <span class="topic-card-icon">⚡</span>
-                    <div class="topic-card-name">Dynamic Programming</div>
-                    <div class="topic-card-hook">"This is impossible" — you're just not seeing the subproblem</div>
-                    <div class="topic-card-desc">DP is pattern recognition. Fibonacci → 1D DP. Knapsack → 2D DP. Every
-                        DP problem has a "try all choices, cache the result" skeleton. Start simple, go deeper.</div>
-                    <div class="topic-card-problems">
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Climbing Stairs · House Robber
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Coin Change · Longest Common Subsequence
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>0/1 Knapsack · Edit Distance
-                        </div>
-                    </div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice on
-                            DSA Yatra</a>
-                    </div>
-                </div>
-
-                <div class="topic-card">
-                    <span class="topic-card-icon">🔍</span>
-                    <div class="topic-card-name">Binary Search</div>
-                    <div class="topic-card-hook">"I know how binary search works, the code is just weird"</div>
-                    <div class="topic-card-desc">Stop memorizing lo/hi/mid. Learn the template: binary search on the
-                        ANSWER space. This applies far beyond sorted arrays — it shows up in capacity, scheduling, and
-                        matrix problems.</div>
-                    <div class="topic-card-problems">
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Binary Search · Search in Rotated Array
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Find Minimum in Rotated Array
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Median of Two Sorted Arrays
-                        </div>
-                    </div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice on
-                            DSA Yatra</a>
-                    </div>
-                </div>
-
-                <div class="topic-card">
-                    <span class="topic-card-icon">🏔️</span>
-                    <div class="topic-card-name">Heaps / Priority Queue</div>
-                    <div class="topic-card-hook">"When do I even use a heap??"</div>
-                    <div class="topic-card-desc">Anytime you need "the k-th largest/smallest" or "stream processing" —
-                        use a heap. Min-heap and max-heap are interchangeable with a sign flip. Underrated, high-yield
-                        topic.</div>
-                    <div class="topic-card-problems">
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Kth Largest Element · Top K Frequent
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>K Closest Points to Origin
-                        </div>
-                        <div class="problem-item">
-                            <div class="prob-dot"></div>Find Median from Data Stream
-                        </div>
-                    </div>
-                    <div class="yt-links">
-                        <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice on
-                            DSA Yatra</a>
-                    </div>
-                </div>
-
-            </div>
-
-            <div class="tip-block">
-                <div class="tip-icon">📊</div>
-                <div class="tip-text"><strong>Interview frequency breakdown:</strong> Arrays & Hashing (25%) ·
-                    Trees/Graphs (30%) · DP (20%) · Binary Search (10%) · Stack/Queue (8%) · Linked Lists (7%). Spend
-                    more time where interviews spend more time. DSA Yatra filters problems by topic and company
-                    frequency.</div>
-            </div>
-
-        </div>
-
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">03 / 06</span>
-        </div>
-    </div>
-
-    <!-- ══════════════════ PAGE 4 — PREP STRATEGY ══════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo-img" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">DSA Escape Plan · The Boring Education</span>
-            <span class="page-num">04</span>
-        </div>
-
-        <div class="page-body">
-            <div class="section-label">The 90-Day Strategy</div>
-            <h2 class="section-title">How to Use DSA Yatra to Actually Get Hired</h2>
-
-            <div class="roadmap">
-
-                <!-- MONTH 1 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">M1</div>
-                        <div class="step-line"></div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Days 1–30 · Pattern Lock-In</div>
-                        <div class="step-phase">Month 01 · Build the Foundation</div>
-                        <div class="step-heading">60 problems. Every day counts. No skipping.</div>
-                        <div class="step-desc">Open DSA Yatra. Set topic to <strong>Arrays → Strings → Stack</strong> in
-                            sequence. Do 2 problems per day — one easy, one medium. Time every attempt. After each
-                            problem, write the pattern. On weekends: revisit problems you failed earlier that week. Do
-                            not jump to trees yet. Build the habit muscle before the topic breadth. By day 30, you'll
-                            have 60 solved problems and 10–12 patterns identified.</div>
-                        <div class="step-tags">
-                            <span class="tag red">60 problems</span>
-                            <span class="tag">Arrays → Strings → Stack</span>
-                            <span class="tag">Easy + Medium mix</span>
-                            <span class="tag">Weekend review</span>
-                            <span class="tag">Pattern journaling</span>
+                    <div class="topic-card">
+                        <span class="topic-card-icon">🌲</span>
+                        <div class="topic-card-name">Trees & BST</div>
+                        <div class="topic-card-hook">"Recursion makes no sense to me"</div>
+                        <div class="topic-card-desc">Trees ARE recursion in disguise. Once you see "left + right + root
+                            =
+                            answer" as a template, trees click instantly. DFS and BFS are everything.</div>
+                        <div class="topic-card-problems">
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Invert Binary Tree · Max Depth
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Level Order Traversal · Diameter
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Lowest Common Ancestor · Serialize
+                            </div>
                         </div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">DSA Yatra
-                                — Month 1 Filter</a>
+                            <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice
+                                on
+                                DSA Yatra</a>
                         </div>
                     </div>
-                </div>
 
-                <!-- MONTH 2 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">M2</div>
-                        <div class="step-line"></div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Days 31–60 · Tree & Graph Unlock</div>
-                        <div class="step-phase">Month 02 · Recursion + Non-Linear DSA</div>
-                        <div class="step-heading">Trees, Graphs, Binary Search — your interview heavy-hitters</div>
-                        <div class="step-desc">Shift DSA Yatra filter to <strong>Binary Search → Linked Lists → Trees →
-                                Graphs</strong>. At this point you have the habit — now build depth. Do 2 problems per
-                            day but allow 1 hard problem per week. The goal: understand BFS/DFS so deeply you can code
-                            them from scratch in 3 minutes. Study graphs via BFS first — it's more intuitive. Implement
-                            Dijkstra once from scratch. Mock yourself: cover the code, re-code from memory.</div>
-                        <div class="step-tags">
-                            <span class="tag red">60 more problems</span>
-                            <span class="tag">Binary Search</span>
-                            <span class="tag">Trees + DFS/BFS</span>
-                            <span class="tag">Graph patterns</span>
-                            <span class="tag">1 hard/week</span>
-                            <span class="tag">Re-code from memory</span>
+                    <div class="topic-card">
+                        <span class="topic-card-icon">🗺️</span>
+                        <div class="topic-card-name">Graphs</div>
+                        <div class="topic-card-hook">"This looks scary" — it's just trees with cycles</div>
+                        <div class="topic-card-desc">Graphs are the senior-level topic. BFS for shortest path, DFS for
+                            connected components, Union-Find for grouping. Most graph problems are one of these 3.</div>
+                        <div class="topic-card-problems">
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Number of Islands · Clone Graph
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Course Schedule · Pacific Atlantic
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Dijkstra's shortest path
+                            </div>
                         </div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">DSA Yatra
-                                — Month 2 Filter</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=EgI5nU9etnU" target="_blank">Graph
-                                Algorithms – WilliamFiset</a>
+                            <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice
+                                on
+                                DSA Yatra</a>
                         </div>
                     </div>
-                </div>
 
-                <!-- MONTH 3 -->
-                <div class="step">
-                    <div class="step-left">
-                        <div class="step-dot">M3</div>
-                    </div>
-                    <div class="step-content">
-                        <div class="time-badge"><span></span> Days 61–90 · DP + Interview Mode</div>
-                        <div class="step-phase">Month 03 · DP + Mock Interviews + Apply</div>
-                        <div class="step-heading">Stop prepping. Start applying. These things must happen at the same
-                            time.</div>
-                        <div class="step-desc">Tackle DP and Heaps this month. Use DSA Yatra's <strong>timed mock
-                                mode</strong> — simulate real interview pressure (30 min per problem, no hints). Do 1
-                            full mock per week: 2 problems, timed, spoken aloud as if explaining to an interviewer.
-                            Simultaneously: apply to 5 companies per week. The feedback loop of real interviews beats
-                            any amount of isolated practice. You're not "almost ready" — you're ready enough. Ship it.
+                    <div class="topic-card">
+                        <span class="topic-card-icon">⚡</span>
+                        <div class="topic-card-name">Dynamic Programming</div>
+                        <div class="topic-card-hook">"This is impossible" — you're just not seeing the subproblem</div>
+                        <div class="topic-card-desc">DP is pattern recognition. Fibonacci → 1D DP. Knapsack → 2D DP.
+                            Every
+                            DP problem has a "try all choices, cache the result" skeleton. Start simple, go deeper.
                         </div>
-                        <div class="step-tags">
-                            <span class="tag red">Apply NOW</span>
-                            <span class="tag">DP: 1D → 2D</span>
-                            <span class="tag">Heaps</span>
-                            <span class="tag">Timed mock mode</span>
-                            <span class="tag">Think aloud practice</span>
-                            <span class="tag">5 apps/week</span>
+                        <div class="topic-card-problems">
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Climbing Stairs · House Robber
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Coin Change · Longest Common Subsequence
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>0/1 Knapsack · Edit Distance
+                            </div>
                         </div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">DSA Yatra
-                                — Mock Mode</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=oBt53YbR9Kk" target="_blank">DP for
-                                Beginners – freeCodeCamp</a>
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=nOIjCDFQbP0" target="_blank">DP
-                                Patterns – Neetcode</a>
+                            <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice
+                                on
+                                DSA Yatra</a>
+                        </div>
+                    </div>
+
+                    <div class="topic-card">
+                        <span class="topic-card-icon">🔍</span>
+                        <div class="topic-card-name">Binary Search</div>
+                        <div class="topic-card-hook">"I know how binary search works, the code is just weird"</div>
+                        <div class="topic-card-desc">Stop memorizing lo/hi/mid. Learn the template: binary search on the
+                            ANSWER space. This applies far beyond sorted arrays — it shows up in capacity, scheduling,
+                            and
+                            matrix problems.</div>
+                        <div class="topic-card-problems">
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Binary Search · Search in Rotated Array
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Find Minimum in Rotated Array
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Median of Two Sorted Arrays
+                            </div>
+                        </div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice
+                                on
+                                DSA Yatra</a>
+                        </div>
+                    </div>
+
+                    <div class="topic-card">
+                        <span class="topic-card-icon">🏔️</span>
+                        <div class="topic-card-name">Heaps / Priority Queue</div>
+                        <div class="topic-card-hook">"When do I even use a heap??"</div>
+                        <div class="topic-card-desc">Anytime you need "the k-th largest/smallest" or "stream processing"
+                            —
+                            use a heap. Min-heap and max-heap are interchangeable with a sign flip. Underrated,
+                            high-yield
+                            topic.</div>
+                        <div class="topic-card-problems">
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Kth Largest Element · Top K Frequent
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>K Closest Points to Origin
+                            </div>
+                            <div class="problem-item">
+                                <div class="prob-dot"></div>Find Median from Data Stream
+                            </div>
+                        </div>
+                        <div class="yt-links">
+                            <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">Practice
+                                on
+                                DSA Yatra</a>
+                        </div>
+                    </div>
+
+                </div>
+
+                <div class="tip-block">
+                    <div class="tip-icon">📊</div>
+                    <div class="tip-text"><strong>Interview frequency breakdown:</strong> Arrays & Hashing (25%) ·
+                        Trees/Graphs (30%) · DP (20%) · Binary Search (10%) · Stack/Queue (8%) · Linked Lists (7%).
+                        Spend
+                        more time where interviews spend more time. DSA Yatra filters problems by topic and company
+                        frequency.</div>
+                </div>
+
+            </div>
+
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">03 / 06</span>
+            </div>
+        </div>
+
+        <!-- ══════════════════ PAGE 4 — PREP STRATEGY ══════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo-img" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">DSA Escape Plan · The Boring Education</span>
+                <span class="page-num">04</span>
+            </div>
+
+            <div class="page-body">
+                <div class="section-label">The 90-Day Strategy</div>
+                <h2 class="section-title">How to Use DSA Yatra to Actually Get Hired</h2>
+
+                <div class="roadmap">
+
+                    <!-- MONTH 1 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">M1</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Days 1–30 · Pattern Lock-In</div>
+                            <div class="step-phase">Month 01 · Build the Foundation</div>
+                            <div class="step-heading">60 problems. Every day counts. No skipping.</div>
+                            <div class="step-desc">Open DSA Yatra. Set topic to <strong>Arrays → Strings →
+                                    Stack</strong> in
+                                sequence. Do 2 problems per day — one easy, one medium. Time every attempt. After each
+                                problem, write the pattern. On weekends: revisit problems you failed earlier that week.
+                                Do
+                                not jump to trees yet. Build the habit muscle before the topic breadth. By day 30,
+                                you'll
+                                have 60 solved problems and 10–12 patterns identified.</div>
+                            <div class="step-tags">
+                                <span class="tag red">60 problems</span>
+                                <span class="tag">Arrays → Strings → Stack</span>
+                                <span class="tag">Easy + Medium mix</span>
+                                <span class="tag">Weekend review</span>
+                                <span class="tag">Pattern journaling</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">DSA
+                                    Yatra
+                                    — Month 1 Filter</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- MONTH 2 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">M2</div>
+                            <div class="step-line"></div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Days 31–60 · Tree & Graph Unlock</div>
+                            <div class="step-phase">Month 02 · Recursion + Non-Linear DSA</div>
+                            <div class="step-heading">Trees, Graphs, Binary Search — your interview heavy-hitters</div>
+                            <div class="step-desc">Shift DSA Yatra filter to <strong>Binary Search → Linked Lists →
+                                    Trees →
+                                    Graphs</strong>. At this point you have the habit — now build depth. Do 2 problems
+                                per
+                                day but allow 1 hard problem per week. The goal: understand BFS/DFS so deeply you can
+                                code
+                                them from scratch in 3 minutes. Study graphs via BFS first — it's more intuitive.
+                                Implement
+                                Dijkstra once from scratch. Mock yourself: cover the code, re-code from memory.</div>
+                            <div class="step-tags">
+                                <span class="tag red">60 more problems</span>
+                                <span class="tag">Binary Search</span>
+                                <span class="tag">Trees + DFS/BFS</span>
+                                <span class="tag">Graph patterns</span>
+                                <span class="tag">1 hard/week</span>
+                                <span class="tag">Re-code from memory</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">DSA
+                                    Yatra
+                                    — Month 2 Filter</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=Graph%20Algorithms%20%E2%80%93%20WilliamFiset"
+                                    target="_blank">Graph
+                                    Algorithms – WilliamFiset</a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- MONTH 3 -->
+                    <div class="step">
+                        <div class="step-left">
+                            <div class="step-dot">M3</div>
+                        </div>
+                        <div class="step-content">
+                            <div class="time-badge"><span></span> Days 61–90 · DP + Interview Mode</div>
+                            <div class="step-phase">Month 03 · DP + Mock Interviews + Apply</div>
+                            <div class="step-heading">Stop prepping. Start applying. These things must happen at the
+                                same
+                                time.</div>
+                            <div class="step-desc">Tackle DP and Heaps this month. Use DSA Yatra's <strong>timed mock
+                                    mode</strong> — simulate real interview pressure (30 min per problem, no hints). Do
+                                1
+                                full mock per week: 2 problems, timed, spoken aloud as if explaining to an interviewer.
+                                Simultaneously: apply to 5 companies per week. The feedback loop of real interviews
+                                beats
+                                any amount of isolated practice. You're not "almost ready" — you're ready enough. Ship
+                                it.
+                            </div>
+                            <div class="step-tags">
+                                <span class="tag red">Apply NOW</span>
+                                <span class="tag">DP: 1D → 2D</span>
+                                <span class="tag">Heaps</span>
+                                <span class="tag">Timed mock mode</span>
+                                <span class="tag">Think aloud practice</span>
+                                <span class="tag">5 apps/week</span>
+                            </div>
+                            <div class="yt-links">
+                                <a class="yt-link" href="https://dsayatra.theboringeducation.com" target="_blank">DSA
+                                    Yatra
+                                    — Mock Mode</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=DP%20for%20Beginners%20%E2%80%93%20freeCodeCamp"
+                                    target="_blank">DP for
+                                    Beginners – freeCodeCamp</a>
+                                <a class="yt-link"
+                                    href="https://www.youtube.com/results?search_query=DP%20Patterns%20%E2%80%93%20Neetcode"
+                                    target="_blank">DP
+                                    Patterns – Neetcode</a>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+
+                <hr class="divider">
+
+                <div class="section-label">Time Investment Guide</div>
+                <div class="stack-table-wrap">
+                    <table class="stack-table">
+                        <thead>
+                            <tr>
+                                <th>Level</th>
+                                <th>Daily Time</th>
+                                <th>Problems/Day</th>
+                                <th>When to Use</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Survival mode</td>
+                                <td>30 min</td>
+                                <td>1 problem</td>
+                                <td>During college exams, heavy work periods</td>
+                            </tr>
+                            <tr>
+                                <td>Standard grind</td>
+                                <td>1–1.5 hrs</td>
+                                <td>2 problems</td>
+                                <td>Every normal day. Non-negotiable baseline</td>
+                            </tr>
+                            <tr>
+                                <td>Interview sprint</td>
+                                <td>2–3 hrs</td>
+                                <td>3–4 problems + 1 mock</td>
+                                <td>30 days before interview season</td>
+                            </tr>
+                            <tr>
+                                <td>Full-send mode</td>
+                                <td>4–5 hrs</td>
+                                <td>5+ problems + revision</td>
+                                <td>If you have an interview in &lt; 2 weeks</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="dark-tip">
+                    <div class="tip-icon">🎯</div>
+                    <div class="tip-text"><strong>The 2-problem rule is sacred.</strong> Not 5 on Monday and 0 on
+                        Tuesday.
+                        Not a 6-hour Sunday grind after a week off. Consistency builds pattern recognition. One easy and
+                        one
+                        medium, every single day, beats binging every single time. DSA Yatra streaks hold you
+                        accountable.
+                    </div>
+                </div>
+            </div>
+
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">04 / 06</span>
+            </div>
+        </div>
+
+        <!-- ══════════════════ PAGE 5 — PATTERNS + ANTI-PATTERNS ══════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo-img" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">DSA Escape Plan · The Boring Education</span>
+                <span class="page-num">05</span>
+            </div>
+
+            <div class="page-body">
+                <div class="section-label">Pattern Recognition Cheat Sheet</div>
+                <h2 class="section-title">See a Problem Type → Know the Pattern Instantly</h2>
+
+                <div class="stack-table-wrap">
+                    <table class="stack-table">
+                        <thead>
+                            <tr>
+                                <th>Problem Keyword</th>
+                                <th>Pattern to Reach For</th>
+                                <th>Why</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Subarray / Substring</td>
+                                <td>Sliding Window or Prefix Sum</td>
+                                <td>Contiguous range → window or cumulative</td>
+                            </tr>
+                            <tr>
+                                <td>Two elements sum to X</td>
+                                <td>Two Pointers or Hash Map</td>
+                                <td>Sort + converge OR store complements</td>
+                            </tr>
+                            <tr>
+                                <td>Find duplicates / frequency</td>
+                                <td>Hash Map / Set</td>
+                                <td>O(1) lookup for membership check</td>
+                            </tr>
+                            <tr>
+                                <td>Kth largest / smallest</td>
+                                <td>Heap (Priority Queue)</td>
+                                <td>Maintain k elements efficiently</td>
+                            </tr>
+                            <tr>
+                                <td>Valid parentheses / matching</td>
+                                <td>Stack</td>
+                                <td>LIFO for matching open/close pairs</td>
+                            </tr>
+                            <tr>
+                                <td>Next greater / smaller element</td>
+                                <td>Monotonic Stack</td>
+                                <td>Maintains ascending/descending order</td>
+                            </tr>
+                            <tr>
+                                <td>Shortest path (unweighted)</td>
+                                <td>BFS</td>
+                                <td>Level-by-level expansion = shortest</td>
+                            </tr>
+                            <tr>
+                                <td>Shortest path (weighted)</td>
+                                <td>Dijkstra (Heap + BFS)</td>
+                                <td>Greedy expansion by minimum cost</td>
+                            </tr>
+                            <tr>
+                                <td>Connected components</td>
+                                <td>DFS / Union-Find</td>
+                                <td>Flood fill or group by root</td>
+                            </tr>
+                            <tr>
+                                <td>Sorted array → find target</td>
+                                <td>Binary Search</td>
+                                <td>Halve search space each step</td>
+                            </tr>
+                            <tr>
+                                <td>Max/min of something feasible</td>
+                                <td>Binary Search on Answer</td>
+                                <td>Monotone feasibility → binary on range</td>
+                            </tr>
+                            <tr>
+                                <td>Count ways / optimal value</td>
+                                <td>Dynamic Programming</td>
+                                <td>Overlapping subproblems + optimal substructure</td>
+                            </tr>
+                            <tr>
+                                <td>Detect cycle in linked list</td>
+                                <td>Fast & Slow Pointers</td>
+                                <td>Floyd's cycle detection algorithm</td>
+                            </tr>
+                            <tr>
+                                <td>All combinations / subsets</td>
+                                <td>Backtracking (DFS)</td>
+                                <td>Explore all branches, prune invalid ones</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <hr class="divider">
+
+                <div class="section-label">Tutorial Hell Anti-Patterns</div>
+                <div
+                    style="font-size:15px; font-weight:800; color:var(--dark); margin-bottom:12px; letter-spacing:-0.01em;">
+                    Stop doing these. Seriously.</div>
+
+                <div class="two-col">
+                    <div>
+                        <div class="reality-box" style="margin-bottom:10px;">
+                            <div class="reality-box-title">❌ Anti-Pattern #1</div>
+                            <div class="reality-box-text"><strong>"I'll watch one more video before I start"</strong> —
+                                You've been saying this for months. The video is not the blocker. Fear of being wrong is
+                                the
+                                blocker. Start wrong. Fix it. That's how it works.</div>
+                        </div>
+                        <div class="reality-box" style="margin-bottom:10px;">
+                            <div class="reality-box-title">❌ Anti-Pattern #2</div>
+                            <div class="reality-box-text"><strong>Reading the solution after 5 minutes</strong> — That's
+                                not
+                                solving, that's memorizing. You need to be stuck for at least 25 minutes before reading
+                                anything. Productive struggle IS the learning.</div>
+                        </div>
+                        <div class="reality-box">
+                            <div class="reality-box-title">❌ Anti-Pattern #3</div>
+                            <div class="reality-box-text"><strong>Solving 20 easy problems in a row</strong> — Easy
+                                problems
+                                don't prepare you for interviews. They give you false confidence. Mix in mediums from
+                                day 1.
+                                Hard problems after day 30.</div>
+                        </div>
+                    </div>
+                    <div>
+                        <div class="tip-block" style="margin-bottom:10px;">
+                            <div class="tip-icon">✅</div>
+                            <div class="tip-text"><strong>Pattern #1 — Think first, code later:</strong> Spend 5–10
+                                minutes
+                                on paper before typing. Draw examples. Identify the pattern. Then code. This mimics real
+                                interviews and builds muscle memory.</div>
+                        </div>
+                        <div class="tip-block" style="margin-bottom:10px;">
+                            <div class="tip-icon">✅</div>
+                            <div class="tip-text"><strong>Pattern #2 — Spaced repetition:</strong> Re-attempt problems
+                                you
+                                failed, 3 days later — without looking at your solution. If you can't solve it again,
+                                the
+                                learning didn't stick. DSA Yatra tracks this for you.</div>
+                        </div>
+                        <div class="tip-block">
+                            <div class="tip-icon">✅</div>
+                            <div class="tip-text"><strong>Pattern #3 — Explain it aloud:</strong> After solving, explain
+                                the
+                                solution in 60 seconds as if teaching someone. If you can't explain it simply, you don't
+                                understand it yet. This is the #1 interview skill.</div>
                         </div>
                     </div>
                 </div>
 
             </div>
 
-            <hr class="divider">
-
-            <div class="section-label">Time Investment Guide</div>
-            <div class="stack-table-wrap">
-                <table class="stack-table">
-                    <thead>
-                        <tr>
-                            <th>Level</th>
-                            <th>Daily Time</th>
-                            <th>Problems/Day</th>
-                            <th>When to Use</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>Survival mode</td>
-                            <td>30 min</td>
-                            <td>1 problem</td>
-                            <td>During college exams, heavy work periods</td>
-                        </tr>
-                        <tr>
-                            <td>Standard grind</td>
-                            <td>1–1.5 hrs</td>
-                            <td>2 problems</td>
-                            <td>Every normal day. Non-negotiable baseline</td>
-                        </tr>
-                        <tr>
-                            <td>Interview sprint</td>
-                            <td>2–3 hrs</td>
-                            <td>3–4 problems + 1 mock</td>
-                            <td>30 days before interview season</td>
-                        </tr>
-                        <tr>
-                            <td>Full-send mode</td>
-                            <td>4–5 hrs</td>
-                            <td>5+ problems + revision</td>
-                            <td>If you have an interview in &lt; 2 weeks</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-
-            <div class="dark-tip">
-                <div class="tip-icon">🎯</div>
-                <div class="tip-text"><strong>The 2-problem rule is sacred.</strong> Not 5 on Monday and 0 on Tuesday.
-                    Not a 6-hour Sunday grind after a week off. Consistency builds pattern recognition. One easy and one
-                    medium, every single day, beats binging every single time. DSA Yatra streaks hold you accountable.
-                </div>
+            <div class="page-footer">
+                <span class="cover-footer-text">theboringeducation.com</span>
+                <span class="page-num">05 / 06</span>
             </div>
         </div>
 
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">04 / 06</span>
-        </div>
-    </div>
-
-    <!-- ══════════════════ PAGE 5 — PATTERNS + ANTI-PATTERNS ══════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo-img" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">DSA Escape Plan · The Boring Education</span>
-            <span class="page-num">05</span>
-        </div>
-
-        <div class="page-body">
-            <div class="section-label">Pattern Recognition Cheat Sheet</div>
-            <h2 class="section-title">See a Problem Type → Know the Pattern Instantly</h2>
-
-            <div class="stack-table-wrap">
-                <table class="stack-table">
-                    <thead>
-                        <tr>
-                            <th>Problem Keyword</th>
-                            <th>Pattern to Reach For</th>
-                            <th>Why</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>Subarray / Substring</td>
-                            <td>Sliding Window or Prefix Sum</td>
-                            <td>Contiguous range → window or cumulative</td>
-                        </tr>
-                        <tr>
-                            <td>Two elements sum to X</td>
-                            <td>Two Pointers or Hash Map</td>
-                            <td>Sort + converge OR store complements</td>
-                        </tr>
-                        <tr>
-                            <td>Find duplicates / frequency</td>
-                            <td>Hash Map / Set</td>
-                            <td>O(1) lookup for membership check</td>
-                        </tr>
-                        <tr>
-                            <td>Kth largest / smallest</td>
-                            <td>Heap (Priority Queue)</td>
-                            <td>Maintain k elements efficiently</td>
-                        </tr>
-                        <tr>
-                            <td>Valid parentheses / matching</td>
-                            <td>Stack</td>
-                            <td>LIFO for matching open/close pairs</td>
-                        </tr>
-                        <tr>
-                            <td>Next greater / smaller element</td>
-                            <td>Monotonic Stack</td>
-                            <td>Maintains ascending/descending order</td>
-                        </tr>
-                        <tr>
-                            <td>Shortest path (unweighted)</td>
-                            <td>BFS</td>
-                            <td>Level-by-level expansion = shortest</td>
-                        </tr>
-                        <tr>
-                            <td>Shortest path (weighted)</td>
-                            <td>Dijkstra (Heap + BFS)</td>
-                            <td>Greedy expansion by minimum cost</td>
-                        </tr>
-                        <tr>
-                            <td>Connected components</td>
-                            <td>DFS / Union-Find</td>
-                            <td>Flood fill or group by root</td>
-                        </tr>
-                        <tr>
-                            <td>Sorted array → find target</td>
-                            <td>Binary Search</td>
-                            <td>Halve search space each step</td>
-                        </tr>
-                        <tr>
-                            <td>Max/min of something feasible</td>
-                            <td>Binary Search on Answer</td>
-                            <td>Monotone feasibility → binary on range</td>
-                        </tr>
-                        <tr>
-                            <td>Count ways / optimal value</td>
-                            <td>Dynamic Programming</td>
-                            <td>Overlapping subproblems + optimal substructure</td>
-                        </tr>
-                        <tr>
-                            <td>Detect cycle in linked list</td>
-                            <td>Fast & Slow Pointers</td>
-                            <td>Floyd's cycle detection algorithm</td>
-                        </tr>
-                        <tr>
-                            <td>All combinations / subsets</td>
-                            <td>Backtracking (DFS)</td>
-                            <td>Explore all branches, prune invalid ones</td>
-                        </tr>
-                    </tbody>
-                </table>
+        <!-- ══════════════════ PAGE 6 — DAILY ROUTINE + CTA ══════════════════ -->
+        <div class="page inner-page">
+            <div class="page-header">
+                <img class="page-header-logo-img" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
+                <span class="page-header-title">DSA Escape Plan · The Boring Education</span>
+                <span class="page-num">06</span>
             </div>
 
-            <hr class="divider">
+            <div class="page-body">
+                <div class="section-label">Daily Routine</div>
+                <h2 class="section-title">The Boring DSA Routine That Actually Works</h2>
 
-            <div class="section-label">Tutorial Hell Anti-Patterns</div>
-            <div
-                style="font-size:15px; font-weight:800; color:var(--dark); margin-bottom:12px; letter-spacing:-0.01em;">
-                Stop doing these. Seriously.</div>
-
-            <div class="two-col">
-                <div>
-                    <div class="reality-box" style="margin-bottom:10px;">
-                        <div class="reality-box-title">❌ Anti-Pattern #1</div>
-                        <div class="reality-box-text"><strong>"I'll watch one more video before I start"</strong> —
-                            You've been saying this for months. The video is not the blocker. Fear of being wrong is the
-                            blocker. Start wrong. Fix it. That's how it works.</div>
+                <div class="checklist" style="margin-bottom:16px;">
+                    <div class="check-item">
+                        <div class="check-box"></div> Open DSA Yatra — not YouTube. First 5 minutes: review yesterday's
+                        problem pattern notes
                     </div>
-                    <div class="reality-box" style="margin-bottom:10px;">
-                        <div class="reality-box-title">❌ Anti-Pattern #2</div>
-                        <div class="reality-box-text"><strong>Reading the solution after 5 minutes</strong> — That's not
-                            solving, that's memorizing. You need to be stuck for at least 25 minutes before reading
-                            anything. Productive struggle IS the learning.</div>
+                    <div class="check-item">
+                        <div class="check-box"></div> Problem 1 (Easy/Medium): 25-min timer. Close tabs. No hints for
+                        first
+                        15 min
                     </div>
-                    <div class="reality-box">
-                        <div class="reality-box-title">❌ Anti-Pattern #3</div>
-                        <div class="reality-box-text"><strong>Solving 20 easy problems in a row</strong> — Easy problems
-                            don't prepare you for interviews. They give you false confidence. Mix in mediums from day 1.
-                            Hard problems after day 30.</div>
+                    <div class="check-item">
+                        <div class="check-box"></div> After solving: write pattern name, key insight, and time taken in
+                        your
+                        notebook
+                    </div>
+                    <div class="check-item">
+                        <div class="check-box"></div> Problem 2 (Medium): same rules. If stuck after 25 min — hint only,
+                        no
+                        full solution
+                    </div>
+                    <div class="check-item">
+                        <div class="check-box"></div> Read the editorial after both problems — even if you solved them.
+                        There's always a cleaner approach
+                    </div>
+                    <div class="check-item">
+                        <div class="check-box"></div> Post 1 thing you learned on LinkedIn or Twitter — forces you to
+                        articulate it clearly
+                    </div>
+                    <div class="check-item">
+                        <div class="check-box"></div> Mark your DSA Yatra streak. Protect it like it's your rating.
                     </div>
                 </div>
-                <div>
-                    <div class="tip-block" style="margin-bottom:10px;">
-                        <div class="tip-icon">✅</div>
-                        <div class="tip-text"><strong>Pattern #1 — Think first, code later:</strong> Spend 5–10 minutes
-                            on paper before typing. Draw examples. Identify the pattern. Then code. This mimics real
-                            interviews and builds muscle memory.</div>
+
+                <hr class="divider">
+
+                <div class="section-label">DSA Yatra Features — Use All of Them</div>
+                <div class="resource-grid" style="margin-bottom:14px;">
+                    <div class="resource-card">
+                        <div class="resource-card-name">📅 Streak Tracking</div>
+                        <div class="resource-card-desc">Daily streak counter that resets on a miss. The psychological
+                            weight
+                            of protecting a 30-day streak is more powerful than any motivation video you'll watch.</div>
                     </div>
-                    <div class="tip-block" style="margin-bottom:10px;">
-                        <div class="tip-icon">✅</div>
-                        <div class="tip-text"><strong>Pattern #2 — Spaced repetition:</strong> Re-attempt problems you
-                            failed, 3 days later — without looking at your solution. If you can't solve it again, the
-                            learning didn't stick. DSA Yatra tracks this for you.</div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">🔖 Topic Filters</div>
+                        <div class="resource-card-desc">Filter problems by DSA topic, difficulty, and company tag.
+                            Follow
+                            the escape plan — don't random-pick. Structured progression beats spray-and-pray.</div>
                     </div>
-                    <div class="tip-block">
-                        <div class="tip-icon">✅</div>
-                        <div class="tip-text"><strong>Pattern #3 — Explain it aloud:</strong> After solving, explain the
-                            solution in 60 seconds as if teaching someone. If you can't explain it simply, you don't
-                            understand it yet. This is the #1 interview skill.</div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">⏱️ Timed Mock Mode</div>
+                        <div class="resource-card-desc">Simulate real interview conditions: 30 minutes, no hints, 2
+                            problems. Do this weekly from month 2. Pressure reveals your real weak spots, not relaxed
+                            practice.</div>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-name">📈 Progress Dashboard</div>
+                        <div class="resource-card-desc">See exactly how many problems you've solved per topic. Instantly
+                            shows where you're neglecting. Use it like a heatmap — fill in the gaps.</div>
                     </div>
                 </div>
-            </div>
 
-        </div>
+                <hr class="divider">
 
-        <div class="page-footer">
-            <span class="cover-footer-text">theboringeducation.com</span>
-            <span class="page-num">05 / 06</span>
-        </div>
-    </div>
+                <div class="cta-block">
+                    <div class="cta-title">The tutorial hell ends today. Not tomorrow. 🔥</div>
+                    <div class="cta-sub">Open DSA Yatra. Pick your first problem. Set a 25-minute timer.<br>Fail. Learn.
+                        Repeat. That's the entire plan.</div>
+                    <a href="https://dsayatra.theboringeducation.com" class="cta-link" target="_blank">→ Start on DSA
+                        Yatra</a>
+                </div>
 
-    <!-- ══════════════════ PAGE 6 — DAILY ROUTINE + CTA ══════════════════ -->
-    <div class="page inner-page">
-        <div class="page-header">
-            <img class="page-header-logo-img" src="https://ik.imagekit.io/tbe/webapp/logo.svg" alt="TBE">
-            <span class="page-header-title">DSA Escape Plan · The Boring Education</span>
-            <span class="page-num">06</span>
-        </div>
+                <hr class="divider">
 
-        <div class="page-body">
-            <div class="section-label">Daily Routine</div>
-            <h2 class="section-title">The Boring DSA Routine That Actually Works</h2>
-
-            <div class="checklist" style="margin-bottom:16px;">
-                <div class="check-item">
-                    <div class="check-box"></div> Open DSA Yatra — not YouTube. First 5 minutes: review yesterday's
-                    problem pattern notes
-                </div>
-                <div class="check-item">
-                    <div class="check-box"></div> Problem 1 (Easy/Medium): 25-min timer. Close tabs. No hints for first
-                    15 min
-                </div>
-                <div class="check-item">
-                    <div class="check-box"></div> After solving: write pattern name, key insight, and time taken in your
-                    notebook
-                </div>
-                <div class="check-item">
-                    <div class="check-box"></div> Problem 2 (Medium): same rules. If stuck after 25 min — hint only, no
-                    full solution
-                </div>
-                <div class="check-item">
-                    <div class="check-box"></div> Read the editorial after both problems — even if you solved them.
-                    There's always a cleaner approach
-                </div>
-                <div class="check-item">
-                    <div class="check-box"></div> Post 1 thing you learned on LinkedIn or Twitter — forces you to
-                    articulate it clearly
-                </div>
-                <div class="check-item">
-                    <div class="check-box"></div> Mark your DSA Yatra streak. Protect it like it's your rating.
+                <div class="section-label">Find Us Everywhere</div>
+                <div class="socials-grid">
+                    <a class="social-card" href="https://instagram.com/theboringeducation" target="_blank">
+                        <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/2111/2111463.png"
+                            alt="Instagram">
+                        <span class="social-name">Instagram</span>
+                        <div class="social-handle">@theboringeducation</div>
+                    </a>
+                    <a class="social-card" href="https://linkedin.com/company/the-boring-education" target="_blank">
+                        <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png"
+                            alt="LinkedIn">
+                        <span class="social-name">LinkedIn</span>
+                        <div class="social-handle">The Boring Education</div>
+                    </a>
+                    <a class="social-card" href="https://github.com/The-Boring-Education" target="_blank">
+                        <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/733/733609.png"
+                            alt="GitHub">
+                        <span class="social-name">GitHub</span>
+                        <div class="social-handle">The-Boring-Education</div>
+                    </a>
                 </div>
             </div>
 
-            <hr class="divider">
-
-            <div class="section-label">DSA Yatra Features — Use All of Them</div>
-            <div class="resource-grid" style="margin-bottom:14px;">
-                <div class="resource-card">
-                    <div class="resource-card-name">📅 Streak Tracking</div>
-                    <div class="resource-card-desc">Daily streak counter that resets on a miss. The psychological weight
-                        of protecting a 30-day streak is more powerful than any motivation video you'll watch.</div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">🔖 Topic Filters</div>
-                    <div class="resource-card-desc">Filter problems by DSA topic, difficulty, and company tag. Follow
-                        the escape plan — don't random-pick. Structured progression beats spray-and-pray.</div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">⏱️ Timed Mock Mode</div>
-                    <div class="resource-card-desc">Simulate real interview conditions: 30 minutes, no hints, 2
-                        problems. Do this weekly from month 2. Pressure reveals your real weak spots, not relaxed
-                        practice.</div>
-                </div>
-                <div class="resource-card">
-                    <div class="resource-card-name">📈 Progress Dashboard</div>
-                    <div class="resource-card-desc">See exactly how many problems you've solved per topic. Instantly
-                        shows where you're neglecting. Use it like a heatmap — fill in the gaps.</div>
-                </div>
-            </div>
-
-            <hr class="divider">
-
-            <div class="cta-block">
-                <div class="cta-title">The tutorial hell ends today. Not tomorrow. 🔥</div>
-                <div class="cta-sub">Open DSA Yatra. Pick your first problem. Set a 25-minute timer.<br>Fail. Learn.
-                    Repeat. That's the entire plan.</div>
-                <a href="https://dsayatra.theboringeducation.com" class="cta-link" target="_blank">→ Start on DSA
-                    Yatra</a>
-            </div>
-
-            <hr class="divider">
-
-            <div class="section-label">Find Us Everywhere</div>
-            <div class="socials-grid">
-                <a class="social-card" href="https://instagram.com/theboringeducation" target="_blank">
-                    <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/2111/2111463.png"
-                        alt="Instagram">
-                    <span class="social-name">Instagram</span>
-                    <div class="social-handle">@theboringeducation</div>
-                </a>
-                <a class="social-card" href="https://linkedin.com/company/the-boring-education" target="_blank">
-                    <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/174/174857.png" alt="LinkedIn">
-                    <span class="social-name">LinkedIn</span>
-                    <div class="social-handle">The Boring Education</div>
-                </a>
-                <a class="social-card" href="https://github.com/The-Boring-Education" target="_blank">
-                    <img class="social-icon" src="https://cdn-icons-png.flaticon.com/512/733/733609.png" alt="GitHub">
-                    <span class="social-name">GitHub</span>
-                    <div class="social-handle">The-Boring-Education</div>
-                </a>
+            <div class="page-footer">
+                <span class="cover-footer-text">© 2026 The Boring Education · Free Tech Education for Everyone</span>
+                <span class="page-num">06 / 06</span>
             </div>
         </div>
-
-        <div class="page-footer">
-            <span class="cover-footer-text">© 2026 The Boring Education · Free Tech Education for Everyone</span>
-            <span class="page-num">06 / 06</span>
-        </div>
-    </div>
     </div>
 </body>
 

--- a/apps/resources/content/frontend-engineer-roadmap/index.html
+++ b/apps/resources/content/frontend-engineer-roadmap/index.html
@@ -1005,36 +1005,36 @@
 
     <div class="section-label">YouTube Resources · Phase 1–3</div>
     <div class="yt-grid">
-      <a class="yt-card" href="https://youtube.com/watch?v=zF6VSky4SIc" target="_blank">
+      <a class="yt-card" href="https://www.youtube.com/results?search_query=How%20the%20Internet%20Works%20in%205%20Minutes%20%E2%80%93%20Aaron" target="_blank">
         <div class="yt-thumb"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-title">How the Internet Works in 5 Minutes</div>
           <div class="yt-channel">Aaron</div>
-          <div class="yt-url">youtube.com/watch?v=zF6VSky4SIc</div>
+          <div class="yt-url">youtube.com</div>
         </div>
       </a>
-      <a class="yt-card" href="https://youtube.com/watch?v=ok-plXXHlWw" target="_blank">
+      <a class="yt-card" href="https://www.youtube.com/results?search_query=HTML%20Full%20Course%20for%20Beginners%20%E2%80%93%20Dave%20Gray" target="_blank">
         <div class="yt-thumb"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-title">HTML Full Course for Beginners</div>
           <div class="yt-channel">Dave Gray</div>
-          <div class="yt-url">youtube.com/watch?v=ok-plXXHlWw</div>
+          <div class="yt-url">youtube.com</div>
         </div>
       </a>
-      <a class="yt-card" href="https://youtube.com/watch?v=1Rs2ND1ryYc" target="_blank">
+      <a class="yt-card" href="https://www.youtube.com/results?search_query=CSS%20Full%20Course%20(including%20Flexbox%20%26%20Grid)%20%E2%80%93%20freeCodeCamp" target="_blank">
         <div class="yt-thumb"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-title">CSS Full Course (including Flexbox & Grid)</div>
           <div class="yt-channel">freeCodeCamp</div>
-          <div class="yt-url">youtube.com/watch?v=1Rs2ND1ryYc</div>
+          <div class="yt-url">youtube.com</div>
         </div>
       </a>
-      <a class="yt-card" href="https://youtube.com/watch?v=phWxA89Dy94" target="_blank">
+      <a class="yt-card" href="https://www.youtube.com/results?search_query=Tailwind%20CSS%20Full%20Course%20%E2%80%93%20Traversy%20Media" target="_blank">
         <div class="yt-thumb"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-title">Tailwind CSS Full Course</div>
           <div class="yt-channel">Traversy Media</div>
-          <div class="yt-url">youtube.com/watch?v=phWxA89Dy94</div>
+          <div class="yt-url">youtube.com</div>
         </div>
       </a>
     </div>
@@ -1120,32 +1120,32 @@
 
     <div class="section-label">YouTube Resources · JavaScript</div>
     <div class="yt-list">
-      <a class="yt-list-item" href="https://youtube.com/watch?v=PkZNo7MFNFg" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=JavaScript%20Full%20Course%20for%20Beginners%20(freeCodeCamp)%20%E2%80%93%20freeCodeCamp" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">JavaScript Full Course for Beginners (freeCodeCamp)</div>
-          <div class="yt-list-ch">freeCodeCamp · youtube.com/watch?v=PkZNo7MFNFg</div>
+          <div class="yt-list-ch">freeCodeCamp · youtube.com</div>
         </div>
       </a>
-      <a class="yt-list-item" href="https://youtube.com/watch?v=W6NZfCO5SIk" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=JavaScript%20Tutorial%20for%20Beginners%20%E2%80%94%20Full%20Course%20in%208%20Hours%20%E2%80%93%20Programming%20with%20Mosh" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">JavaScript Tutorial for Beginners — Full Course in 8 Hours</div>
-          <div class="yt-list-ch">Programming with Mosh · youtube.com/watch?v=W6NZfCO5SIk</div>
+          <div class="yt-list-ch">Programming with Mosh · youtube.com</div>
         </div>
       </a>
-      <a class="yt-list-item" href="https://youtube.com/watch?v=Mus_vwhTCq0" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=Async%20JavaScript%20(Callbacks%2C%20Promises%2C%20Async%2FAwait)%20%E2%80%93%20Traversy%20Media" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">Async JavaScript (Callbacks, Promises, Async/Await)</div>
-          <div class="yt-list-ch">Traversy Media · youtube.com/watch?v=PoRJizFvM7s</div>
+          <div class="yt-list-ch">Traversy Media · youtube.com</div>
         </div>
       </a>
-      <a class="yt-list-item" href="https://youtube.com/watch?v=8aGhZQkoFbQ" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=What%20the%20Heck%20is%20the%20Event%20Loop%20Anyway%3F%20%E2%80%93%20Philip%20Roberts" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">What the Heck is the Event Loop Anyway?</div>
-          <div class="yt-list-ch">Philip Roberts · JSConf · youtube.com/watch?v=8aGhZQkoFbQ</div>
+          <div class="yt-list-ch">Philip Roberts · youtube.com</div>
         </div>
       </a>
     </div>
@@ -1229,32 +1229,32 @@
 
     <div class="section-label">YouTube Resources · React</div>
     <div class="yt-list">
-      <a class="yt-list-item" href="https://youtube.com/watch?v=bMknfKXIFA8" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=React%20Full%20Course%20for%20Beginners%20(freeCodeCamp)%20%E2%80%93%20freeCodeCamp" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">React Full Course for Beginners (freeCodeCamp)</div>
-          <div class="yt-list-ch">freeCodeCamp · youtube.com/watch?v=bMknfKXIFA8</div>
+          <div class="yt-list-ch">freeCodeCamp · youtube.com</div>
         </div>
       </a>
-      <a class="yt-list-item" href="https://youtube.com/watch?v=j942wKiXFu8" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=React%202024%20%E2%80%94%20Hooks%2C%20Router%2C%20Redux%20Toolkit%20%E2%80%93%20Traversy%20Media" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">React 2024 — Hooks, Router, Redux Toolkit</div>
-          <div class="yt-list-ch">Traversy Media · youtube.com/watch?v=j942wKiXFu8</div>
+          <div class="yt-list-ch">Traversy Media · youtube.com</div>
         </div>
       </a>
-      <a class="yt-list-item" href="https://youtube.com/watch?v=TNhaISOUy6Q" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=TanStack%20Query%20(React%20Query)%20Full%20Tutorial%20%E2%80%93%20Web%20Dev%20Simplified" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">TanStack Query (React Query) Full Tutorial</div>
-          <div class="yt-list-ch">Web Dev Simplified · youtube.com/watch?v=TNhaISOUy6Q</div>
+          <div class="yt-list-ch">Web Dev Simplified · youtube.com</div>
         </div>
       </a>
-      <a class="yt-list-item" href="https://youtube.com/watch?v=ZjAqacIC_3c" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=Zustand%20State%20Management%20%E2%80%94%20Full%20Tutorial%20%E2%80%93%20Dave%20Gray" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">Zustand State Management — Full Tutorial</div>
-          <div class="yt-list-ch">Dave Gray · youtube.com/watch?v=ZjAqacIC_3c</div>
+          <div class="yt-list-ch">Dave Gray · youtube.com</div>
         </div>
       </a>
     </div>
@@ -1334,32 +1334,32 @@
 
     <div class="section-label">YouTube Resources · TypeScript & Next.js</div>
     <div class="yt-list">
-      <a class="yt-list-item" href="https://youtube.com/watch?v=30LWjhZzg50" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=TypeScript%20Full%20Course%20for%20JavaScript%20Developers%20%E2%80%93%20freeCodeCamp" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">TypeScript Full Course for JavaScript Developers</div>
-          <div class="yt-list-ch">freeCodeCamp · youtube.com/watch?v=30LWjhZzg50</div>
+          <div class="yt-list-ch">freeCodeCamp · youtube.com</div>
         </div>
       </a>
-      <a class="yt-list-item" href="https://youtube.com/watch?v=ZjAqacIC_3c" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=TypeScript%20in%20React%20%E2%80%94%20Complete%20Beginner's%20Guide%20%E2%80%93%20Web%20Dev%20Simplified" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">TypeScript in React — Complete Beginner's Guide</div>
-          <div class="yt-list-ch">Web Dev Simplified · youtube.com/watch?v=TPACABQTHvM</div>
+          <div class="yt-list-ch">Web Dev Simplified · youtube.com</div>
         </div>
       </a>
-      <a class="yt-list-item" href="https://youtube.com/watch?v=ZVnjOPwW4ZA" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=Next.js%2014%20Full%20Course%20%E2%80%94%20App%20Router%2C%20Server%20Actions%20%E2%80%93%20Traversy%20Media" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">Next.js 14 Full Course — App Router, Server Actions</div>
-          <div class="yt-list-ch">Traversy Media · youtube.com/watch?v=ZVnjOPwW4ZA</div>
+          <div class="yt-list-ch">Traversy Media · youtube.com</div>
         </div>
       </a>
-      <a class="yt-list-item" href="https://youtube.com/watch?v=wm5gMKuwSYk" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=Next.js%20Full%20Stack%20App%20with%20Auth%2C%20DB%20%26%20Deployment%20%E2%80%93%20Josh%20tried%20coding" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">Next.js Full Stack App with Auth, DB & Deployment</div>
-          <div class="yt-list-ch">Josh tried coding · youtube.com/watch?v=wm5gMKuwSYk</div>
+          <div class="yt-list-ch">Josh tried coding · youtube.com</div>
         </div>
       </a>
     </div>
@@ -1501,25 +1501,25 @@
 
     <div class="section-label">YouTube Resources · Testing & Performance</div>
     <div class="yt-list">
-      <a class="yt-list-item" href="https://youtube.com/watch?v=8Xwq35cPwYg" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=React%20Testing%20Library%20%26%20Vitest%20%E2%80%94%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">React Testing Library & Vitest — Full Course</div>
-          <div class="yt-list-ch">freeCodeCamp · youtube.com/watch?v=8Xwq35cPwYg</div>
+          <div class="yt-list-ch">freeCodeCamp · youtube.com</div>
         </div>
       </a>
-      <a class="yt-list-item" href="https://youtube.com/watch?v=r9HdJ8P6GQI" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=Web%20Performance%20%E2%80%94%20Core%20Web%20Vitals%20Deep%20Dive%20%E2%80%93%20Google%20Chrome%20Developers" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">Web Performance — Core Web Vitals Deep Dive</div>
-          <div class="yt-list-ch">Google Chrome Developers · youtube.com/watch?v=r9HdJ8P6GQI</div>
+          <div class="yt-list-ch">Google Chrome Developers · youtube.com</div>
         </div>
       </a>
-      <a class="yt-list-item" href="https://youtube.com/watch?v=0hqgX6znADk" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=Playwright%20End-to-End%20Testing%20Tutorial%20%E2%80%93%20Traversy%20Media" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">Playwright End-to-End Testing Tutorial</div>
-          <div class="yt-list-ch">Traversy Media · youtube.com/watch?v=0hqgX6znADk</div>
+          <div class="yt-list-ch">Traversy Media · youtube.com</div>
         </div>
       </a>
     </div>
@@ -1602,25 +1602,25 @@
 
     <div class="section-label">YouTube Resources · DSA & Interviews</div>
     <div class="yt-list" style="margin-bottom:12px;">
-      <a class="yt-list-item" href="https://youtube.com/watch?v=8hly31xKli0" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=Data%20Structures%20%26%20Algorithms%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">Data Structures & Algorithms Full Course</div>
-          <div class="yt-list-ch">freeCodeCamp · youtube.com/watch?v=8hly31xKli0</div>
+          <div class="yt-list-ch">freeCodeCamp · youtube.com</div>
         </div>
       </a>
-      <a class="yt-list-item" href="https://youtube.com/watch?v=Rub-JsjMhWY" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=Frontend%20Interview%20Prep%20%E2%80%94%20HTML%2C%20CSS%2C%20JS%20Questions%20%E2%80%93%20Akshay%20Saini" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">Frontend Interview Prep — HTML, CSS, JS Questions</div>
-          <div class="yt-list-ch">Akshay Saini · youtube.com/watch?v=Rub-JsjMhWY</div>
+          <div class="yt-list-ch">Akshay Saini · youtube.com</div>
         </div>
       </a>
-      <a class="yt-list-item" href="https://youtube.com/watch?v=5OdVzdlI1JA" target="_blank">
+      <a class="yt-list-item" href="https://www.youtube.com/results?search_query=Frontend%20System%20Design%20Interview%20%E2%80%94%20Typeahead%20Search%20%E2%80%93%20Chirag%20Goel" target="_blank">
         <div class="yt-dot"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg></div>
         <div>
           <div class="yt-list-title">Frontend System Design Interview — Typeahead Search</div>
-          <div class="yt-list-ch">Chirag Goel · youtube.com/watch?v=5OdVzdlI1JA</div>
+          <div class="yt-list-ch">Chirag Goel · youtube.com</div>
         </div>
       </a>
     </div>

--- a/apps/resources/content/genai-engineer-roadmap/index.html
+++ b/apps/resources/content/genai-engineer-roadmap/index.html
@@ -1094,10 +1094,10 @@
                                 <span class="tag">Jupyter Notebooks</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=rfscVS0vtbw" target="_blank">Python Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=QUT1VHiLmmI" target="_blank">NumPy Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=vmEHCJofslg" target="_blank">Pandas Tutorial – Corey Schafer</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=3Xc3CA655Y4" target="_blank">Matplotlib Crash Course – Traversy</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Python%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">Python Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=NumPy%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">NumPy Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Pandas%20Tutorial%20%E2%80%93%20Corey%20Schafer" target="_blank">Pandas Tutorial – Corey Schafer</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Matplotlib%20Crash%20Course%20%E2%80%93%20Traversy" target="_blank">Matplotlib Crash Course – Traversy</a>
                             </div>
                         </div>
                     </div>
@@ -1126,10 +1126,10 @@
                                 <span class="tag">Entropy & KL Divergence</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab" target="_blank">Essence of Linear Algebra – 3B1B</a>
-                                <a class="yt-link" href="https://www.youtube.com/playlist?list=PLZHQObOWTQDMsr9K-rj53DwVRMYO3t5Yr" target="_blank">Essence of Calculus – 3B1B</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=uzkc-qNVoOk" target="_blank">Statistics for ML – StatQuest</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=VPZD43kOzLs" target="_blank">Probability for ML – StatQuest</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Essence%20of%20Linear%20Algebra%20%E2%80%93%203B1B" target="_blank">Essence of Linear Algebra – 3B1B</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Essence%20of%20Calculus%20%E2%80%93%203B1B" target="_blank">Essence of Calculus – 3B1B</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Statistics%20for%20ML%20%E2%80%93%20StatQuest" target="_blank">Statistics for ML – StatQuest</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Probability%20for%20ML%20%E2%80%93%20StatQuest" target="_blank">Probability for ML – StatQuest</a>
                             </div>
                         </div>
                     </div>
@@ -1159,10 +1159,10 @@
                                 <span class="tag">Model evaluation</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=NWONeJKn6kc" target="_blank">ML Full Course – StatQuest</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=7eh4d6sabA0" target="_blank">scikit-learn Crash Course – Python Engineer</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=GwIo3gDZCVQ" target="_blank">XGBoost Tutorial – StatQuest</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=0Lt9w-BxKFQ" target="_blank">ML for Beginners – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=ML%20Full%20Course%20%E2%80%93%20StatQuest" target="_blank">ML Full Course – StatQuest</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=scikit-learn%20Crash%20Course%20%E2%80%93%20Python%20Engineer" target="_blank">scikit-learn Crash Course – Python Engineer</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=XGBoost%20Tutorial%20%E2%80%93%20StatQuest" target="_blank">XGBoost Tutorial – StatQuest</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=ML%20for%20Beginners%20%E2%80%93%20freeCodeCamp" target="_blank">ML for Beginners – freeCodeCamp</a>
                             </div>
                         </div>
                     </div>
@@ -1228,10 +1228,10 @@
                                 <span class="tag">Regularization</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/playlist?list=PLAqhIrjkxbuWI23v9cThsA9GvCAUhRvKZ" target="_blank">Neural Networks: Zero to Hero – Karpathy</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=c36lUUr864M" target="_blank">PyTorch Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=V_xro1bcAuA" target="_blank">PyTorch Tutorials – Aladdin Persson</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=twR3GX5NmS4" target="_blank">Backprop Explained Visually – 3B1B</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Neural%20Networks%3A%20Zero%20to%20Hero%20%E2%80%93%20Karpathy" target="_blank">Neural Networks: Zero to Hero – Karpathy</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=PyTorch%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">PyTorch Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=PyTorch%20Tutorials%20%E2%80%93%20Aladdin%20Persson" target="_blank">PyTorch Tutorials – Aladdin Persson</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Backprop%20Explained%20Visually%20%E2%80%93%203B1B" target="_blank">Backprop Explained Visually – 3B1B</a>
                             </div>
                         </div>
                     </div>
@@ -1262,11 +1262,11 @@
                                 <span class="tag">Context Windows</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=kCc8FmEb1nY" target="_blank">Build GPT from Scratch – Karpathy</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=wjZofJX0v4M" target="_blank">Transformers Explained – 3B1B</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=aircAruvnKk" target="_blank">Attention Mechanism Deep Dive – 3B1B</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=SZorAJ4I-sA" target="_blank">LLM Architecture Explained – Andrej Karpathy</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=zduSFxRajkE" target="_blank">Tokenization Deep Dive – Karpathy</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Build%20GPT%20from%20Scratch%20%E2%80%93%20Karpathy" target="_blank">Build GPT from Scratch – Karpathy</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Transformers%20Explained%20%E2%80%93%203B1B" target="_blank">Transformers Explained – 3B1B</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Attention%20Mechanism%20Deep%20Dive%20%E2%80%93%203B1B" target="_blank">Attention Mechanism Deep Dive – 3B1B</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=LLM%20Architecture%20Explained%20%E2%80%93%20Andrej%20Karpathy" target="_blank">LLM Architecture Explained – Andrej Karpathy</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Tokenization%20Deep%20Dive%20%E2%80%93%20Karpathy" target="_blank">Tokenization Deep Dive – Karpathy</a>
                             </div>
                         </div>
                     </div>
@@ -1372,10 +1372,10 @@
                                 <span class="tag">Streaming</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=lG7Uxts9SXs" target="_blank">LangChain Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=aywZrzNaKjs" target="_blank">Prompt Engineering Guide – Andrew Ng</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=T-D1OfcDW1M" target="_blank">OpenAI API Crash Course – Traversy Media</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=czvVibB2lRA" target="_blank">LlamaIndex Full Tutorial – Matt Williams</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=LangChain%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">LangChain Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Prompt%20Engineering%20Guide%20%E2%80%93%20Andrew%20Ng" target="_blank">Prompt Engineering Guide – Andrew Ng</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=OpenAI%20API%20Crash%20Course%20%E2%80%93%20Traversy%20Media" target="_blank">OpenAI API Crash Course – Traversy Media</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=LlamaIndex%20Full%20Tutorial%20%E2%80%93%20Matt%20Williams" target="_blank">LlamaIndex Full Tutorial – Matt Williams</a>
                             </div>
                         </div>
                     </div>
@@ -1408,11 +1408,11 @@
                                 <span class="tag">Document chunking</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=tcqEUSNCn8I" target="_blank">RAG from Scratch – LangChain</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=sVcwVQRHIc8" target="_blank">Vector Databases Explained – Fireship</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=dN0lsF2cvm4" target="_blank">Build RAG App – Tech With Tim</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=T-D1OfcDW1M" target="_blank">Advanced RAG Techniques – Pinecone</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=wd7TZ4w1mSw" target="_blank">Chroma & Embeddings – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=RAG%20from%20Scratch%20%E2%80%93%20LangChain" target="_blank">RAG from Scratch – LangChain</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Vector%20Databases%20Explained%20%E2%80%93%20Fireship" target="_blank">Vector Databases Explained – Fireship</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Build%20RAG%20App%20%E2%80%93%20Tech%20With%20Tim" target="_blank">Build RAG App – Tech With Tim</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Advanced%20RAG%20Techniques%20%E2%80%93%20Pinecone" target="_blank">Advanced RAG Techniques – Pinecone</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Chroma%20%26%20Embeddings%20%E2%80%93%20freeCodeCamp" target="_blank">Chroma & Embeddings – freeCodeCamp</a>
                             </div>
                         </div>
                     </div>
@@ -1520,11 +1520,11 @@
                                 <span class="tag">PEFT</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=eC6Hd1hFvos" target="_blank">Fine-Tune Llama 3 – Maxime Labonne</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=us5pV0rWvO8" target="_blank">QLoRA Explained – Yannic Kilcher</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=laDd6RL2kqE" target="_blank">Hugging Face Full Course – HF Team</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Pb_RGAl75VE" target="_blank">DPO Training Guide – Alignment Lab</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=aLnZhaZ7Z0k" target="_blank">vLLM Production Inference – Anyscale</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Fine-Tune%20Llama%203%20%E2%80%93%20Maxime%20Labonne" target="_blank">Fine-Tune Llama 3 – Maxime Labonne</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=QLoRA%20Explained%20%E2%80%93%20Yannic%20Kilcher" target="_blank">QLoRA Explained – Yannic Kilcher</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Hugging%20Face%20Full%20Course%20%E2%80%93%20HF%20Team" target="_blank">Hugging Face Full Course – HF Team</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=DPO%20Training%20Guide%20%E2%80%93%20Alignment%20Lab" target="_blank">DPO Training Guide – Alignment Lab</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=vLLM%20Production%20Inference%20%E2%80%93%20Anyscale" target="_blank">vLLM Production Inference – Anyscale</a>
                             </div>
                         </div>
                     </div>
@@ -1558,10 +1558,10 @@
                                 <span class="tag">Guardrails</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=jGg_1h0qzaE" target="_blank">LangGraph Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=sPzc6hMg7So" target="_blank">CrewAI Multi-Agent – Sam Witteveen</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=1qw4lBZ6q7I" target="_blank">AutoGen Tutorial – Microsoft</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=Lnc3o8zaASY" target="_blank">AI Agents Explained – Andrew Ng</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=LangGraph%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">LangGraph Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=CrewAI%20Multi-Agent%20%E2%80%93%20Sam%20Witteveen" target="_blank">CrewAI Multi-Agent – Sam Witteveen</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AutoGen%20Tutorial%20%E2%80%93%20Microsoft" target="_blank">AutoGen Tutorial – Microsoft</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=AI%20Agents%20Explained%20%E2%80%93%20Andrew%20Ng" target="_blank">AI Agents Explained – Andrew Ng</a>
                             </div>
                         </div>
                     </div>
@@ -1579,7 +1579,7 @@
                             function name and args. Your code executes it and feeds results back. Foundation of every
                             production agent.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=aqdWSYWC_LI" target="_blank">Function Calling – OpenAI Docs</a>
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Function%20Calling%20%E2%80%93%20OpenAI%20Docs" target="_blank">Function Calling – OpenAI Docs</a>
                         </div>
                     </div>
                     <div class="resource-card">
@@ -1588,7 +1588,7 @@
                             Reduces API costs 40–70% for production apps. Use GPTCache or Redis with vector similarity.
                         </div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=A_8BdPjzG80" target="_blank">GPTCache Tutorial – Zilliz</a>
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=GPTCache%20Tutorial%20%E2%80%93%20Zilliz" target="_blank">GPTCache Tutorial – Zilliz</a>
                         </div>
                     </div>
                     <div class="resource-card">
@@ -1597,7 +1597,7 @@
                             RAGAS for RAG pipelines, and frameworks like DeepEval and PromptFoo to systematically
                             evaluate outputs.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=Dr-PmCNHFpQ" target="_blank">LLM Eval Guide – DeepEval</a>
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=LLM%20Eval%20Guide%20%E2%80%93%20DeepEval" target="_blank">LLM Eval Guide – DeepEval</a>
                         </div>
                     </div>
                     <div class="resource-card">
@@ -1606,7 +1606,7 @@
                             NeMo Guardrails, or custom output validators to prevent hallucinations, PII leaks, and
                             harmful outputs reaching users.</div>
                         <div class="yt-links">
-                            <a class="yt-link" href="https://www.youtube.com/watch?v=g4ANaZMNdoI" target="_blank">Guardrails for LLMs – AI Jason</a>
+                            <a class="yt-link" href="https://www.youtube.com/results?search_query=Guardrails%20for%20LLMs%20%E2%80%93%20AI%20Jason" target="_blank">Guardrails for LLMs – AI Jason</a>
                         </div>
                     </div>
                 </div>
@@ -1660,11 +1660,11 @@
                                 <span class="tag">GitHub portfolio</span>
                             </div>
                             <div class="yt-links">
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=WT-V3WT5OyM" target="_blank">MLflow Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=oH0ciL1F-5A" target="_blank">W&amp;B Tutorial – Weights &amp; Biases</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=_BZGtifh_gw" target="_blank">Deploy ML Models FastAPI – Patrick Loeber</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=MpF9HENQjDo" target="_blank">Streamlit Full Course – freeCodeCamp</a>
-                                <a class="yt-link" href="https://www.youtube.com/watch?v=5dNJ14E3cBQ" target="_blank">Quantization Explained – Hugging Face</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=MLflow%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">MLflow Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=W%26B%20Tutorial%20%E2%80%93%20Weights%20%26%20Biases" target="_blank">W&amp;B Tutorial – Weights &amp; Biases</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Deploy%20ML%20Models%20FastAPI%20%E2%80%93%20Patrick%20Loeber" target="_blank">Deploy ML Models FastAPI – Patrick Loeber</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Streamlit%20Full%20Course%20%E2%80%93%20freeCodeCamp" target="_blank">Streamlit Full Course – freeCodeCamp</a>
+                                <a class="yt-link" href="https://www.youtube.com/results?search_query=Quantization%20Explained%20%E2%80%93%20Hugging%20Face" target="_blank">Quantization Explained – Hugging Face</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Standardize all direct YouTube video and playlist links under apps/resources/content/ 
to search query result links.
Given the large volume of links (~422 across 10 roadmap HTML files), manual 
modification was highly impractical and error-prone. Instead, a programmatic 
approach was taken using Node.js script utilities to decode HTML entities, 
clean up text metadata (titles & channel labels), and generate URL-encoded 
search query endpoints. 
This ensures fallback learning alternatives are easily discoverable if original 
videos become private or deleted, while keeping stable creator channel URLs 
intact. Text labels rendering full watch URLs inside the frontend-engineer 
roadmap were also cleanly updated to reference general "youtube.com" hosts.