### PR TITLE
fix: add empty-string guard to name.split() in email greeting and revenue initials

### DIFF
--- a/apps/api/src/pages/api/v1/prepyatra/prep-log/index.ts
+++ b/apps/api/src/pages/api/v1/prepyatra/prep-log/index.ts
@@ -229,7 +229,7 @@ const handleAddMentorFeedback = async (
           to_name: userName,
           subject: "I have some feedback for your Prep Yatra 🚀",
           html_content:
-            `<p>Hi ${userName.split(" ")[0]},</p>` +
+            `<p>Hi ${userName.trim().split(" ").filter(Boolean)[0] || "there"},</p>` +
             `<p>I reviewed your recent Prep Yatra logs. Here's my feedback to help you level up this week:</p>` +
             `<blockquote style="margin:12px 0;padding:12px;border-left:4px solid #6b46c1;background:#faf7ff;">${
               mentorFeedback

--- a/apps/api/src/pages/api/v1/revenue/transparency.ts
+++ b/apps/api/src/pages/api/v1/revenue/transparency.ts
@@ -118,13 +118,14 @@ const handleGetRevenueData = async (
       date: payment.date,
       type: payment.type,
       // Anonymize user data for privacy
-      userInitials: payment.user?.name
-        ? payment.user.name
-            .split(" ")
-            .map((n: string) => n[0])
-            .join("")
-            .toUpperCase()
-        : "U",
+      userInitials:
+        payment.user?.name
+          ?.trim()
+          .split(" ")
+          .filter(Boolean)
+          .map((n: string) => n[0])
+          .join("")
+          .toUpperCase() || "U",
     }));
 
     return res.status(apiStatusCodes.OKAY).json(


### PR DESCRIPTION
## Summary

Fixes #1015 — reported by @NamanBharsakale

Two places in the API split a user name on `" "` without guarding against blank or whitespace-only values, causing:
- Feedback emails to render **`Hi ,`** instead of **`Hi there,`**
- Revenue transparency page to show **empty initials** instead of **`U`**

### Changes

| File | What changed |
|------|-------------|
| `apps/api/src/pages/api/v1/prepyatra/prep-log/index.ts` | `userName.split(" ")[0]` → `userName.trim().split(" ").filter(Boolean)[0] \|\| "there"` |
| `apps/api/src/pages/api/v1/revenue/transparency.ts` | Added `.filter(Boolean)` before `.map(n => n[0])` and appended `\|\| "U"` fallback |

### How it works
- `trim()` removes leading/trailing whitespace
- `filter(Boolean)` drops empty strings produced by splitting a whitespace-only string
- Fallback values (`"there"` / `"U"`) guarantee a graceful result when the name is entirely blank

## Test plan
- [ ] Send a feedback email for a user with an empty name — greeting should read `Hi there,`
- [ ] Send a feedback email for a user with a valid name — greeting should remain unchanged (e.g. `Hi Sachin,`)
- [ ] View revenue transparency page with a payment record whose user has a blank name — initials should show `U`
- [ ] View revenue transparency page with a valid name — initials should remain correct (e.g. `AB`)

---

Hey @NamanBharsakale — the fix is ready for your review! Both acceptance criteria from the issue are covered. Let me know if you'd like any tweaks. 🙌

https://claude.ai/code/session_01CLWPyqXxd2a4AKytzxrYs1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLWPyqXxd2a4AKytzxrYs1)_