### PR TITLE
fix: format prep-yatra goal timeline label instead of raw value

### DIFF
--- a/apps/testing/src/unit/utils/onboarding.test.ts
+++ b/apps/testing/src/unit/utils/onboarding.test.ts
@@ -1,5 +1,6 @@
 import {
   checkUsernameAvailable,
+  formatGoalTimelineLabel,
   getOnboardingUser,
 } from "@tbe/utils/onboarding";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -176,6 +177,30 @@ describe("Onboarding Utilities", () => {
       const result = await getOnboardingUser("user-123");
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe("formatGoalTimelineLabel", () => {
+    it("should return empty string for undefined, null, or empty string", () => {
+      expect(formatGoalTimelineLabel()).toBe("");
+      expect(formatGoalTimelineLabel(null)).toBe("");
+      expect(formatGoalTimelineLabel("")).toBe("");
+    });
+
+    it("should return correct labels for known raw formats", () => {
+      expect(formatGoalTimelineLabel("3_months")).toBe("3 Months");
+      expect(formatGoalTimelineLabel("6_months")).toBe("6 Months");
+      expect(formatGoalTimelineLabel("1_year")).toBe("1 Year");
+      expect(formatGoalTimelineLabel("3Months")).toBe("3 Months");
+      expect(formatGoalTimelineLabel("6Months")).toBe("6 Months");
+      expect(formatGoalTimelineLabel("1Year")).toBe("1 Year");
+    });
+
+    it("should fall back to humanizing other formats", () => {
+      expect(formatGoalTimelineLabel("2_years")).toBe("2 Years");
+      expect(formatGoalTimelineLabel("18Months")).toBe("18 Months");
+      expect(formatGoalTimelineLabel("four_months")).toBe("Four Months");
+      expect(formatGoalTimelineLabel("  5_months  ")).toBe("5 Months");
     });
   });
 });

--- a/packages/components/src/prepyatra/dashboard/ProfileSection.tsx
+++ b/packages/components/src/prepyatra/dashboard/ProfileSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatGoalTimelineLabel } from "@tbe/utils";
 import { Copy, Edit, ExternalLink, Github, Linkedin } from "lucide-react";
 import { useRouter } from "next/router";
 import React from "react";
@@ -196,7 +197,7 @@ const ProfileSection: React.FC<ProfileSectionProps> = ({
               variant="default"
               className="bg-white border-2 border-[#FF5757]/20 text-[#FF5757]  hover:bg-[#FF5757] hover:text-white transition-all duration-200 text-xs px-3 py-1"
             >
-              {profile?.prepYatra?.goal || "Not set"}
+              {formatGoalTimelineLabel(profile?.prepYatra?.goal) || "Not set"}
             </Badge>
           </FlexContainer>
 

--- a/packages/components/src/prepyatra/pages/PrepYatraPublicJourneyPage.tsx
+++ b/packages/components/src/prepyatra/pages/PrepYatraPublicJourneyPage.tsx
@@ -1,5 +1,5 @@
 import type { PrepLog, UserProfile } from "@tbe/interface";
-import { getTimeOfDay, withProtocol } from "@tbe/utils";
+import { formatGoalTimelineLabel, getTimeOfDay, withProtocol } from "@tbe/utils";
 import {
   Calendar,
   Clock,
@@ -207,7 +207,8 @@ const PrepYatraPublicJourneyPage = () => {
                 <span className="font-medium text-foreground">Goal:</span>
                 <br />
                 <span className="text-muted-foreground">
-                  {profile.prepYatra.goal || "Not specified"}
+                  {formatGoalTimelineLabel(profile.prepYatra.goal) ||
+                    "Not specified"}
                 </span>
               </div>
             </div>

--- a/packages/utils/src/onboarding.ts
+++ b/packages/utils/src/onboarding.ts
@@ -8,6 +8,29 @@ import { sendRequest } from "./api";
  * Pass `apiBaseUrl` in Vite or non-Next clients so `sendRequest` hits the API directly.
  */
 
+// Prep-yatra's "goal" has been stored in a few different raw formats over time
+// (e.g. "6_months", "6Months"), so map the known ones explicitly and fall back
+// to a generic humanization for anything else.
+const GOAL_TIMELINE_LABELS: Record<string, string> = {
+  "3_months": "3 Months",
+  "6_months": "6 Months",
+  "1_year": "1 Year",
+  "3Months": "3 Months",
+  "6Months": "6 Months",
+  "1Year": "1 Year",
+};
+
+export function formatGoalTimelineLabel(goal?: string | null): string {
+  if (!goal) return "";
+  if (GOAL_TIMELINE_LABELS[goal]) return GOAL_TIMELINE_LABELS[goal];
+
+  return goal
+    .replace(/_/g, " ")
+    .replace(/([0-9])([A-Za-z])/g, "$1 $2")
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+    .trim();
+}
+
 export async function checkUsernameAvailable(
   username: string,
   token?: string,


### PR DESCRIPTION
## What does this PR do?

Fixes the "Goal" display on Prep Yatra profile pages so it shows a human-readable label (e.g. "6 Months") instead of the raw stored value (e.g. "6_months").

## Why?

Fixes #1040 — the `prepYatra.goal` field is stored in a raw internal format (`3_months`, `6_months`, `1_year`, or in some flows `3Months`/`6Months`/`1Year`), but two display locations rendered that raw value directly to users instead of mapping it to a label:

- `packages/components/src/prepyatra/dashboard/ProfileSection.tsx` (dashboard "Goal" badge)
- `packages/components/src/prepyatra/pages/PrepYatraPublicJourneyPage.tsx` (public `/journey/[username]` page)

Added a shared `formatGoalTimelineLabel` helper in `packages/utils/src/onboarding.ts` that maps the known raw formats to their labels and falls back to a generic humanized format (underscore → space, digit/letter split, capitalized) for any other value, so the underscore never leaks through to the UI.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 Refactor / cleanup (no functional change)
- [x] 🎨 UI / styling change
- [ ] 🔌 API change (new or modified endpoints, request/response shape changes)
- [ ] 📦 Dependency update
- [ ] 📝 Documentation only

---

## Testing

### Does this PR include tests?

- [ ] Yes — unit tests
- [ ] Yes — integration / e2e tests
- [x] No — here's why: small display formatting fix; verified the mapping logic manually against all known raw value formats (`3_months`, `6_months`, `1_year`, `3Months`, `6Months`, `1Year`) and confirmed correct output, plus ran `tsc --noEmit` on the `@tbe/components` package with no new errors.

### How to test manually

1. Complete Prep Yatra onboarding (or seed a user) with `prepYatra.goal` set to `6_months`.
2. Visit the Prep Yatra dashboard profile section — the "Goal" badge should read "6 Months", not "6_months".
3. Visit the public journey page at `/journey/[username]` for that user — the "Goal" field should also read "6 Months".

---

## Checklist

- [x] I've tested this locally and it works as expected
- [ ] I've checked for console errors / warnings
- [x] No unrelated changes snuck in
- [ ] If UI change — tested on mobile viewport too
- [ ] If API change — backward compatible or migration plan noted above


---
_Generated by [Claude Code](https://claude.ai/code/session_01RGp8rhiHCsebWVpEQ7X78r)_