### PR TITLE
fix(unskilled): add fallback and user-friendly errors for resume evaluation

### DIFF
--- a/apps/testing/src/unit/services/resumeService.test.ts
+++ b/apps/testing/src/unit/services/resumeService.test.ts
@@ -7,6 +7,7 @@ vi.mock("@tbe/constants", async (importOriginal) => {
     envConfig: {
       ...actual.envConfig,
       UNSKILLED_API_URL: "https://unskilled.test.com",
+      API_URL: "https://api.test.com",
     },
   };
 });
@@ -19,6 +20,7 @@ describe("resumeEvaluationService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -28,8 +30,9 @@ describe("resumeEvaluationService", () => {
   describe("evaluateResume", () => {
     it("returns evaluation on success", async () => {
       const mockResponse = {
-        score: 85,
-        feedback: ["Good experience"],
+        status: true,
+        message: "OK",
+        data: { resumeScore: 85 },
       };
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
         ok: true,
@@ -38,20 +41,17 @@ describe("resumeEvaluationService", () => {
       });
 
       const result = await resumeEvaluationService.evaluateResume({
-        resume: "resume text",
-        jobDescription: "job desc",
+        resumeSkills: ["javascript"],
+        domains: ["Backend Development"],
+        experienceLevel: "Fresher (0 yrs)",
       });
 
       expect(global.fetch).toHaveBeenCalledWith(
         "https://unskilled.test.com/resume/evaluate",
-        {
+        expect.objectContaining({
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            resume: "resume text",
-            jobDescription: "job desc",
-          }),
-        },
+        }),
       );
       expect(result).toEqual(mockResponse);
     });
@@ -67,8 +67,9 @@ describe("resumeEvaluationService", () => {
 
       await expect(
         resumeEvaluationService.evaluateResume({
-          resume: "resume",
-          jobDescription: "job",
+          resumeSkills: ["js"],
+          domains: ["Backend Development"],
+          experienceLevel: "Fresher (0 yrs)",
         }),
       ).rejects.toThrow(`Server returned 500: ${longText.substring(0, 200)}`);
     });
@@ -83,8 +84,9 @@ describe("resumeEvaluationService", () => {
 
       await expect(
         resumeEvaluationService.evaluateResume({
-          resume: "resume",
-          jobDescription: "job",
+          resumeSkills: ["js"],
+          domains: ["Backend Development"],
+          experienceLevel: "Fresher (0 yrs)",
         }),
       ).rejects.toThrow("Invalid resume format");
     });
@@ -99,23 +101,75 @@ describe("resumeEvaluationService", () => {
 
       await expect(
         resumeEvaluationService.evaluateResume({
-          resume: "resume",
-          jobDescription: "job",
+          resumeSkills: ["js"],
+          domains: ["Backend Development"],
+          experienceLevel: "Fresher (0 yrs)",
         }),
       ).rejects.toThrow("Failed to evaluate resume");
     });
 
-    it("throws on network error", async () => {
+    it("falls back to internal API on network error", async () => {
+      const internalResponse = {
+        status: true,
+        message: "Resume evaluation successfully",
+        data: {
+          matchedSkills: [
+            { skill: "javascript", frequency: 10, percentage: 50 },
+          ],
+          missingSkills: [
+            { skill: "typescript", frequency: 8, percentage: 40 },
+          ],
+          resumeScore: 60,
+          totalJobsAnalyzed: 20,
+          companyTypeDistribution: [
+            { name: "Startup", count: 5, percentage: 25 },
+          ],
+          remoteJobs: 3,
+        },
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => internalResponse,
+        });
+
+      const result = await resumeEvaluationService.evaluateResume({
+        resumeSkills: ["javascript"],
+        domains: ["Backend Development"],
+        experienceLevel: "Fresher (0 yrs)",
+      });
+
+      expect(result.status).toBe(true);
+      expect(result.data.resumeScore).toBe(60);
+      expect(result.data.skillsMatched).toBe(1);
+      expect(result.data.skillsMissing).toBe(1);
+      expect(result.data.matchingSkills[0].jobCount).toBe(10);
+      expect(result.data.companyTypeDistribution[0].type).toBe("Startup");
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        "https://api.test.com/v1/unskilled/evaluation",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("shows user-friendly message when both services fail with network error", async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
-        new Error("Network error"),
+        new TypeError("Failed to fetch"),
       );
 
       await expect(
         resumeEvaluationService.evaluateResume({
-          resume: "resume",
-          jobDescription: "job",
+          resumeSkills: ["js"],
+          domains: ["Backend Development"],
+          experienceLevel: "Fresher (0 yrs)",
         }),
-      ).rejects.toThrow("Network error");
+      ).rejects.toThrow(
+        "Unable to reach the evaluation service. Please check your internet connection and try again.",
+      );
     });
   });
 
@@ -135,6 +189,7 @@ describe("resumeEvaluationService", () => {
 
       expect(global.fetch).toHaveBeenCalledWith(
         "https://unskilled.test.com/evaluate/health",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
       );
       expect(result).toEqual(mockHealth);
     });
