### PR TITLE
improve interview sheets

### DIFF
--- a/apps/api/src/lib/database/models/InterviewPrep/Sheet.ts
+++ b/apps/api/src/lib/database/models/InterviewPrep/Sheet.ts
@@ -43,6 +43,16 @@ const questionSchema = new Schema<InterviewSheetQuestionModel>(
       default: "Medium",
       required: true,
     },
+    difficulty: {
+      type: String,
+      default: "Medium",
+    },
+    content: {
+      markdownContent: {
+        type: String,
+        default: null,
+      },
+    },
     resources: {
       youtubeURL: {
         type: String,

--- a/apps/api/src/lib/database/queries/interview-prep.ts
+++ b/apps/api/src/lib/database/queries/interview-prep.ts
@@ -117,24 +117,12 @@ const getInterviewSheetBySlugFromDB = async (
     let mappedQuestions = (sheet.questions || []).map((q) => q.toObject());
 
     if (userId) {
-      const targetCompanies = await getUserDSATargetCompanies(userId);
       const userSheet = await UserSheet.findOne({
         userId,
         sheetId: sheet._id,
       });
 
       isEnrolled = !!userSheet;
-
-      // Filter questions based on personalization settings if targets are set
-      if (targetCompanies.length > 0) {
-        mappedQuestions = mappedQuestions.filter((question: any) => {
-          if (!question.companyTypes || question.companyTypes.length === 0)
-            return true;
-          return question.companyTypes.some((type: string) =>
-            targetCompanies.includes(type),
-          );
-        });
-      }
 
       if (userSheet) {
         mappedQuestions = mappedQuestions.map((question: any) => {
@@ -148,9 +136,6 @@ const getInterviewSheetBySlugFromDB = async (
             isStarred: userQuestion?.isStarred || false,
           };
         });
-      } else if (targetCompanies.length > 0) {
-        // Even if not enrolled, the list of questions should be personalized
-        // mappedQuestions is already filtered above
       }
     }
 

--- a/apps/api/src/lib/interfaces/database.ts
+++ b/apps/api/src/lib/interfaces/database.ts
@@ -226,6 +226,10 @@ export interface InterviewSheetQuestionModel {
   frequency: QuestionFrequencyType;
   companyTypes?: CompanyType[];
   priority: PriorityType;
+  difficulty?: string;
+  content?: {
+    markdownContent?: string;
+  };
   toObject: () => InterviewSheetQuestionModel;
   resources?: QuestionResourcesModel;
 }

--- a/apps/oncampus/src/components/InterviewQuestionContent.tsx
+++ b/apps/oncampus/src/components/InterviewQuestionContent.tsx
@@ -1,7 +1,6 @@
-import { MDXRenderer } from "@tbe/components";
-import { AnimatePresence, motion } from "framer-motion";
-import { useMemo } from "react";
 import { FaRegStar, FaStar } from "react-icons/fa";
+
+import { CoreSubjectMDXRenderer } from "./CoreSubjectMDXRenderer";
 
 interface InterviewQuestionContentProps {
   questionTitle: string;
@@ -15,50 +14,6 @@ interface InterviewQuestionContentProps {
   onToggleStar?: () => void;
 }
 
-interface Section {
-  title: string;
-  content: string;
-}
-
-function parseSections(answer: string): Section[] {
-  if (!answer) return [];
-  const sections: Section[] = [];
-  const regex = /^#{2,5}\s+(.+)$/gm;
-  let match;
-  const matches: { title: string; index: number }[] = [];
-
-  while ((match = regex.exec(answer)) !== null) {
-    const beforeMatch = answer.substring(0, match.index);
-    const codeFences = (beforeMatch.match(/```/g) || []).length;
-    if (codeFences % 2 !== 0) continue; // inside code block
-    matches.push({ title: match[1].trim(), index: match.index });
-  }
-
-  if (matches.length === 0) {
-    return [{ title: "Answer", content: answer.trim() }];
-  }
-
-  // If there's text before the first heading, add it as 'Introduction'
-  if (matches[0].index > 0) {
-    const introContent = answer.substring(0, matches[0].index).trim();
-    if (introContent) {
-      sections.push({ title: "Introduction", content: introContent });
-    }
-  }
-
-  for (let i = 0; i < matches.length; i++) {
-    const start =
-      matches[i].index +
-      matches[i].title.length +
-      answer.substring(matches[i].index).match(/^#{2,5}\s+/)?.[0].length!;
-    const end = i + 1 < matches.length ? matches[i + 1].index : answer.length;
-    const content = answer.slice(start, end).trim();
-    sections.push({ title: matches[i].title, content });
-  }
-
-  return sections;
-}
-
 const InterviewQuestionContent = ({
   questionTitle,
   question,
@@ -70,98 +25,83 @@ const InterviewQuestionContent = ({
   isStarred,
   onToggleStar,
 }: InterviewQuestionContentProps) => {
-  const sections = useMemo(() => parseSections(answer), [answer]);
-
   return (
     <div className="w-full flex flex-col">
-      {/* Header Fields - Premium Glass Styling */}
-      <div className="mb-10 p-8 md:p-12 rounded-3xl border border-white/[0.05] bg-gradient-to-br from-white/[0.04] to-transparent backdrop-blur-2xl relative overflow-hidden group">
-        <div className="absolute inset-0 bg-gradient-to-br from-red-500/5 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-700" />
+      {/* Sleek Minimal Title */}
+      <div className="flex items-start justify-between gap-4 mb-4">
+        <h1 className="text-2xl sm:text-3xl font-black text-white tracking-tight leading-tight">
+          {questionTitle}
+        </h1>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleStar?.();
+          }}
+          className="p-1.5 rounded-full transition-all duration-200 hover:bg-white/5 active:scale-95 shrink-0 cursor-pointer text-xl"
+          aria-label={isStarred ? "Unstar question" : "Star question"}
+        >
+          {isStarred ? (
+            <FaStar className="text-yellow-400 drop-shadow-[0_0_8px_rgba(250,204,21,0.5)]" />
+          ) : (
+            <FaRegStar className="text-white/30 hover:text-white/60" />
+          )}
+        </button>
+      </div>
 
-        {questionTitle && (
-          <div className="flex items-start justify-between gap-4 mb-8">
-            <h1 className="relative text-3xl md:text-5xl font-black text-transparent bg-clip-text bg-gradient-to-r from-white via-white to-white/40 leading-tight tracking-tight">
-              {questionTitle}
-            </h1>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggleStar?.();
-              }}
-              className="relative z-10 mt-1 p-2 rounded-full transition-all duration-300 hover:bg-white/10 active:scale-90 shrink-0 cursor-pointer group/star"
-              aria-label={isStarred ? "Unstar question" : "Star question"}
-            >
-              <AnimatePresence mode="wait" initial={false}>
-                <motion.div
-                  key={isStarred ? "starred" : "unstarred"}
-                  initial={{ opacity: 0, scale: 0.5, rotate: -15 }}
-                  animate={{ opacity: 1, scale: 1, rotate: 0 }}
-                  exit={{ opacity: 0, scale: 0.5, rotate: 15 }}
-                  transition={{ duration: 0.2, ease: "easeOut" }}
-                  className="text-3xl md:text-4xl"
-                >
-                  {isStarred ? (
-                    <FaStar className="text-yellow-400 drop-shadow-[0_0_10px_rgba(250,204,21,0.6)]" />
-                  ) : (
-                    <FaRegStar className="text-white/30 group-hover/star:text-white/60" />
-                  )}
-                </motion.div>
-              </AnimatePresence>
-            </button>
+      {/* Sleek aesthetic breadcrumb & priority / frequency / companies row */}
+      <div className="flex items-center gap-3 text-xs text-gray-550 pb-4 border-b border-gray-900 mb-6 flex-wrap">
+        {priority && (
+          <span className="text-[10px] font-bold text-red-500 uppercase tracking-widest bg-red-500/10 px-2 py-0.5 rounded">
+            {priority} Priority
+          </span>
+        )}
+        {frequency && (
+          <>
+            {priority && <span className="text-gray-700 font-semibold">•</span>}
+            <span className="font-semibold text-gray-400">{frequency}</span>
+          </>
+        )}
+        {companyTypes && companyTypes.length > 0 && (
+          <>
+            {(priority || frequency) && (
+              <span className="text-gray-700 font-semibold">•</span>
+            )}
+            <div className="flex items-center gap-1.5 flex-wrap">
+              {companyTypes.map((ct) => (
+                <span key={ct} className="text-gray-400 font-semibold">
+                  {ct}
+                </span>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Structured Content matching Core Subjects */}
+      <div className="space-y-8 w-full">
+        {question && (
+          <div className="space-y-4 pb-8 border-b border-gray-900">
+            <h2 className="text-xs font-bold text-red-500 uppercase tracking-widest flex items-center gap-2">
+              <span className="w-4 h-[2px] bg-red-500 rounded-full" />
+              Problem Statement
+            </h2>
+            <div className="prose prose-invert max-w-none prose-red prose-headings:scroll-mt-6">
+              <CoreSubjectMDXRenderer mdxSource={question} />
+            </div>
           </div>
         )}
 
-        <div className="relative flex flex-wrap items-center gap-2 md:gap-3">
-          {frequency && (
-            <div className="px-3 py-1 md:px-5 md:py-2 rounded-full bg-red-500/5 border border-red-500/40 backdrop-blur-sm transition-all duration-300">
-              <span className="text-red-400 text-xs md:text-sm font-medium tracking-wide">
-                {frequency}
-              </span>
-            </div>
-          )}
-          {priority && (
-            <div className="px-3 py-1 md:px-5 md:py-2 rounded-full bg-white/[0.02] border border-white/10 backdrop-blur-sm hover:border-white/20 transition-all duration-300">
-              <span className="text-gray-300 text-xs md:text-sm font-medium tracking-wide">
-                Priority: {priority}
-              </span>
-            </div>
-          )}
-          {companyTypes?.map((ct) => (
-            <div
-              key={ct}
-              className="px-3 py-1 md:px-5 md:py-2 rounded-full bg-white/[0.02] border border-white/10 backdrop-blur-sm hover:border-white/20 transition-all duration-300"
-            >
-              <span className="text-gray-400 text-xs md:text-sm font-medium tracking-wide">
-                {ct}
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Structured Sections taking full width */}
-      <div className="space-y-10 md:space-y-12 w-full mt-6 md:mt-8">
-        {sections.map((section, idx) => (
-          <div
-            key={idx}
-            className="space-y-4 md:space-y-6 pt-6 md:pt-8 first:pt-0 border-t border-gray-800/50 first:border-0 w-full"
-          >
-            <div className="flex items-center gap-2.5 md:gap-3 mb-4 md:mb-6">
-              <div className="w-1 md:w-1.5 h-6 md:h-7 rounded-full bg-gradient-to-b from-red-400 to-red-600 shrink-0 shadow-[0_0_12px_rgba(239,68,68,0.4)]" />
-              <h2 className="text-white font-extrabold text-xl md:text-2xl tracking-tight m-0 drop-shadow-md">
-                {section.title}
-              </h2>
-            </div>
-
-            <div className="text-gray-200 text-base md:text-lg leading-relaxed md:leading-loose prose prose-invert prose-lg md:prose-xl max-w-none prose-p:my-3 md:prose-p:my-4 prose-headings:mb-3 md:prose-headings:mb-4 prose-headings:mt-6 md:prose-headings:mt-8 prose-pre:bg-[#0A0A0A] prose-pre:border prose-pre:border-gray-800/50 prose-pre:shadow-xl prose-pre:rounded-xl prose-table:w-full prose-table:table-auto prose-table:border-collapse prose-th:bg-white/[0.05] prose-th:p-2 md:prose-th:p-4 prose-td:p-2 md:prose-td:p-4 prose-td:border-b prose-td:border-white/[0.05] prose-table:text-xs md:prose-table:text-base w-full overflow-x-auto scrollbar-hide">
-              <MDXRenderer theme="dark" mdxSource={section.content} />
+        {answer && (
+          <div className="space-y-4">
+            <div className="prose prose-invert max-w-none prose-red prose-headings:scroll-mt-6">
+              <CoreSubjectMDXRenderer mdxSource={answer} />
             </div>
           </div>
-        ))}
+        )}
       </div>
 
       {actions && actions.length > 0 && (
-        <div className="mt-8 pt-6 border-t border-gray-800 flex flex-wrap items-center gap-2">
+        <div className="mt-8 pt-6 border-t border-gray-900 flex flex-wrap items-center gap-2">
           {actions}
         </div>
       )}

--- a/apps/oncampus/src/components/InterviewSheetWorkspace.tsx
+++ b/apps/oncampus/src/components/InterviewSheetWorkspace.tsx
@@ -4,8 +4,6 @@ import {
   DifficultyGroupedList,
   FeedbackPopup,
   FlexContainer,
-  mapInterviewPriorityToDifficultyGroup,
-  MDXRenderer,
   PaymentCard,
   QuestionLink,
   ResourceTooltip,
@@ -37,6 +35,7 @@ import {
 } from "react";
 import { FaLock } from "react-icons/fa";
 
+import { CoreSubjectMDXRenderer } from "@/components/CoreSubjectMDXRenderer";
 import InterviewQuestionContent from "@/components/InterviewQuestionContent";
 import { MobileNav } from "@/components/MobileNav";
 import OnCampusLearningLayout from "@/components/OnCampusLearningLayout";
@@ -48,6 +47,13 @@ const slugify = (text: string) =>
     .replace(/[^\w\s-]/g, "")
     .replace(/[\s_-]+/g, "-")
     .replace(/^-+|-+$/g, "");
+
+const getSafeId = (id: any): string => {
+  if (!id) return "";
+  if (typeof id === "string") return id;
+  if (typeof id === "object" && "$oid" in id) return id.$oid;
+  return id.toString();
+};
 
 /** Serializes `href` for `next/link` — `QuestionLink` only accepts `string`, not a UrlObject. */
 const buildPathWithQuery = (
@@ -110,7 +116,7 @@ export const InterviewSheetWorkspace = ({
   const currentQuestion = useMemo(() => {
     if (!urlQuestionSlug) {
       return (
-        questions.find((q) => q._id.toString() === initialQuestionId) ||
+        questions.find((q) => getSafeId(q._id) === initialQuestionId) ||
         questions[0]
       );
     }
@@ -121,7 +127,7 @@ export const InterviewSheetWorkspace = ({
   }, [questions, urlQuestionSlug, initialQuestionId]);
 
   const currentQuestionId = useMemo(
-    () => currentQuestion?._id?.toString() || "",
+    () => getSafeId(currentQuestion?._id),
     [currentQuestion],
   );
   const isQuestionCompleted = useMemo(
@@ -134,7 +140,7 @@ export const InterviewSheetWorkspace = ({
   );
 
   const currentIndex = useMemo(
-    () => questions.findIndex((q) => q._id.toString() === currentQuestionId),
+    () => questions.findIndex((q) => getSafeId(q._id) === currentQuestionId),
     [questions, currentQuestionId],
   );
 
@@ -200,7 +206,7 @@ export const InterviewSheetWorkspace = ({
     (questionMeta: string, questionId: string) => {
       if (!isLocked) {
         const selectedQuestion = questions.find(
-          (q) => q._id.toString() === questionId,
+          (q) => getSafeId(q._id) === questionId,
         );
 
         if (selectedQuestion) {
@@ -237,7 +243,7 @@ export const InterviewSheetWorkspace = ({
     // Optimistic update
     setQuestions((prev) =>
       prev.map((q) =>
-        q._id.toString() === currentQuestionId
+        getSafeId(q._id) === currentQuestionId
           ? { ...q, isStarred: newStarStatus }
           : q,
       ),
@@ -284,7 +290,7 @@ export const InterviewSheetWorkspace = ({
       // Optimistic update
       setQuestions((prev) =>
         prev.map((q) =>
-          q._id.toString() === currentQuestionId
+          getSafeId(q._id) === currentQuestionId
             ? { ...q, isCompleted: newCompletionStatus }
             : q,
         ),
@@ -341,7 +347,7 @@ export const InterviewSheetWorkspace = ({
 
         if (newCompletionStatus) {
           const updatedQuestions = questions.map((question) =>
-            question._id.toString() === currentQuestionId
+            getSafeId(question._id) === currentQuestionId
               ? { ...question, isCompleted: newCompletionStatus }
               : question,
           );
@@ -386,12 +392,8 @@ export const InterviewSheetWorkspace = ({
       <DifficultyGroupedList
         className="gap-px flex-grow"
         items={questions ?? []}
-        getDifficulty={(q) =>
-          mapInterviewPriorityToDifficultyGroup(
-            (q as { priority?: string }).priority,
-          )
-        }
-        getItemKey={(q) => q._id?.toString() ?? ""}
+        getDifficulty={(q) => (q as { difficulty?: string }).difficulty}
+        getItemKey={(q) => getSafeId(q._id)}
         initialExpandedGroups={STANDARD_DIFFICULTY_GROUPS_DEFAULT_EXPANDED}
         difficultyOrder={STANDARD_DIFFICULTY_ORDER}
         difficultyLabels={STANDARD_DIFFICULTY_LABELS}
@@ -403,11 +405,12 @@ export const InterviewSheetWorkspace = ({
             title,
             question,
             answer,
+            content,
             isCompleted,
             frequency,
             isStarred,
           } = item;
-          const questionId = _id?.toString() ?? "";
+          const questionId = getSafeId(_id);
           const questionSlug = slugify(title);
 
           const questionHref = buildPathWithQuery(router.asPath.split("?")[0], {
@@ -415,17 +418,20 @@ export const InterviewSheetWorkspace = ({
             question: questionSlug,
           });
 
+          const fullQuestionText =
+            content?.markdownContent || `${question}\n\n${answer}`;
+
           return (
             <div key={questionId} className="flex items-center w-full">
               <QuestionLink
                 currentQuestionId={currentQuestionId}
                 frequency={frequency}
                 handleQuestionClick={() =>
-                  handleQuestionClick(`${question}\n\n${answer}`, questionId)
+                  handleQuestionClick(fullQuestionText, questionId)
                 }
                 href={questionHref}
                 isCompleted={isCompleted}
-                question={`${question}\n\n${answer}`}
+                question={fullQuestionText}
                 questionId={questionId}
                 title={title}
                 isLocked={isLocked}
@@ -569,7 +575,9 @@ export const InterviewSheetWorkspace = ({
                   <Text level="h2" className="heading-4 mb-4 text-contentDark">
                     Interview Sheet Overview
                   </Text>
-                  <MDXRenderer theme="dark" mdxSource={sheet.meta || ""} />
+                  <div className="prose prose-invert max-w-none prose-red prose-headings:scroll-mt-6">
+                    <CoreSubjectMDXRenderer mdxSource={sheet.meta || ""} />
+                  </div>
                   <div className="mt-6 w-full rounded bg-yellow-100 p-4 border border-yellow-300 shadow-sm text-black">
                     <Text level="h4" className="mb-2 flex items-center gap-2">
                       <FaLock className="text-yellow-600" />
@@ -612,7 +620,11 @@ export const InterviewSheetWorkspace = ({
                     <InterviewQuestionContent
                       questionTitle={currentQuestion?.title || ""}
                       question={currentQuestion?.question || ""}
-                      answer={currentQuestion?.answer || ""}
+                      answer={
+                        currentQuestion?.content?.markdownContent ||
+                        currentQuestion?.answer ||
+                        ""
+                      }
                       frequency={currentQuestion?.frequency}
                       priority={currentQuestion?.priority}
                       companyTypes={currentQuestion?.companyTypes}

--- a/packages/interface/src/database.ts
+++ b/packages/interface/src/database.ts
@@ -156,6 +156,10 @@ export interface InterviewSheetQuestionModel {
   frequency: QuestionFrequencyType;
   companyTypes?: CompanyType[];
   priority: PriorityType;
+  difficulty?: string;
+  content?: {
+    markdownContent?: string;
+  };
   toObject: () => UserCourseModel;
   resources?: QuestionResourcesModel;
 }

--- a/packages/types/src/database.ts
+++ b/packages/types/src/database.ts
@@ -217,6 +217,12 @@ export interface InterviewSheetQuestionModel {
   frequency: QuestionFrequencyType;
   isCompleted: boolean;
   isStarred?: boolean;
+  priority?: string;
+  difficulty?: string;
+  companyTypes?: string[];
+  content?: {
+    markdownContent?: string;
+  };
   resources?: QuestionResourcesModel;
 }
 


### PR DESCRIPTION
## What does this PR do?

- Integrates markdown rendering for interview sheets to match the design of Core Subjects.
- Fixes the sidebar question grouping to categorize questions by their actual `difficulty` field instead of `priority`.
- Removes the server-side `targetCompanies` personalization filter so that all questions (e.g. all 30+ Java questions) load correctly.


## Why?

- Users were missing questions (e.g. only 18 out of 30 Java questions were visible) due to automatic target-company filtering.
- The sidebar grouping was broken, leaving the "Easy" difficulty bucket empty.
- Custom rendering was replaced with clean, consistent markdown parsing matching the style of Core Subjects.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🎨 UI / styling change
- [x] 🔌 API change (new or modified endpoints, request/response shape changes)

---

## Screenshots / Recordings

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7b93bdc7-6565-473a-8e1d-c6c991b1d8d0" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/204b81b8-0e85-416d-8c44-af2647d58a03" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f485ff89-fb7b-459b-a7db-5c49b5fcde4d" />


## Testing

### Does this PR include tests?

- [x] No — here's why: Verified manually through local development server and workspace-wide TypeScript type-checking (`pnpm check-types`).

### How to test manually

1. Open `/coresubjects` and verify the markdown styling matches `/interview-prep/java-interview-questions`.
2. Inspect the sidebar to confirm "Easy", "Medium", and "Hard" groups are populated and match the question counts in the database.
3. Verify all Java interview questions are visible regardless of user profile goal settings.

---

## Checklist

- [x] I've tested this locally and it works as expected
- [x] I've checked for console errors / warnings
- [x] No unrelated changes snuck in
- [x] If UI change — tested on mobile viewport too
- [x] If API change — backward compatible or migration plan noted above
