### PR TITLE
feat: add dark theme toggle button to hero section

### DIFF
--- a/apps/platform/src/pages/index.tsx
+++ b/apps/platform/src/pages/index.tsx
@@ -34,6 +34,7 @@ const Home = ({ seoMeta }: PageProps) => {
       <LandingPageHero
         backgroundImageUrl={`${STATIC_FILE_PATH.svg}/hero-image.svg`}
         heroText='Learn Tech Skills & Prepare yourself for a Tech Job.'
+        showThemeToggle={true}
         primaryButton={
           <LinkButton
             buttonProps={{

--- a/packages/components/src/containers/Page/common/Hero.tsx
+++ b/packages/components/src/containers/Page/common/Hero.tsx
@@ -1,3 +1,4 @@
+import { MoonIcon, SunIcon } from "@heroicons/react/24/outline";
 import {
   FlexContainer,
   Image,
@@ -6,19 +7,68 @@ import {
   Text,
 } from "@tbe/components";
 import type { LandingPageHeroProps } from "@tbe/interface";
+import { useEffect, useState } from "react";
+
+const THEME_STORAGE_KEY = "tbe-hero-theme";
+
 const LandingPageHero = ({
   sectionHeaderProps,
   primaryButton,
   secondaryButton,
   backgroundImageUrl,
   heroText,
-  theme = "light",
+  theme: themeProp = "light",
+  showThemeToggle = false,
 }: LandingPageHeroProps) => {
   const { heading, focusText } = sectionHeaderProps;
+  const [theme, setTheme] = useState<"light" | "dark">(themeProp);
+
+  useEffect(() => {
+    if (!showThemeToggle) return;
+    const saved = localStorage.getItem(THEME_STORAGE_KEY) as
+      | "light"
+      | "dark"
+      | null;
+    if (saved) setTheme(saved);
+  }, [showThemeToggle]);
+
+  const toggleTheme = () => {
+    const next = theme === "light" ? "dark" : "light";
+    setTheme(next);
+    localStorage.setItem(THEME_STORAGE_KEY, next);
+  };
+
   const isDark = theme === "dark";
+
   return (
     <Section className={isDark ? "bg-[#0A0A0A]" : ""}>
       <FlexContainer className="py-2 sm:py-6" direction="col" justifyCenter>
+        {showThemeToggle && (
+          <FlexContainer className="w-full justify-end mb-2">
+            <button
+              aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+              className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition-colors ${
+                isDark
+                  ? "bg-gray-800 text-yellow-300 hover:bg-gray-700"
+                  : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+              }`}
+              onClick={toggleTheme}
+              type="button"
+            >
+              {isDark ? (
+                <>
+                  <SunIcon className="h-4 w-4" />
+                  <span>Light</span>
+                </>
+              ) : (
+                <>
+                  <MoonIcon className="h-4 w-4" />
+                  <span>Dark</span>
+                </>
+              )}
+            </button>
+          </FlexContainer>
+        )}
         <FlexContainer
           className="wrap-reverse flex-col-reverse gap-6 lg:flex-row"
           itemCenter

--- a/packages/interface/src/Components.ts
+++ b/packages/interface/src/Components.ts
@@ -337,6 +337,7 @@ export interface LandingPageHeroProps {
   backgroundImageUrl: string;
   heroText: string;
   theme?: "light" | "dark";
+  showThemeToggle?: boolean;
 }
 
 interface BaseCardContainerProps {

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -546,6 +546,8 @@ export interface LandingPageHeroProps {
   secondaryButton?: ReactNode;
   backgroundImageUrl: string;
   heroText: string;
+  theme?: "light" | "dark";
+  showThemeToggle?: boolean;
 }
 
 export interface ProjectHeroContainerProps {


### PR DESCRIPTION
## Summary

Closes #1036 — adds a dark/light theme toggle button to the `LandingPageHero` component on the platform landing page.

- Added a sun/moon icon toggle button in the top-right corner of the hero section
- Clicking the button switches between light (`#FFFFFF`) and dark (`#0A0A0A`) backgrounds with appropriate text colours
- User preference is persisted to `localStorage` so the chosen theme survives page refreshes
- Toggle is opt-in via a new `showThemeToggle` prop on `LandingPageHero` (non-breaking — defaults to `false`)
- Updated `LandingPageHeroProps` in both `@tbe/interface` and `@tbe/types` to include the new prop

## Files Changed

| File | Change |
|---|---|
| `packages/components/src/containers/Page/common/Hero.tsx` | Added theme state, localStorage persistence, and toggle button |
| `packages/interface/src/Components.ts` | Added `showThemeToggle?: boolean` to `LandingPageHeroProps` |
| `packages/types/src/components.ts` | Same interface update |
| `apps/platform/src/pages/index.tsx` | Passed `showThemeToggle={true}` to enable the toggle |

## Test Plan

- [ ] Visit the platform landing page — a dark/light toggle button should appear in the hero section
- [ ] Click the toggle — background, text, and heading colours should switch correctly
- [ ] Refresh the page — the previously selected theme should be restored from localStorage
- [ ] Check on mobile — the toggle should be visible and functional at all screen sizes
- [ ] Verify other pages that use `LandingPageHero` without `showThemeToggle` are unaffected

---

Hey @Shubhang-Sagar-Shukla — this is the implementation of your request in #1036! 🎉 Would love your feedback. Please take a look and let us know if the button placement, styling, or behaviour matches what you had in mind. Happy to iterate!

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdqLGJqM5FTidbL2nR39td)_