### PR TITLE
Cloud Agent dev environment setup (blocked on npm registry egress)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Turborepo + **pnpm 10** monorepo (`packageManager: pnpm@10.30.3`, Node `>=20`). All standard
+commands live in the root `package.json` scripts and `README.md`; prefer those over duplicating here.
+
+### Network egress requirement (important, non-obvious)
+
+Dependency installation requires outbound HTTPS to the npm registry, which is **not** on the default
+Cloud Agent egress allowlist. If `pnpm install` fails with `ECONNRESET` / `ERR_PNPM_META_FETCH_FAIL`,
+the network — not the repo — is the problem. Ask the user to allow these hosts in
+**Cloud Agent → Network Access**:
+
+- `registry.npmjs.org` — **required** (all JS deps; also how corepack fetches the pinned pnpm)
+- `objects.githubusercontent.com` — GitHub release assets (prebuilt native binaries, e.g. `sharp`)
+- `cdn.playwright.dev` (a.k.a. `playwright.azureedge.net`) — Playwright Chromium download run by
+  `apps/testing`'s `postinstall`; needed for E2E (`pnpm test:e2e`)
+- `fastdl.mongodb.org` — `mongodb-memory-server` binary used by unit/API tests in `apps/testing`
+
+`pnpm` itself is installed via corepack using the pinned version, so `registry.npmjs.org` also
+unblocks pnpm. Use `corepack enable && corepack prepare pnpm@10.30.3 --activate` before `pnpm install`.
+
+### Services
+
+One central backend serves all frontends:
+
+- **`@tbe/api`** (port **3004**, `pnpm dev:api`) — Next.js API under `/api/v1/`, backed by MongoDB
+  (Mongoose). **Every frontend depends on it** for auth (JWT + Google OAuth) and data.
+- Frontends (start the one you're testing): `@tbe/platform` 3000, `@tbe/prep-yatra` 3001,
+  `@tbe/quizes` 3002, `@tbe/techyatra` 3003, `@tbe/dsayatra` 3005, `@tbe/resume-yatra` 3006,
+  `@tbe/oncampus` 3007, `@tbe/admin` 3008 (Vite), `@tbe/resources` 3010, `@tbe/onboarding` (Vite).
+- Each app needs its own env file: copy the app's committed `.env.example` to `.env.local`.
+  Frontends need at minimum `NEXT_PUBLIC_API_URL=http://localhost:3004/api/v1`; the API needs
+  `MONGODB_URI`, `NEXTAUTH_SECRET` (or `AUTH_JWT_SECRET`), and `ADMIN_SECRET`.
+
+### Gotchas
+
+- **MongoDB**: the API needs a running MongoDB (default `mongodb://localhost:27017/tbe-platform`).
+  There is no in-repo `docker-compose`; provide MongoDB yourself (local `mongod`, Docker, or Atlas).
+  Tests do **not** need it — `apps/testing` uses `mongodb-memory-server`.
+- **Onboarding port**: `README.md` says onboarding is on 3003, but it is a Vite app with no port
+  override, so it actually runs on Vite's default **5173**. Port 3003 is used by `techyatra`.
+- **Tests live only in `apps/testing`**: `pnpm test` (all), `pnpm test:unit`, `pnpm test:api`,
+  `pnpm test:e2e`, `pnpm test:coverage`. Quality gate: `pnpm quality:check`
+  (lint + format:check + check-types). `pnpm build` runs with `--concurrency=1` (memory-heavy).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for the TBE-Web Turborepo monorepo (pnpm 10, Node 20+).

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the network egress requirement, services/ports, and non-obvious gotchas (MongoDB requirement, onboarding port discrepancy, where tests live).
- Proposes an update script (`corepack enable` → `corepack prepare pnpm@10.30.3 --activate` → `pnpm install --frozen-lockfile`).

## Blocker

Dependency installation is currently **blocked by the Cloud Agent network egress allowlist**. Only `github.com` / `api.github.com` are reachable; `registry.npmjs.org` (and all mirrors, the GitHub release asset CDN, PyPI, and Debian) are reset during the TLS handshake. Because this is a pnpm monorepo, `pnpm install` cannot fetch any packages, so dependencies could not be installed and the apps/tests could not be run or validated in this session.

To unblock, allow these hosts in **Cloud Agent → Network Access**:

- `registry.npmjs.org` — required (all JS deps; also how corepack fetches pnpm)
- `objects.githubusercontent.com` — GitHub release assets (prebuilt native binaries, e.g. `sharp`)
- `cdn.playwright.dev` — Playwright Chromium download for E2E tests
- `fastdl.mongodb.org` — `mongodb-memory-server` binary for unit/API tests

Note: the API also needs a running MongoDB (no in-repo docker-compose).

## Verification

Not yet possible — install/build/run/test are all blocked on the egress issue above. Once the registry is allowlisted, the update script will install dependencies and the standard `pnpm dev:*`, `pnpm lint`, and `pnpm test` commands can be validated.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-225aa00d-b0d0-4e8b-89f4-24a712c40390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-225aa00d-b0d0-4e8b-89f4-24a712c40390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

