### PR TITLE
fix: improve spacing on interview prep page

### DIFF
--- a/packages/components/src/containers/Cards/CardContainerA.tsx
+++ b/packages/components/src/containers/Cards/CardContainerA.tsx
@@ -15,7 +15,9 @@ const CardContainerA = ({
   subtext,
   theme = "light",
 }: CardContainerAProps) => (
-  <Section className={theme === "dark" ? "bg-[#0A0A0A]" : ""}>
+  <Section
+    className={`md:px-8 md:py-8 px-2 py-4${theme === "dark" ? " bg-[#0A0A0A]" : ""}`}
+  >
     <FlexContainer className="gap-4" direction="col">
       <SectionHeaderContainer
         focusText={focusText || ""}

--- a/packages/components/src/containers/Cards/Items/PrimaryCard.tsx
+++ b/packages/components/src/containers/Cards/Items/PrimaryCard.tsx
@@ -18,7 +18,7 @@ const PrimaryCard = ({
     >
       <Image
         alt={imageAltText}
-        className="h-40 w-48"
+        className="h-40 w-48 mx-auto"
         fullHeight={false}
         fullWidth={false}
         src={`${image}`}


### PR DESCRIPTION
## Description

Fixed the spacing issue on the Interview Prep page.

## Changes Made

- Improved spacing between the content section and footer
- Enhanced visual consistency of the page

Fixes #1003

## Before
<img width="1919" height="1022" alt="image" src="https://github.com/user-attachments/assets/fec16137-1202-43de-a079-758e64c2b758" />


## After
<img width="1919" height="1018" alt="image" src="https://github.com/user-attachments/assets/c870f8ea-f5e5-46de-a66b-cc260780ec50" />