@@ -149,13 +204,13 @@ describe("resumeEvaluationService", () => {
       );
     });
 
-    it("throws on network error", async () => {
+    it("throws user-friendly message on network error", async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
-        new Error("Connection refused"),
+        new TypeError("Failed to fetch"),
       );
 
       await expect(resumeEvaluationService.checkHealth()).rejects.toThrow(
-        "Connection refused",
+        "Evaluation service is temporarily unavailable.",
       );
     });
   });

--- a/packages/hooks/src/useUnskilledGraphData.ts
+++ b/packages/hooks/src/useUnskilledGraphData.ts
@@ -6,12 +6,36 @@ const useUnskilledGraphData = () => {
   const { data, isLoading, error } = useQuery<any>({
     queryKey: ["unskilled", "graph"],
     queryFn: async () => {
-      const response = await fetch(`${UNSKILLED_API_URL}/graph`);
-      if (!response.ok) throw new Error("Failed to fetch graph data");
-      return response.json();
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 15_000);
+      try {
+        const response = await fetch(`${UNSKILLED_API_URL}/graph`, {
+          signal: controller.signal,
+        });
+        if (!response.ok) throw new Error("Failed to fetch graph data");
+        return response.json();
+      } catch (error) {
+        if (
+          error instanceof TypeError &&
+          /failed to fetch/i.test(error.message)
+        ) {
+          throw new Error(
+            "Unable to load market insights. Please try again later.",
+          );
+        }
+        if (error instanceof DOMException && error.name === "AbortError") {
+          throw new Error(
+            "Market insights request timed out. Please try again later.",
+          );
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeoutId);
+      }
     },
     ...CACHE_TIMES.STATIC,
     enabled: !!UNSKILLED_API_URL,
+    retry: 1,
   });
 
   return {

--- a/packages/services/src/resumeService.ts
+++ b/packages/services/src/resumeService.ts
@@ -1,70 +1,177 @@
 /**
  * Resume Evaluation Service
  * Handles API calls to Unskilled backend for resume evaluation
- * Follows same pattern as graph API calls
+ * Falls back to internal TBE API when the external service is unreachable
  */
 
-import { envConfig } from "@tbe/constants";
+import { envConfig, JOB_EXPERIENCE_LEVEL } from "@tbe/constants";
 import type {
   ResumeEvaluationRequest,
   ResumeEvaluationResponse,
 } from "@tbe/types";
 
-/**
- * Evaluate resume against job market
- * Calls Unskilled backend directly (like graph API)
- */
+const EVALUATION_TIMEOUT_MS = 30_000;
+
+const isNetworkError = (error: unknown): boolean =>
+  error instanceof TypeError && /failed to fetch/i.test(error.message);
+
+const mapExperienceLevel = (level: string): { min: number; max: number } => {
+  const match = JOB_EXPERIENCE_LEVEL.find((e) => e.value === level);
+  return match ? { min: match.min, max: match.max } : { min: 0, max: 1 };
+};
+
+const evaluateViaExternalApi = async (
+  payload: ResumeEvaluationRequest,
+  signal: AbortSignal,
+): Promise<ResumeEvaluationResponse> => {
+  const apiUrl = `${envConfig.UNSKILLED_API_URL}/resume/evaluate`;
+
+  const response = await fetch(apiUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    signal,
+  });
+
+  const contentType = response.headers.get("content-type");
+  if (!contentType || !contentType.includes("application/json")) {
+    const textResponse = await response.text();
+    throw new Error(
+      `Server returned ${response.status}: ${textResponse.substring(0, 200)}`,
+    );
+  }
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.detail || "Failed to evaluate resume");
+  }
+
+  return await response.json();
+};
+
+const evaluateViaInternalApi = async (
+  payload: ResumeEvaluationRequest,
+  signal: AbortSignal,
+): Promise<ResumeEvaluationResponse> => {
+  const apiUrl = `${envConfig.API_URL}/v1/unskilled/evaluation`;
+  const experience = mapExperienceLevel(payload.experienceLevel);
+
+  const response = await fetch(apiUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      skills: payload.resumeSkills,
+      domains: payload.domains,
+      experience,
+    }),
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error((errorData as any).message || "Failed to evaluate resume");
+  }
+
+  const result = await response.json();
+  const d = result.data;
+
+  return {
+    status: true,
+    message: result.message || "Resume evaluation successfully",
+    data: {
+      resumeScore: d.resumeScore,
+      skillsMatched: d.matchedSkills?.length ?? 0,
+      skillsMissing: d.missingSkills?.length ?? 0,
+      remoteJobs: d.remoteJobs ?? 0,
+      jobsAnalyzed: d.totalJobsAnalyzed ?? 0,
+      matchingSkills: (d.matchedSkills ?? []).map(
+        (s: { skill: string; percentage: number; frequency: number }) => ({
+          skill: s.skill,
+          percentage: s.percentage,
+          jobCount: s.frequency,
+        }),
+      ),
+      missingSkills: (d.missingSkills ?? []).map(
+        (s: { skill: string; percentage: number; frequency: number }) => ({
+          skill: s.skill,
+          percentage: s.percentage,
+          jobCount: s.frequency,
+        }),
+      ),
+      companyTypeDistribution: (d.companyTypeDistribution ?? []).map(
+        (c: { name: string; count: number; percentage: number }) => ({
+          type: c.name,
+          percentage: c.percentage,
+          jobCount: c.count,
+        }),
+      ),
+    },
+  };
+};
+
 export const evaluateResume = async (
   payload: ResumeEvaluationRequest,
 ): Promise<ResumeEvaluationResponse> => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), EVALUATION_TIMEOUT_MS);
