### PR TITLE
fix oncampus routing

### DIFF
--- a/apps/oncampus/src/components/CoreSubjectMDXRenderer.tsx
+++ b/apps/oncampus/src/components/CoreSubjectMDXRenderer.tsx
@@ -97,6 +97,40 @@ const TabbedCodeBlock = ({
   );
 };
 
+interface PlainTextBlockProps {
+  content: string;
+}
+
+const PlainTextBlock = ({ content }: PlainTextBlockProps) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard not available */
+    }
+  };
+
+  return (
+    <div className="relative group bg-[#0A0A0A] border border-gray-800/40 rounded-lg my-6 overflow-hidden">
+      <button
+        onClick={handleCopy}
+        className="absolute top-2.5 right-2.5 px-2 py-1 text-[10px] font-mono rounded border transition-all duration-200 opacity-0 group-hover:opacity-100 z-10 bg-gray-800 border-gray-700 text-gray-400 hover:text-white hover:border-gray-600 cursor-pointer"
+      >
+        {copied ? "✓ Copied" : "Copy"}
+      </button>
+      <div className="overflow-x-auto p-4 scrollbar-thin-grey">
+        <pre className="font-mono text-[12.5px] text-gray-300 leading-relaxed whitespace-pre bg-transparent p-0 m-0 border-0 shadow-none">
+          {content}
+        </pre>
+      </div>
+    </div>
+  );
+};
+
 interface CoreSubjectMDXRendererProps {
   mdxSource: string;
 }
@@ -218,6 +252,7 @@ export const CoreSubjectMDXRenderer = ({
           defaultLanguage: string;
           languages: Record<string, { code: string }>;
         }
+      | { type: "text-block"; content: string }
     > = [];
     let currentMarkdownLines: string[] = [];
 
@@ -232,6 +267,27 @@ export const CoreSubjectMDXRenderer = ({
             content: currentMarkdownLines.join("\n"),
           });
           currentMarkdownLines = [];
+        }
+
+        const initialLang = line.trim().slice(3).trim().toLowerCase() || "text";
+
+        if (["text", "txt", "plaintext"].includes(initialLang)) {
+          const codeLines: string[] = [];
+          i++; // skip ```
+          while (i < lines.length) {
+            const codeLine = lines[i];
+            if (codeLine.trim() === "```") {
+              i++;
+              break;
+            }
+            codeLines.push(codeLine);
+            i++;
+          }
+          segments.push({
+            type: "text-block",
+            content: codeLines.join("\n"),
+          });
+          continue;
         }
 
         const groupLanguages: Record<string, { code: string }> = {};
