### PR TITLE
fix: add empty-string guards to all name.split() usages

### DIFF
--- a/apps/api/src/pages/api/v1/prepyatra/prep-log/index.ts
+++ b/apps/api/src/pages/api/v1/prepyatra/prep-log/index.ts
@@ -229,7 +229,7 @@ const handleAddMentorFeedback = async (
           to_name: userName,
           subject: "I have some feedback for your Prep Yatra 🚀",
           html_content:
-            `<p>Hi ${userName.split(" ")[0]},</p>` +
+            `<p>Hi ${userName.trim().split(" ").filter(Boolean)[0] || "there"},</p>` +
             `<p>I reviewed your recent Prep Yatra logs. Here's my feedback to help you level up this week:</p>` +
             `<blockquote style="margin:12px 0;padding:12px;border-left:4px solid #6b46c1;background:#faf7ff;">${
               mentorFeedback

--- a/apps/api/src/pages/api/v1/revenue/transparency.ts
+++ b/apps/api/src/pages/api/v1/revenue/transparency.ts
@@ -118,12 +118,14 @@ const handleGetRevenueData = async (
       date: payment.date,
       type: payment.type,
       // Anonymize user data for privacy
-      userInitials: payment.user?.name
+      userInitials: payment.user?.name?.trim()
         ? payment.user.name
+            .trim()
             .split(" ")
+            .filter(Boolean)
             .map((n: string) => n[0])
             .join("")
-            .toUpperCase()
+            .toUpperCase() || "U"
         : "U",
     }));
 

--- a/apps/dsayatra/src/pages/dashboard.tsx
+++ b/apps/dsayatra/src/pages/dashboard.tsx
@@ -132,7 +132,9 @@ const DsaClient = () => {
                     ) : (
                       <div className="flex size-full items-center justify-center bg-gradient-to-br from-[#ff5757] to-[#cc4444] text-2xl font-black text-white sm:text-3xl">
                         {user?.name
-                          ?.split(" ")
+                          ?.trim()
+                          .split(" ")
+                          .filter(Boolean)
                           .map((n) => n[0])
                           .join("") || "SJ"}
                       </div>

--- a/apps/quizes/src/pages/dashboard/index.tsx
+++ b/apps/quizes/src/pages/dashboard/index.tsx
@@ -72,7 +72,7 @@ function DashboardContent() {
           {/* Welcome Header */}
           <div className="text-center mb-12">
             <h1 className="text-4xl font-bold text-gray-900 mb-4">
-              Welcome back, {user?.name?.split(" ")[0]}! 👋
+              Welcome back, {user?.name?.trim().split(" ").filter(Boolean)[0] || "there"}! 👋
             </h1>
             <p className="text-xl text-gray-600">
               Ready to test your knowledge? Choose a quiz below to get started.

--- a/apps/quizes/src/pages/dashboard/leaderboard/index.tsx
+++ b/apps/quizes/src/pages/dashboard/leaderboard/index.tsx
@@ -84,12 +84,16 @@ function LeaderboardEntry({
   onViewProfile,
 }: LeaderboardEntryProps) {
   const getInitials = (name: string) => {
-    return name
-      .split(" ")
-      .map((n) => n[0])
-      .join("")
-      .toUpperCase()
-      .slice(0, 2);
+    return (
+      name
+        .trim()
+        .split(" ")
+        .filter(Boolean)
+        .map((n) => n[0])
+        .join("")
+        .toUpperCase()
+        .slice(0, 2) || "U"
+    );
   };
 
   const formatTime = (seconds: number) => {
@@ -179,12 +183,16 @@ function UserProfileModal({ profile, isOpen, onClose }: UserProfileModalProps) {
   if (!isOpen || !profile) return null;
 
   const getInitials = (name: string) => {
-    return name
-      .split(" ")
-      .map((n) => n[0])
-      .join("")
-      .toUpperCase()
-      .slice(0, 2);
+    return (
+      name
+        .trim()
+        .split(" ")
+        .filter(Boolean)
+        .map((n) => n[0])
+        .join("")
+        .toUpperCase()
+        .slice(0, 2) || "U"
+    );
   };
 
   return (

--- a/packages/components/src/prepyatra/dashboard/ProfileSection.tsx
+++ b/packages/components/src/prepyatra/dashboard/ProfileSection.tsx
@@ -60,12 +60,16 @@ const withProtocol = (url: string) => {
 
 /** ✅ Safe initials fallback */
 const getInitials = (name?: string) => {
-  if (!name) return "NA";
-  return name
-    .split(" ")
-    .map((part) => part[0])
-    .join("")
-    .toUpperCase();
+  if (!name?.trim()) return "NA";
+  return (
+    name
+      .trim()
+      .split(" ")
+      .filter(Boolean)
+      .map((part) => part[0])
+      .join("")
+      .toUpperCase() || "NA"
+  );
 };
 
 const ProfileSection: React.FC<ProfileSectionProps> = ({

--- a/packages/components/src/quizes/layout/DashboardNav.tsx
+++ b/packages/components/src/quizes/layout/DashboardNav.tsx
@@ -35,12 +35,16 @@ export function DashboardNav() {
   };
 
   const getInitials = (name: string) => {
-    return name
-      .split(" ")
-      .map((n) => n[0])
-      .join("")
-      .toUpperCase()
-      .slice(0, 2);
+    return (
+      name
+        .trim()
+        .split(" ")
+        .filter(Boolean)
+        .map((n) => n[0])
+        .join("")
+        .toUpperCase()
+        .slice(0, 2) || "U"
+    );
   };
 
   return (


### PR DESCRIPTION
## What does this PR do?

Adds `trim().split(" ").filter(Boolean)` guards with appropriate fallbacks to **all 8 locations** in the codebase where `name.split(" ")` is used without handling empty, whitespace-only, or multi-space names.

This is a comprehensive fix that extends beyond the 2 files reported in #1015 to cover 6 additional locations with the same vulnerability.

## Why?

Closes #1015. When a user's name is empty, whitespace-only (e.g. `"   "`), or contains consecutive spaces (e.g. `"John  Doe"`):

- **Email greetings** render as `"Hi ,"` instead of `"Hi there,"`
- **User initials** produce `undefined` coercion (displaying `"JundefinedD"`) or empty strings instead of a proper fallback like `"U"`

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Files Changed (8 locations across 7 files)

| File | Fix |
|------|-----|
| `apps/api/.../prepyatra/prep-log/index.ts` | Email greeting falls back to `"there"` |
| `apps/api/.../revenue/transparency.ts` | Initials fall back to `"U"` |
| `apps/quizes/.../dashboard/index.tsx` | Welcome greeting falls back to `"there"` |
| `apps/quizes/.../leaderboard/index.tsx` (×2) | Both `getInitials` functions fall back to `"U"` |
| `apps/dsayatra/.../dashboard.tsx` | Initials chain uses `.filter(Boolean)` |
| `packages/components/.../ProfileSection.tsx` | `getInitials` guards empty/whitespace names |
| `packages/components/.../DashboardNav.tsx` | `getInitials` falls back to `"U"` |

## Testing

### Does this PR include tests?

- [ ] No — these are straightforward string-processing guards with no existing test infrastructure for the affected code paths.

### How to test manually

1. Set a user's name to an empty string, whitespace-only (`"   "`), or multi-space name (`"John  Doe"`)
2. Trigger the PrepYatra feedback email → greeting should say `"Hi there,"` not `"Hi ,"`
3. Visit the revenue transparency page → initials should show `"U"` not blank
4. Visit quiz dashboard → welcome should say `"Welcome back, there!"` not `"Welcome back, !"`
5. Check leaderboard entries → initials should show `"U"` not blank/corrupted text
6. Verify normal names (e.g. `"John Doe"`) still display correctly (`"JD"`, `"John"`, etc.)

## Checklist

- [x] I've tested this locally and it works as expected
- [x] I've checked for console errors / warnings
- [x] No unrelated changes snuck in
- [x] If API change — backward compatible or migration plan noted above

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwagCwGeJ2BkAPG4VnHw76)_