+
   try {
-    const apiUrl = `${envConfig.UNSKILLED_API_URL}/resume/evaluate`;
+    if (envConfig.UNSKILLED_API_URL) {
+      try {
+        return await evaluateViaExternalApi(payload, controller.signal);
+      } catch (externalError) {
+        if (
+          isNetworkError(externalError) ||
+          (externalError instanceof DOMException &&
+            externalError.name === "AbortError")
+        ) {
+          console.warn(
+            "External evaluation service unreachable, falling back to internal API",
+          );
+        } else {
+          throw externalError;
+        }
+      }
+    }
 
-    const response = await fetch(apiUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(payload),
-    });
+    if (envConfig.API_URL) {
+      return await evaluateViaInternalApi(payload, controller.signal);
+    }
 
-    console.log("Response status:", response.status);
-    console.log("Response headers:", response.headers);
-
-    // Check content type before parsing
-    const contentType = response.headers.get("content-type");
-    if (!contentType || !contentType.includes("application/json")) {
-      const textResponse = await response.text();
-      console.error("Non-JSON response:", textResponse);
+    throw new Error(
+      "Resume evaluation service is temporarily unavailable. Please try again later.",
+    );
+  } catch (error: any) {
+    if (isNetworkError(error)) {
       throw new Error(
-        `Server returned ${response.status}: ${textResponse.substring(0, 200)}`,
+        "Unable to reach the evaluation service. Please check your internet connection and try again.",
       );
     }
-
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.detail || "Failed to evaluate resume");
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new Error("Evaluation request timed out. Please try again later.");
     }
-
-    const result: ResumeEvaluationResponse = await response.json();
-    return result;
-  } catch (error: any) {
-    console.error("Error evaluating resume:", error);
     throw error;
+  } finally {
+    clearTimeout(timeoutId);
   }
 };
 
-/**
- * Check resume evaluation service health
- */
 export const checkResumeServiceHealth = async (): Promise<{
   status: boolean;
   message: string;
   jobsAvailable: number;
 }> => {
+  if (!envConfig.UNSKILLED_API_URL) {
+    throw new Error("Service health check not available");
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10_000);
+
   try {
     const response = await fetch(
       `${envConfig.UNSKILLED_API_URL}/evaluate/health`,
+      { signal: controller.signal },
     );
 
     if (!response.ok) {
@@ -73,8 +180,12 @@ export const checkResumeServiceHealth = async (): Promise<{
 
     return await response.json();
   } catch (error: any) {
-    console.error("Error checking service health:", error);
+    if (isNetworkError(error)) {
+      throw new Error("Evaluation service is temporarily unavailable.");
+    }
     throw error;
+  } finally {
+    clearTimeout(timeoutId);
   }
 };
 


### PR DESCRIPTION
## Summary

Fixes #1048 — Resume evaluation fails with raw "Failed to fetch" error exposing internal Cloud Run hostname to users.

**What changed:**

- **Internal API fallback**: When the external Cloud Run service (`unskilled-*.run.app`) is unreachable, evaluation now transparently retries via the existing TBE API endpoint (`/api/v1/unskilled/evaluation`) which queries MongoDB directly — no external dependency needed
- **Request timeouts**: Added 30s timeout on evaluation, 15s on graph data, 10s on health check via `AbortController` — users no longer wait indefinitely
- **User-friendly error messages**: Network errors and timeouts now show actionable messages ("Unable to reach the evaluation service. Please check your internet connection and try again.") instead of leaking infrastructure details like `Failed to fetch (unskilled-183084025505.asia-south2.run.app)`
- **Graph data resilience**: Added timeout, retry(1), and friendly error messages to the `useUnskilledGraphData` hook

**Files changed:**
- `packages/services/src/resumeService.ts` — core fix: fallback logic + timeout + error handling
- `packages/hooks/src/useUnskilledGraphData.ts` — timeout + error handling for graph data
- `apps/testing/src/unit/services/resumeService.test.ts` — updated + 3 new tests covering fallback and error scenarios

## Test plan

- [x] All 9 unit tests pass (6 updated + 3 new: fallback, user-friendly errors, health check errors)
- [x] Full test suite passes (200 files, 1609 tests)
- [x] TypeScript type check passes
- [x] ESLint + Prettier pass via pre-commit hooks

cc @codingpratham — this addresses the issue you reported! Would love your review 🙏

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6Qsw3mWEZRxUvkUkQXzxY)_