### PR TITLE
fix(unskilled): fix Job Domains bar chart bars not rendering with correct colour

### DIFF
--- a/apps/platform/src/pages/unskilled/index.tsx
+++ b/apps/platform/src/pages/unskilled/index.tsx
@@ -105,7 +105,7 @@ const UnskilledLandingPage = ({
         <YAxis type='number' />
         <XAxis dataKey='name' type='category' width={100} />
         <Tooltip />
-        <Bar dataKey='count' fill='bg-primary' />
+        <Bar dataKey='count' fill='hsl(var(--primary))' />
       </BarChart>
     </ResponsiveContainer>,
 


### PR DESCRIPTION
## Summary

Fixes #1026 — reported by @kashyap-savaliya

- `fill='bg-primary'` was passed to Recharts `<Bar />` as the SVG `fill` attribute. SVG `fill` expects a CSS colour value (hex, `rgb()`, `hsl()`, etc.), **not** a Tailwind utility class. Browsers treat the invalid value as black/opaque, making the Job Domains chart bars appear solid black.
- Changed to `fill='hsl(var(--primary))'` so the bar colour correctly tracks the design system's primary colour CSS variable — matching the intent of the original code.

## Root cause

```diff
- <Bar dataKey='count' fill='bg-primary' />
+ <Bar dataKey='count' fill='hsl(var(--primary))' />
```

## Test plan

- [ ] Navigate to `/unskilled`
- [ ] Scroll to the **Job Market Insights** section
- [ ] Switch to the **Job Domains** tab — bars should now render in the primary brand colour (not black)
- [ ] Verify the other three chart tabs (Trending Skills, Company Types, Top Locations) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q82E4AiHGzkLwZnZiLZA5U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q82E4AiHGzkLwZnZiLZA5U)_