### PR TITLE
fix(services): prevent 304 empty-body failures on cached API GETs

### DIFF
--- a/apps/testing/src/unit/services/base.test.ts
+++ b/apps/testing/src/unit/services/base.test.ts
@@ -70,6 +70,20 @@ describe("APIClient (base)", () => {
     expect(h.get("Content-Type")).toBe("application/json");
   });
 
+  it("uses cache: no-store on GET to avoid 304 empty-body failures", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      ) as unknown as typeof fetch;
+
+    const client = new APIClient("http://api.test");
+    await client.get("gamification", { params: { userId: "123" } });
+
+    const init = vi.mocked(globalThis.fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.cache).toBe("no-store");
+  });
+
   it("returns JSON body on success", async () => {
     const payload = { id: "q1", name: "Quiz" };
     globalThis.fetch = vi

--- a/packages/services/src/base.ts
+++ b/packages/services/src/base.ts
@@ -107,6 +107,7 @@ export class APIClient {
 
     const response = await fetch(url, {
       method: "GET",
+      cache: "no-store",
       headers: {
         ...this.getAuthHeaders(),
         ...requestOptions.headers,
@@ -124,6 +125,7 @@ export class APIClient {
   ): Promise<T> {
     const response = await fetch(this.buildURL(endpoint), {
       method: "POST",
+      cache: "no-store",
       headers: {
         ...this.getAuthHeaders(),
         ...options.headers,
@@ -142,6 +144,7 @@ export class APIClient {
   ): Promise<T> {
     const response = await fetch(this.buildURL(endpoint), {
       method: "PUT",
+      cache: "no-store",
       headers: {
         ...this.getAuthHeaders(),
         ...options.headers,
@@ -156,6 +159,7 @@ export class APIClient {
   async delete<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
     const response = await fetch(this.buildURL(endpoint), {
       method: "DELETE",
+      cache: "no-store",
       headers: {
         ...this.getAuthHeaders(),
         ...options.headers,


### PR DESCRIPTION
## Summary

- Fixes gamification (and other `@tbe/services` APIClient) GET failures in production when the browser revalidates with `if-none-match` and Vercel returns **304 Not Modified** with an empty body.
- Adds `cache: "no-store"` to all `APIClient` fetch calls so the browser HTTP cache does not intercept requests — React Query continues to handle app-level caching.
- Adds a unit test asserting GET requests use `cache: "no-store"`.

**Root cause:** `/api/v1/gamification?userId=…` on dsayatra worked on first load (200 + JSON) but failed on refetch when the browser sent `if-none-match: "…"`. `APIClient.handleResponse` treats 304 as non-OK and throws because there is no JSON body to parse.

## Test plan

- [x] `pnpm exec vitest run src/unit/services/base.test.ts` (7 tests pass)
- [ ] Deploy to preview / prod and verify dsayatra gamification points load after hard refresh + navigation back to sheets
- [ ] Confirm Network tab no longer shows failed gamification GET after cached 304


Made with [Cursor](https://cursor.com)