@@ -337,6 +393,8 @@ export const CoreSubjectMDXRenderer = ({
                 className="break-words text-contentDark [&_*]:text-contentDark [&_h1]:text-2xl [&_h2]:text-xl [&_h3]:text-lg [&_h4]:text-base [&_h5]:text-sm [&_h6]:text-xs [&_h1]:mt-4 [&_h2]:mt-3 [&_h3]:mt-2 [&_h4]:mt-2 [&_h5]:mt-2 [&_h6]:mt-2 [&_strong]:font-bold [&_strong]:text-contentDark [&_em]:italic [&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-xl [&_img]:my-6 [&_table]:block [&_table]:overflow-x-auto [&_table]:w-full [&_table]:my-6 [&_table]:border-collapse [&_table]:text-left [&_th]:px-4 [&_th]:py-2 [&_th]:border-b [&_th]:border-gray-800 [&_th]:text-gray-200 [&_th]:font-bold [&_th]:text-sm [&_td]:px-4 [&_td]:py-2 [&_td]:border-b [&_td]:border-gray-900 [&_td]:text-gray-400 [&_td]:text-sm"
               />
             );
+          } else if (seg.type === "text-block") {
+            return <PlainTextBlock key={idx} content={seg.content} />;
           } else {
             return (
               <TabbedCodeBlock

--- a/apps/oncampus/src/config/oncampusDashboardNavItems.ts
+++ b/apps/oncampus/src/config/oncampusDashboardNavItems.ts
@@ -33,7 +33,7 @@ export const ONCAMPUS_DASHBOARD_NAV_ITEMS: OncampusDashboardNavItem[] = [
   {
     name: "Core Subjects",
     shortLabel: "Subjects",
-    href: "/dashboard/coresubjects",
+    href: "/coresubjects",
     icon: BookOpen,
   },
 ];

--- a/apps/oncampus/src/pages/_app.tsx
+++ b/apps/oncampus/src/pages/_app.tsx
@@ -40,9 +40,7 @@ const AppContent = ({
   // Exclude the Quizzes page for fullscreen workspace experience
   const isQuizzesRoute = router.pathname === "/dashboard/quizzes";
   // Exclude the Core Subjects page for fullscreen workspace experience
-  const isCoreSubjectsRoute = router.pathname.startsWith(
-    "/dashboard/coresubjects",
-  );
+  const isCoreSubjectsRoute = router.pathname.startsWith("/coresubjects");
 
   const shouldUseDashboardLayout =
     (isDashboardRoute || isDSAPrepRoute) &&

--- a/apps/oncampus/src/pages/coresubjects/[[...params]].tsx
+++ b/apps/oncampus/src/pages/coresubjects/[[...params]].tsx
@@ -14,6 +14,7 @@ import {
   ListFilter,
   Play,
 } from "lucide-react";
+import { useRouter } from "next/router";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { CoreSubjectMDXRenderer } from "@/components/CoreSubjectMDXRenderer";
@@ -22,7 +23,7 @@ import type { Chapter, Subject } from "@/config/coreSubjectsData";
 
 /* ─────────────────────────────────────────────
    Sub-components
-───────────────────────────────────────────── */
+ ───────────────────────────────────────────── */
 
 /** Single subject entry in the left sidebar */
 function SubjectItem({
@@ -89,7 +90,7 @@ function ChapterCard({
           {/* Top row */}
           <div className="flex items-center justify-between mb-3">
             <div className="w-9 h-9 flex items-center justify-center rounded-lg border border-gray-800 bg-gray-900/50 group-hover:scale-110 transition-transform duration-300">
-              <span className="text-[11px] font-black text-gray-500 group-hover:text-red-500 transition-colors duration-300">
+              <span className="text-[11px] font-black text-gray-505 group-hover:text-red-500 transition-colors duration-300">
                 {String(index + 1).padStart(2, "0")}
               </span>
             </div>
@@ -104,7 +105,7 @@ function ChapterCard({
           </h3>
 
           {/* Description */}
-          <p className="text-gray-500 text-xs leading-relaxed mb-3 line-clamp-2 group-hover:text-gray-300 transition-colors duration-300 flex-1">
+          <p className="text-gray-550 text-xs leading-relaxed mb-3 line-clamp-2 group-hover:text-gray-300 transition-colors duration-300 flex-1">
             {chapter.description}
           </p>
 
@@ -114,7 +115,7 @@ function ChapterCard({
               <span className="text-[10px] font-bold text-gray-600 uppercase tracking-wider">
                 Progress
               </span>
-              <span className="text-[10px] font-bold text-gray-600">0%</span>
+              <span className="text-[10px] font-bold text-gray-650">0%</span>
             </div>
             <div className="w-full h-[3px] bg-gray-800 rounded-full overflow-hidden">
               <div className="h-full w-0 bg-red-500 rounded-full transition-all duration-500" />
@@ -160,6 +161,13 @@ function ChapterContent({
   const [activeId, setActiveId] = useState<string>("");
   const [isCompleted, setIsCompleted] = useState<boolean>(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const scrollToHeading = (id: string) => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  };
 
   // Dynamic Reading Time Estimator
   const readingTime = useMemo(() => {
@@ -427,7 +435,7 @@ function ChapterContent({
                 onClick={() => onChapterSelect(nextChapter)}
                 className="group flex flex-col items-end px-5 py-3.5 bg-[#0A0A0A] border border-gray-800 rounded-xl hover:border-red-500/30 text-right transition-all duration-300 max-w-[45%] ml-auto"
               >
-                <span className="text-[9px] font-black text-gray-500 uppercase tracking-widest flex items-center gap-1.5 mb-1.5">
+                <span className="text-[9px] font-black text-gray-550 uppercase tracking-widest flex items-center gap-1.5 mb-1.5">
                   NEXT CHAPTER
                   <ChevronRight className="w-3.5 h-3.5 group-hover:translate-x-0.5 transition-transform" />
                 </span>
@@ -488,11 +496,18 @@ function ChapterContent({
   );
 }
 
-/* ─────────────────────────────────────────────
-   Main Page
-───────────────────────────────────────────── */
+const slugify = (text: string) =>
+  text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 
 const CoreSubjectsPage = () => {
+  const router = useRouter();
+  const { params } = router.query;
+
   const { data: response, isLoading } = useQuery<any>({
     queryKey: ["coreSubjects"],
     queryFn: () =>
@@ -506,50 +521,92 @@ const CoreSubjectsPage = () => {
     return response?.data ?? [];
   }, [response]);
 
-  const [selectedSubjectId, setSelectedSubjectId] = useState<string | null>(
-    null,
-  );
-  const [selectedChapter, setSelectedChapter] = useState<Chapter | null>(null);
+  const paramsArr = useMemo(() => {
+    if (!params) return [];
+    return Array.isArray(params) ? params : [params];
+  }, [params]);
+
+  const selectedSubjectId = paramsArr[0] || null;
+  const selectedChapterSlug = paramsArr[1] || null;
+
   const [isMobileSubjectsOpen, setIsMobileSubjectsOpen] = useState(false);
 
   useEffect(() => {
-    // Reset chapter when subject changes
-    setSelectedChapter(null);
+    if (!selectedSubjectId) {
+      setIsMobileSubjectsOpen(true);
+    } else {
+      setIsMobileSubjectsOpen(false);
+    }
   }, [selectedSubjectId]);
 
-  const selectedSubject: Subject | undefined = coreSubjects.find(
-    (s) => s.id === selectedSubjectId,
-  );
+  const selectedSubject = useMemo(() => {
+    if (!selectedSubjectId) return undefined;
+    return coreSubjects.find((s) => s.id === selectedSubjectId);
+  }, [coreSubjects, selectedSubjectId]);
 
-  const currentChapterIndex =
-    selectedSubject?.chapters.findIndex((c) => c.id === selectedChapter?.id) ??
-    -1;
+  const selectedChapter = useMemo(() => {
+    if (!selectedSubject || !selectedChapterSlug) return null;
+    return (
+      selectedSubject.chapters.find(
+        (c) =>
+          slugify(c.title) === selectedChapterSlug ||
+          c.id === selectedChapterSlug,
+      ) || null
+    );
+  }, [selectedSubject, selectedChapterSlug]);
 
-  const prevChapter =
-    currentChapterIndex > 0
-      ? selectedSubject?.chapters[currentChapterIndex - 1]
-      : null;
+  const currentChapterIndex = useMemo(() => {
+    if (!selectedSubject || !selectedChapter) return -1;
+    return selectedSubject.chapters.findIndex(
+      (c) => c.id === selectedChapter.id,
+    );
+  }, [selectedSubject, selectedChapter]);
 
-  const nextChapter =
-    selectedSubject &&
-    currentChapterIndex >= 0 &&
-    currentChapterIndex < selectedSubject.chapters.length - 1
-      ? selectedSubject.chapters[currentChapterIndex + 1]
-      : null;
+  const prevChapter = useMemo(() => {
+    if (currentChapterIndex > 0 && selectedSubject) {
+      return selectedSubject.chapters[currentChapterIndex - 1];
+    }
+    return null;
+  }, [selectedSubject, currentChapterIndex]);
+
+  const nextChapter = useMemo(() => {
+    if (
+      selectedSubject &&
+      currentChapterIndex >= 0 &&
+      currentChapterIndex < selectedSubject.chapters.length - 1
+    ) {
+      return selectedSubject.chapters[currentChapterIndex + 1];
+    }
+    return null;
+  }, [selectedSubject, currentChapterIndex]);
 
   const handleSubjectClick = (id: string) => {
-    setSelectedSubjectId(id);
-    setIsMobileSubjectsOpen(false);
+    router.push(`/coresubjects/${id}`, undefined, { shallow: true });
   };
 
   const handleBackToSubjects = () => {
-    setSelectedSubjectId(null);
-    setSelectedChapter(null);
+    router.push("/coresubjects", undefined, { shallow: true });
     setIsMobileSubjectsOpen(true);
   };
 
   const handleBackToChapters = () => {
-    setSelectedChapter(null);
+    if (selectedSubjectId) {
+      router.push(`/coresubjects/${selectedSubjectId}`, undefined, {
+        shallow: true,
+      });
+    } else {
+      router.push("/coresubjects", undefined, { shallow: true });
+    }
+  };
+
+  const handleChapterSelect = (ch: Chapter) => {
+    if (selectedSubjectId) {
+      router.push(
+        `/coresubjects/${selectedSubjectId}/${slugify(ch.title)}`,
+        undefined,
+        { shallow: true },
+      );
+    }
   };
 
   if (isLoading) {
@@ -590,7 +647,7 @@ const CoreSubjectsPage = () => {
                   </Text>
                   <Text
                     level="p"
-                    className="text-[9px] font-bold text-gray-500 uppercase tracking-[0.1em]"
+                    className="text-[9px] font-bold text-gray-550 uppercase tracking-[0.1em]"
                   >
                     Choose a subject
                   </Text>
@@ -617,7 +674,7 @@ const CoreSubjectsPage = () => {
                     </Text>
                     <Text
                       level="p"
-                      className="text-[10px] font-medium text-gray-500 uppercase tracking-wider hidden sm:block"
+                      className="text-[10px] font-medium text-gray-550 uppercase tracking-wider hidden sm:block"
                     >
                       {selectedSubject
                         ? `${selectedSubject.chapters.length} chapters available`
@@ -747,7 +804,7 @@ const CoreSubjectsPage = () => {
               onBack={handleBackToChapters}
               prevChapter={prevChapter ?? null}
               nextChapter={nextChapter ?? null}
-              onChapterSelect={(ch) => setSelectedChapter(ch)}
+              onChapterSelect={handleChapterSelect}
             />
           ) : (
             /* Chapter cards grid */
@@ -757,7 +814,7 @@ const CoreSubjectsPage = () => {
                 <h2 className="text-2xl font-extrabold text-white tracking-tight mb-1">
                   {selectedSubject?.label}
                 </h2>
-                <p className="text-gray-500 text-sm">
+                <p className="text-gray-550 text-sm">
                   {selectedSubject?.chapters.length} chapters · Click a card to
                   start reading
                 </p>
@@ -769,7 +826,7 @@ const CoreSubjectsPage = () => {
                     key={chapter.id}
                     chapter={chapter}
                     index={i}
-                    onClick={() => setSelectedChapter(chapter)}
+                    onClick={() => handleChapterSelect(chapter)}
                   />
                 ))}
               </div>

--- a/apps/oncampus/src/pages/coresubjects/[[...params]].tsx
+++ b/apps/oncampus/src/pages/coresubjects/[[...params]].tsx
@@ -247,6 +247,13 @@ function ChapterContent({
     setIsCompleted(localStorage.getItem(key) === "true");
   }, [chapter.id]);
 
+  // Scroll to top of next/prev topic when chapter changes
+  useEffect(() => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = 0;
+    }
+  }, [chapter.id]);
+
   const toggleCompleted = () => {
     const key = `coresubjects-completed-${chapter.id}`;
     const nextState = !isCompleted;

--- a/apps/oncampus/src/pages/coresubjects/[[...params]].tsx
+++ b/apps/oncampus/src/pages/coresubjects/[[...params]].tsx
@@ -410,41 +410,41 @@ function ChapterContent({
           )}
 
           {/* Navigation controls (Next/Prev) */}
-          <div className="flex items-center justify-between border-t border-gray-800/60 mt-12 pt-8 pb-16">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 border-t border-gray-800/60 mt-12 pt-8 pb-16">
             {prevChapter ? (
               <button
                 type="button"
                 onClick={() => onChapterSelect(prevChapter)}
-                className="group flex flex-col items-start px-5 py-3.5 bg-[#0A0A0A] border border-gray-800 rounded-xl hover:border-red-500/30 text-left transition-all duration-300 max-w-[45%]"
+                className="group flex flex-col items-start px-4 py-2.5 sm:px-5 sm:py-3.5 bg-[#0A0A0A] border border-gray-800 rounded-xl hover:border-red-500/30 text-left transition-all duration-300 w-full sm:w-auto sm:max-w-[45%]"
               >
-                <span className="text-[9px] font-black text-gray-500 uppercase tracking-widest flex items-center gap-1.5 mb-1.5">
+                <span className="text-[9px] font-black text-gray-500 uppercase tracking-widest flex items-center gap-1.5 mb-1">
                   <ChevronLeft className="w-3.5 h-3.5 group-hover:-translate-x-0.5 transition-transform" />
                   PREVIOUS CHAPTER
                 </span>
-                <span className="text-white font-bold text-[13px] line-clamp-1 group-hover:text-red-400 transition-colors">
+                <span className="text-white font-bold text-xs sm:text-[13px] line-clamp-1 group-hover:text-red-400 transition-colors">
                   {prevChapter.title}
                 </span>
               </button>
             ) : (
-              <div />
+              <div className="hidden sm:block" />
             )}
 
             {nextChapter ? (
               <button
                 type="button"
                 onClick={() => onChapterSelect(nextChapter)}
-                className="group flex flex-col items-end px-5 py-3.5 bg-[#0A0A0A] border border-gray-800 rounded-xl hover:border-red-500/30 text-right transition-all duration-300 max-w-[45%] ml-auto"
+                className="group flex flex-col items-end px-4 py-2.5 sm:px-5 sm:py-3.5 bg-[#0A0A0A] border border-gray-800 rounded-xl hover:border-red-500/30 text-right transition-all duration-300 w-full sm:w-auto sm:max-w-[45%] sm:ml-auto"
               >
-                <span className="text-[9px] font-black text-gray-500 uppercase tracking-widest flex items-center gap-1.5 mb-1.5">
+                <span className="text-[9px] font-black text-gray-500 uppercase tracking-widest flex items-center gap-1.5 mb-1">
                   NEXT CHAPTER
                   <ChevronRight className="w-3.5 h-3.5 group-hover:translate-x-0.5 transition-transform" />
                 </span>
-                <span className="text-white font-bold text-[13px] line-clamp-1 group-hover:text-red-400 transition-colors">
+                <span className="text-white font-bold text-xs sm:text-[13px] line-clamp-1 group-hover:text-red-400 transition-colors">
                   {nextChapter.title}
                 </span>
               </button>
             ) : (
-              <div />
+              <div className="hidden sm:block" />
             )}
           </div>
         </div>

--- a/apps/oncampus/src/pages/coresubjects/[[...params]].tsx
+++ b/apps/oncampus/src/pages/coresubjects/[[...params]].tsx
@@ -90,7 +90,7 @@ function ChapterCard({
           {/* Top row */}
           <div className="flex items-center justify-between mb-3">
             <div className="w-9 h-9 flex items-center justify-center rounded-lg border border-gray-800 bg-gray-900/50 group-hover:scale-110 transition-transform duration-300">
-              <span className="text-[11px] font-black text-gray-505 group-hover:text-red-500 transition-colors duration-300">
+              <span className="text-[11px] font-black text-gray-500 transition-colors duration-300 group-hover:text-red-500">
                 {String(index + 1).padStart(2, "0")}
               </span>
             </div>
@@ -105,7 +105,7 @@ function ChapterCard({
           </h3>
 
           {/* Description */}
-          <p className="text-gray-550 text-xs leading-relaxed mb-3 line-clamp-2 group-hover:text-gray-300 transition-colors duration-300 flex-1">
+          <p className="text-gray-500 text-xs leading-relaxed mb-3 line-clamp-2 group-hover:text-gray-300 transition-colors duration-300 flex-1">
             {chapter.description}
           </p>
 
@@ -115,7 +115,7 @@ function ChapterCard({
               <span className="text-[10px] font-bold text-gray-600 uppercase tracking-wider">
                 Progress
               </span>
-              <span className="text-[10px] font-bold text-gray-650">0%</span>
+              <span className="text-[10px] font-bold text-gray-600">0%</span>
             </div>
             <div className="w-full h-[3px] bg-gray-800 rounded-full overflow-hidden">
               <div className="h-full w-0 bg-red-500 rounded-full transition-all duration-500" />
@@ -278,7 +278,7 @@ function ChapterContent({
           </h1>
 
           {/* Sleek aesthetic breadcrumb & reading time / completion row */}
-          <div className="flex items-center gap-3 text-xs text-gray-500 pb-4 border-b border-gray-900 mb-6 flex-wrap">
+          <div className="flex items-center gap-3 text-xs text-gray-550 pb-4 border-b border-gray-900 mb-6 flex-wrap">
             <span className="text-[10px] font-bold text-red-500 uppercase tracking-widest bg-red-500/10 px-2 py-0.5 rounded">
               {subjectLabel}
             </span>
@@ -435,7 +435,7 @@ function ChapterContent({
                 onClick={() => onChapterSelect(nextChapter)}
                 className="group flex flex-col items-end px-5 py-3.5 bg-[#0A0A0A] border border-gray-800 rounded-xl hover:border-red-500/30 text-right transition-all duration-300 max-w-[45%] ml-auto"
               >
-                <span className="text-[9px] font-black text-gray-550 uppercase tracking-widest flex items-center gap-1.5 mb-1.5">
+                <span className="text-[9px] font-black text-gray-500 uppercase tracking-widest flex items-center gap-1.5 mb-1.5">
                   NEXT CHAPTER
                   <ChevronRight className="w-3.5 h-3.5 group-hover:translate-x-0.5 transition-transform" />
                 </span>
@@ -539,49 +539,39 @@ const CoreSubjectsPage = () => {
     }
   }, [selectedSubjectId]);
 
-  const selectedSubject = useMemo(() => {
-    if (!selectedSubjectId) return undefined;
-    return coreSubjects.find((s) => s.id === selectedSubjectId);
-  }, [coreSubjects, selectedSubjectId]);
+  const selectedSubject: Subject | undefined = coreSubjects.find(
+    (s) => s.id === selectedSubjectId || slugify(s.label) === selectedSubjectId,
+  );
 
-  const selectedChapter = useMemo(() => {
-    if (!selectedSubject || !selectedChapterSlug) return null;
-    return (
-      selectedSubject.chapters.find(
-        (c) =>
-          slugify(c.title) === selectedChapterSlug ||
-          c.id === selectedChapterSlug,
-      ) || null
-    );
-  }, [selectedSubject, selectedChapterSlug]);
+  const selectedChapter: Chapter | null =
+    (selectedSubject && selectedChapterSlug
+      ? selectedSubject.chapters.find(
+          (c) =>
+            slugify(c.title) === selectedChapterSlug ||
+            c.id === selectedChapterSlug,
+        )
+      : null) || null;
 
-  const currentChapterIndex = useMemo(() => {
-    if (!selectedSubject || !selectedChapter) return -1;
-    return selectedSubject.chapters.findIndex(
-      (c) => c.id === selectedChapter.id,
-    );
-  }, [selectedSubject, selectedChapter]);
+  const currentChapterIndex =
+    selectedSubject?.chapters.findIndex((c) => c.id === selectedChapter?.id) ??
+    -1;
 
-  const prevChapter = useMemo(() => {
-    if (currentChapterIndex > 0 && selectedSubject) {
-      return selectedSubject.chapters[currentChapterIndex - 1];
-    }
-    return null;
-  }, [selectedSubject, currentChapterIndex]);
+  const prevChapter =
+    currentChapterIndex > 0
+      ? selectedSubject?.chapters[currentChapterIndex - 1]
+      : null;
 
-  const nextChapter = useMemo(() => {
-    if (
-      selectedSubject &&
-      currentChapterIndex >= 0 &&
-      currentChapterIndex < selectedSubject.chapters.length - 1
-    ) {
-      return selectedSubject.chapters[currentChapterIndex + 1];
-    }
-    return null;
-  }, [selectedSubject, currentChapterIndex]);
+  const nextChapter =
+    selectedSubject &&
+    currentChapterIndex >= 0 &&
+    currentChapterIndex < selectedSubject.chapters.length - 1
+      ? selectedSubject.chapters[currentChapterIndex + 1]
+      : null;
 
-  const handleSubjectClick = (id: string) => {
-    router.push(`/coresubjects/${id}`, undefined, { shallow: true });
+  const handleSubjectClick = (subject: Subject) => {
+    router.push(`/coresubjects/${slugify(subject.label)}`, undefined, {
+      shallow: true,
+    });
   };
 
   const handleBackToSubjects = () => {
@@ -590,19 +580,23 @@ const CoreSubjectsPage = () => {
   };
 
   const handleBackToChapters = () => {
-    if (selectedSubjectId) {
-      router.push(`/coresubjects/${selectedSubjectId}`, undefined, {
-        shallow: true,
-      });
+    if (selectedSubject) {
+      router.push(
+        `/coresubjects/${slugify(selectedSubject.label)}`,
+        undefined,
+        {
+          shallow: true,
+        },
+      );
     } else {
       router.push("/coresubjects", undefined, { shallow: true });
     }
   };
 
   const handleChapterSelect = (ch: Chapter) => {
-    if (selectedSubjectId) {
+    if (selectedSubject) {
       router.push(
-        `/coresubjects/${selectedSubjectId}/${slugify(ch.title)}`,
+        `/coresubjects/${slugify(selectedSubject.label)}/${slugify(ch.title)}`,
         undefined,
         { shallow: true },
       );
@@ -647,7 +641,7 @@ const CoreSubjectsPage = () => {
                   </Text>
                   <Text
                     level="p"
-                    className="text-[9px] font-bold text-gray-550 uppercase tracking-[0.1em]"
+                    className="text-[9px] font-bold text-gray-500 uppercase tracking-[0.1em]"
                   >
                     Choose a subject
                   </Text>
@@ -674,7 +668,7 @@ const CoreSubjectsPage = () => {
                     </Text>
                     <Text
                       level="p"
-                      className="text-[10px] font-medium text-gray-550 uppercase tracking-wider hidden sm:block"
+                      className="text-[10px] font-medium text-gray-500 uppercase tracking-wider hidden sm:block"
                     >
                       {selectedSubject
                         ? `${selectedSubject.chapters.length} chapters available`
@@ -714,8 +708,12 @@ const CoreSubjectsPage = () => {
                   <SubjectItem
                     key={subject.id}
                     subject={subject}
-                    isActive={selectedSubjectId === subject.id}
-                    onClick={() => handleSubjectClick(subject.id)}
+                    isActive={
+                      selectedSubject
+                        ? selectedSubject.id === subject.id
+                        : false
+                    }
+                    onClick={() => handleSubjectClick(subject)}
                   />
                 ))}
               </div>
@@ -747,8 +745,12 @@ const CoreSubjectsPage = () => {
                     <SubjectItem
                       key={subject.id}
                       subject={subject}
-                      isActive={selectedSubjectId === subject.id}
-                      onClick={() => handleSubjectClick(subject.id)}
+                      isActive={
+                        selectedSubject
+                          ? selectedSubject.id === subject.id
+                          : false
+                      }
+                      onClick={() => handleSubjectClick(subject)}
                     />
                   ))}
                 </FlexContainer>
@@ -814,7 +816,7 @@ const CoreSubjectsPage = () => {
                 <h2 className="text-2xl font-extrabold text-white tracking-tight mb-1">
                   {selectedSubject?.label}
                 </h2>
-                <p className="text-gray-550 text-sm">
+                <p className="text-gray-500 text-sm">
                   {selectedSubject?.chapters.length} chapters · Click a card to
                   start reading
                 </p>


### PR DESCRIPTION
## What does this PR do?

Refactors the core subjects module from a state-based selection into a dynamic catch-all route at `/coresubjects`.

## Why?

Enables route-based deep-linking for subjects and chapters (e.g. `/coresubjects/operating-system/classes-objects`) to match the DSA sheet learning experience.

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔧 Refactor / cleanup (no functional change)
- [ ] 🎨 UI / styling change
- [ ] 🔌 API change (new or modified endpoints, request/response shape changes)
- [ ] 📦 Dependency update
- [ ] 📝 Documentation only

---

## Screenshots / Recordings
## Before
<img width="1343" height="788" alt="{13A200DB-255F-4825-9629-361AA8D6C986}" src="https://github.com/user-attachments/assets/ba4c77a7-4b35-4a76-ab33-c6a34d1e7c44" />

## After 
<img width="1253" height="775" alt="{C7BC2466-5710-42DD-AE53-653B6DB43EA5}" src="https://github.com/user-attachments/assets/3adb2db7-6daf-4991-b141-78d4da13d273" />


---

## Testing

### Does this PR include tests?

- [ ] Yes — unit tests
- [ ] Yes — integration / e2e tests
- [x] No — here's why: Pure routing layout changes, verified via TypeScript type compilation checks.

### How to test manually

1. Navigate to `/coresubjects` and verify the landing page loads.
2. Click a subject (e.g. *Operating System*) and verify the URL updates to `/coresubjects/operating-system` and lists the chapters.
3. Click a chapter and verify it opens deep-linked at `/coresubjects/operating-system/classes-objects` with working back buttons and next/prev controls.

---

## Checklist

- [x] I've tested this locally and it works as expected
- [x] I've checked for console errors / warnings
- [x] No unrelated changes snuck in
- [x] If UI change — tested on mobile viewport too
