### PR TITLE
fix: guard against empty/whitespace names in email greeting and reven…

### DIFF
--- a/apps/api/src/pages/api/v1/prepyatra/prep-log/index.ts
+++ b/apps/api/src/pages/api/v1/prepyatra/prep-log/index.ts
@@ -222,6 +222,9 @@ const handleAddMentorFeedback = async (
       try {
         const { emailClient } = await import("@/lib/services");
 
+        const firstName =
+          userName.trim().split(" ").filter(Boolean)[0] || "there";
+
         await emailClient.sendEmail({
           from_email: process.env.FROM_EMAIL || "theboringeducation@gmail.com",
           from_name: "Sachin from The Boring Education",
@@ -229,7 +232,7 @@ const handleAddMentorFeedback = async (
           to_name: userName,
           subject: "I have some feedback for your Prep Yatra 🚀",
           html_content:
-            `<p>Hi ${userName.split(" ")[0]},</p>` +
+            `<p>Hi ${firstName},</p>` +
             `<p>I reviewed your recent Prep Yatra logs. Here's my feedback to help you level up this week:</p>` +
             `<blockquote style="margin:12px 0;padding:12px;border-left:4px solid #6b46c1;background:#faf7ff;">${
               mentorFeedback

--- a/apps/api/src/pages/api/v1/revenue/transparency.ts
+++ b/apps/api/src/pages/api/v1/revenue/transparency.ts
@@ -120,10 +120,12 @@ const handleGetRevenueData = async (
       // Anonymize user data for privacy
       userInitials: payment.user?.name
         ? payment.user.name
+            .trim()
             .split(" ")
+            .filter(Boolean)
             .map((n: string) => n[0])
             .join("")
-            .toUpperCase()
+            .toUpperCase() || "U"
         : "U",
     }));
 


### PR DESCRIPTION
# Summary

Closes #1015 


* Fix unsafe `name.split(" ")[0]` access in the mentor feedback email template that produced `Hi ,` for users with empty or whitespace-only names.
* Fix blank user initials on the revenue transparency page when a user's name is missing or contains only whitespace.

## Changes

### `apps/api/src/pages/api/v1/prepyatra/prep-log/index.ts`

* Extract `firstName` using:

```ts
const firstName =
  userName.trim().split(" ").filter(Boolean)[0] || "there";
```

* `.filter(Boolean)` removes empty strings created by `.split(" ")` when the name is blank or whitespace-only.
* Added a fallback of `"there"` so the email greeting becomes:

```text
Hi there,
```

instead of:

```text
Hi ,
```

### `apps/api/src/pages/api/v1/revenue/transparency.ts`

* Added `.trim()` and `.filter(Boolean)` before `.map(n => n[0])` in the initials generation chain.
* Previously, empty or whitespace-only names could produce empty strings, resulting in blank initials being displayed publicly.
* Added:

```ts
|| "U"
```

to ensure the existing fallback is applied when initials cannot be derived from the provided name.

## Root Cause

`String.prototype.split(" ")` on an empty or whitespace-only string returns an array containing empty strings.

Examples:

```ts
"".split(" ");     // [""]
"   ".split(" ");  // ["", "", "", ""]
```

Accessing the first element returns an empty string (`""`), not `undefined`, so existing null/undefined checks do not catch this case. As a result:

* Email greetings rendered as `Hi ,`
* Revenue transparency initials rendered as blank values

## Test Plan

* [ ] Send mentor feedback with `notifyEmail: true` for a user whose name is an empty string — greeting should read `Hi there,`
* [ ] Send mentor feedback for a user with a normal name such as `Naman Bharsakale` — greeting should read `Hi Naman,`
* [ ] Load the revenue transparency page with a payment record whose user name is blank — initials should display `U`
* [ ] Load the revenue transparency page with a normal name such as `Riya Shah` — initials should display `RS`
* [ ] Run `tsc --noEmit` and verify there are 0 TypeScript errors
