### PR TITLE
refactor(analytics): standardize GA event names to UPPERCASE

### DIFF
--- a/apps/testing/src/unit/api/ga4Transforms.test.ts
+++ b/apps/testing/src/unit/api/ga4Transforms.test.ts
@@ -89,14 +89,14 @@ describe("ga4Transforms", () => {
         rows: [
           {
             dimensionValues: [
-              { value: "signup_success" },
+              { value: "SIGNUP_SUCCESS" },
               { value: "20260701" },
             ],
             metricValues: [{ value: "100" }],
           },
           {
             dimensionValues: [
-              { value: "user_activated" },
+              { value: "USER_ACTIVATED" },
               { value: "20260701" },
             ],
             metricValues: [{ value: "40" }],

--- a/apps/testing/src/unit/constants/analyticsEvents.test.ts
+++ b/apps/testing/src/unit/constants/analyticsEvents.test.ts
@@ -12,11 +12,11 @@ describe("ANALYTICS_EVENTS registry", () => {
   });
 
   it("uses snake_case for modern events", () => {
-    expect(ANALYTICS_EVENTS.LOGIN_SUCCESS).toBe("login_success");
-    expect(ANALYTICS_EVENTS.USER_ACTIVATED).toBe("user_activated");
-    expect(ANALYTICS_EVENTS.DSA_QUESTION_VIEW).toBe("dsa_question_view");
+    expect(ANALYTICS_EVENTS.LOGIN_SUCCESS).toBe("LOGIN_SUCCESS");
+    expect(ANALYTICS_EVENTS.USER_ACTIVATED).toBe("USER_ACTIVATED");
+    expect(ANALYTICS_EVENTS.DSA_QUESTION_VIEW).toBe("DSA_QUESTION_VIEW");
     expect(ANALYTICS_EVENTS.RESUME_BUILDER_COMPLETE).toBe(
-      "resume_builder_complete",
+      "RESUME_BUILDER_COMPLETE",
     );
   });
 

--- a/apps/testing/src/unit/services/challenges.test.ts
+++ b/apps/testing/src/unit/services/challenges.test.ts
@@ -92,7 +92,7 @@ describe("challengesService", () => {
       const result = await challengesService.create(createData);
 
       expect(result).toEqual(mockData);
-      expect(mockTrackEvent).toHaveBeenCalledWith("challenge_create", {
+      expect(mockTrackEvent).toHaveBeenCalledWith("CHALLENGE_CREATE", {
         category: "challenge",
         value: 30,
         challengeName: "New Challenge",
@@ -202,7 +202,7 @@ describe("challengesService", () => {
         totalDays: 60,
       });
 
-      expect(mockTrackEvent).toHaveBeenCalledWith("challenge_update", {
+      expect(mockTrackEvent).toHaveBeenCalledWith("CHALLENGE_UPDATE", {
         category: "challenge",
         challengeId: "ch-1",
         updatedFields: ["name", "totalDays"],
@@ -223,7 +223,7 @@ describe("challengesService", () => {
         "https://api.test.com/v1/prepyatra/challenges/ch-1",
         { method: "DELETE", headers: { "Content-Type": "application/json" } },
       );
-      expect(mockTrackEvent).toHaveBeenCalledWith("challenge_delete", {
+      expect(mockTrackEvent).toHaveBeenCalledWith("CHALLENGE_DELETE", {
         category: "challenge",
         challengeId: "ch-1",
       });
@@ -281,7 +281,7 @@ describe("challengesService", () => {
       const result = await challengesService.createLog(createData);
 
       expect(result).toEqual(mockLog);
-      expect(mockTrackEvent).toHaveBeenCalledWith("challenge_log_create", {
+      expect(mockTrackEvent).toHaveBeenCalledWith("CHALLENGE_LOG_CREATE", {
         category: "challenge",
         challengeId: "ch-1",
         day: 1,

--- a/apps/testing/src/unit/services/prep-logs.test.ts
+++ b/apps/testing/src/unit/services/prep-logs.test.ts
@@ -67,7 +67,7 @@ describe("prepLogsService", () => {
     });
     expect(out).toEqual(created);
     expect(mockTrackEvent).toHaveBeenCalledWith(
-      "prep_log_create",
+      "PREP_LOG_CREATE",
       expect.objectContaining({ category: "prep_log" }),
     );
   });
@@ -83,7 +83,7 @@ describe("prepLogsService", () => {
     const out = await prepLogsService.update({ prepLogId: "1", title: "X" });
     expect(out).toEqual(updated);
     expect(mockTrackEvent).toHaveBeenCalledWith(
-      "prep_log_update",
+      "PREP_LOG_UPDATE",
       expect.anything(),
     );
   });
@@ -101,7 +101,7 @@ describe("prepLogsService", () => {
       expect.objectContaining({ method: "DELETE" }),
     );
     expect(mockTrackEvent).toHaveBeenCalledWith(
-      "prep_log_delete",
+      "PREP_LOG_DELETE",
       expect.anything(),
     );
   });

--- a/apps/testing/src/unit/utils/analytics.test.ts
+++ b/apps/testing/src/unit/utils/analytics.test.ts
@@ -98,7 +98,7 @@ describe("Analytics Utilities", () => {
 
       expect(mockGtag).toHaveBeenCalledWith(
         "event",
-        "ui_click",
+        "UI_CLICK",
         expect.objectContaining({
           click_label: "Start",
           element_id: "hero-cta",
@@ -144,7 +144,7 @@ describe("Analytics Utilities", () => {
 
       expect(mockGtag).toHaveBeenCalledWith(
         "event",
-        "quiz_start",
+        "QUIZ_START",
         expect.objectContaining({
           quiz_id: "quiz-123",
           app_id: "test-suite-app",
@@ -158,7 +158,7 @@ describe("Analytics Utilities", () => {
 
       expect(mockGtag).toHaveBeenCalledWith(
         "event",
-        "quiz_question_answered",
+        "QUIZ_QUESTION_ANSWERED",
         expect.objectContaining({
           quiz_id: "quiz-123",
           question_id: "question-456",
@@ -172,7 +172,7 @@ describe("Analytics Utilities", () => {
 
       expect(mockGtag).toHaveBeenCalledWith(
         "event",
-        "quiz_complete",
+        "QUIZ_COMPLETE",
         expect.objectContaining({
           quiz_id: "quiz-123",
         }),
@@ -184,7 +184,7 @@ describe("Analytics Utilities", () => {
 
       expect(mockGtag).toHaveBeenCalledWith(
         "event",
-        "quiz_score",
+        "QUIZ_SCORE",
         expect.objectContaining({
           quiz_id: "quiz-123",
           score: 85,
@@ -199,7 +199,7 @@ describe("Analytics Utilities", () => {
 
       expect(mockGtag).toHaveBeenCalledWith(
         "event",
-        "course_view",
+        "COURSE_VIEW",
         expect.objectContaining({
           course_id: "course-123",
         }),
@@ -211,7 +211,7 @@ describe("Analytics Utilities", () => {
 
       expect(mockGtag).toHaveBeenCalledWith(
         "event",
-        "enroll_click",
+        "ENROLL_CLICK",
         expect.objectContaining({
           course_id: "course-123",
         }),
@@ -225,7 +225,7 @@ describe("Analytics Utilities", () => {
 
       expect(mockGtag).toHaveBeenCalledWith(
         "event",
-        "login_success",
+        "LOGIN_SUCCESS",
         expect.objectContaining({
           user_id: "user-123",
         }),
@@ -237,7 +237,7 @@ describe("Analytics Utilities", () => {
 
       expect(mockGtag).toHaveBeenCalledWith(
         "event",
-        "signup_success",
+        "SIGNUP_SUCCESS",
         expect.objectContaining({
           user_id: "user-123",
         }),
@@ -249,7 +249,7 @@ describe("Analytics Utilities", () => {
 
       expect(mockGtag).toHaveBeenCalledWith(
         "event",
-        "logout",
+        "LOGOUT",
         expect.objectContaining({
           user_id: "user-123",
         }),
@@ -261,7 +261,7 @@ describe("Analytics Utilities", () => {
 
       expect(mockGtag).toHaveBeenCalledWith(
         "event",
-        "user_activated",
+        "USER_ACTIVATED",
         expect.objectContaining({
           user_id: "user-123",
           product_id: "platform",
@@ -323,7 +323,7 @@ describe("Analytics Utilities", () => {
 
       expect(mockGtag).toHaveBeenCalledWith(
         "event",
-        "ui_click",
+        "UI_CLICK",
         expect.objectContaining({
           element_tag: "button",
           element_id: "save-profile",
@@ -373,7 +373,7 @@ describe("Analytics Utilities", () => {
 
       expect(mockGtag).toHaveBeenCalledWith(
         "event",
-        "ui_form_submit",
+        "UI_FORM_SUBMIT",
         expect.objectContaining({
           form_name: "signup",
           interaction_type: "form_submit",

--- a/apps/testing/src/unit/utils/challenges.test.ts
+++ b/apps/testing/src/unit/utils/challenges.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { challengesService } from "@tbe/utils/challenges";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock dependencies
 vi.mock("@tbe/utils/api", () => ({
@@ -10,8 +10,8 @@ vi.mock("@tbe/utils/analytics", () => ({
   trackEvent: vi.fn(),
 }));
 
-import { sendRequest } from "@tbe/utils/api";
 import { trackEvent } from "@tbe/utils/analytics";
+import { sendRequest } from "@tbe/utils/api";
 
 const mockSendRequest = vi.mocked(sendRequest);
 const mockTrackEvent = vi.mocked(trackEvent);
@@ -93,7 +93,7 @@ describe("Challenges Utilities", () => {
         body: challengeData,
       });
       expect(result).toEqual(mockChallenge);
-      expect(mockTrackEvent).toHaveBeenCalledWith("challenge_create", {
+      expect(mockTrackEvent).toHaveBeenCalledWith("CHALLENGE_CREATE", {
         category: "challenge",
         value: 30,
         challengeName: "30 Day Challenge",
@@ -166,7 +166,7 @@ describe("Challenges Utilities", () => {
         url: "/prepyatra/challenges/challenge-123",
         method: "DELETE",
       });
-      expect(mockTrackEvent).toHaveBeenCalledWith("challenge_delete", {
+      expect(mockTrackEvent).toHaveBeenCalledWith("CHALLENGE_DELETE", {
         category: "challenge",
         challengeId: "challenge-123",
       });
@@ -217,7 +217,7 @@ describe("Challenges Utilities", () => {
         body: logData,
       });
       expect(result).toEqual(mockLog);
-      expect(mockTrackEvent).toHaveBeenCalledWith("challenge_log_create", {
+      expect(mockTrackEvent).toHaveBeenCalledWith("CHALLENGE_LOG_CREATE", {
         category: "challenge",
         challengeId: "challenge-123",
         day: 5,

--- a/apps/testing/src/unit/utils/quiz.test.ts
+++ b/apps/testing/src/unit/utils/quiz.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { cleanOptionText, quizService } from "@tbe/utils/quiz";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock dependencies
 vi.mock("@tbe/utils/api", () => ({
@@ -10,8 +10,8 @@ vi.mock("@tbe/utils/analytics", () => ({
   trackEvent: vi.fn(),
 }));
 
-import { sendRequest } from "@tbe/utils/api";
 import { trackEvent } from "@tbe/utils/analytics";
+import { sendRequest } from "@tbe/utils/api";
 
 const mockSendRequest = vi.mocked(sendRequest);
 const mockTrackEvent = vi.mocked(trackEvent);
@@ -179,7 +179,7 @@ describe("Quiz Utilities", () => {
         },
       });
       expect(result).toEqual(mockSession);
-      expect(mockTrackEvent).toHaveBeenCalledWith("quiz_session_start", {
+      expect(mockTrackEvent).toHaveBeenCalledWith("QUIZ_SESSION_START", {
         action: "quiz_session_start",
         category: "quiz",
         label: "quiz-123",
@@ -249,7 +249,7 @@ describe("Quiz Utilities", () => {
         method: "POST",
       });
       expect(result).toEqual(mockResult);
-      expect(mockTrackEvent).toHaveBeenCalledWith("quiz_session_complete", {
+      expect(mockTrackEvent).toHaveBeenCalledWith("QUIZ_SESSION_COMPLETE", {
         action: "quiz_session_complete",
         category: "quiz",
         sessionId: "session-123",

--- a/apps/testing/tsconfig.json
+++ b/apps/testing/tsconfig.json
@@ -18,7 +18,8 @@
       "@/*": ["./src/*", "../api/src/*"],
       "@test-utils/*": ["./src/test-utils/*"],
       "@/lib/*": ["../api/src/lib/*"],
-      "@/middleware/*": ["../api/src/middleware/*"]
+      "@/middleware/*": ["../api/src/middleware/*"],
+      "@api/*": ["../api/src/*"]
     },
     "noEmit": true,
     "incremental": true,

--- a/packages/constants/src/analyticsEvents.ts
+++ b/packages/constants/src/analyticsEvents.ts
@@ -6,62 +6,62 @@
 /** Modern snake_case GA4 event names */
 export const ANALYTICS_EVENTS = {
   // UI (automatic via delegated listeners)
-  UI_CLICK: "ui_click",
-  UI_FORM_SUBMIT: "ui_form_submit",
+  UI_CLICK: "UI_CLICK",
+  UI_FORM_SUBMIT: "UI_FORM_SUBMIT",
 
   // Auth & lifecycle
-  LOGIN_CLICK: "login_click",
-  LOGIN_REDIRECT_CLICK: "login_redirect_click",
-  LOGIN_SUCCESS: "login_success",
-  SIGNUP_SUCCESS: "signup_success",
-  LOGOUT: "logout",
-  USER_ACTIVATED: "user_activated",
-  SIGNUP_CLICK: "signup_click",
+  LOGIN_CLICK: "LOGIN_CLICK",
+  LOGIN_REDIRECT_CLICK: "LOGIN_REDIRECT_CLICK",
+  LOGIN_SUCCESS: "LOGIN_SUCCESS",
+  SIGNUP_SUCCESS: "SIGNUP_SUCCESS",
+  LOGOUT: "LOGOUT",
+  USER_ACTIVATED: "USER_ACTIVATED",
+  SIGNUP_CLICK: "SIGNUP_CLICK",
 
   // Onboarding
-  ONBOARDING_NEXT: "onboarding_next",
-  ONBOARDING_PREVIOUS: "onboarding_previous",
-  ONBOARDING_SUBMIT: "onboarding_submit",
-  ONBOARDING_COMPLETE: "onboarding_complete",
-  ONBOARDING_ERROR: "onboarding_error",
+  ONBOARDING_NEXT: "ONBOARDING_NEXT",
+  ONBOARDING_PREVIOUS: "ONBOARDING_PREVIOUS",
+  ONBOARDING_SUBMIT: "ONBOARDING_SUBMIT",
+  ONBOARDING_COMPLETE: "ONBOARDING_COMPLETE",
+  ONBOARDING_ERROR: "ONBOARDING_ERROR",
 
   // Quiz
-  QUIZ_START: "quiz_start",
-  QUIZ_QUESTION_ANSWERED: "quiz_question_answered",
-  QUIZ_COMPLETE: "quiz_complete",
-  QUIZ_SCORE: "quiz_score",
-  QUIZ_SESSION_START: "quiz_session_start",
-  QUIZ_ANSWER_SUBMIT: "quiz_answer_submit",
-  QUIZ_SESSION_COMPLETE: "quiz_session_complete",
-  QUIZ_RESULTS_VIEW: "quiz_results_view",
+  QUIZ_START: "QUIZ_START",
+  QUIZ_QUESTION_ANSWERED: "QUIZ_QUESTION_ANSWERED",
+  QUIZ_COMPLETE: "QUIZ_COMPLETE",
+  QUIZ_SCORE: "QUIZ_SCORE",
+  QUIZ_SESSION_START: "QUIZ_SESSION_START",
+  QUIZ_ANSWER_SUBMIT: "QUIZ_ANSWER_SUBMIT",
+  QUIZ_SESSION_COMPLETE: "QUIZ_SESSION_COMPLETE",
+  QUIZ_RESULTS_VIEW: "QUIZ_RESULTS_VIEW",
 
   // Course & learning
-  COURSE_VIEW: "course_view",
-  ENROLL_CLICK: "enroll_click",
+  COURSE_VIEW: "COURSE_VIEW",
+  ENROLL_CLICK: "ENROLL_CLICK",
 
   // Prep Yatra
-  PREP_LOG_CREATE: "prep_log_create",
-  PREP_LOG_UPDATE: "prep_log_update",
-  PREP_LOG_DELETE: "prep_log_delete",
-  CHALLENGE_CREATE: "challenge_create",
-  CHALLENGE_UPDATE: "challenge_update",
-  CHALLENGE_DELETE: "challenge_delete",
-  CHALLENGE_LOG_CREATE: "challenge_log_create",
-  SKILL_ADD: "skill_add",
-  SKILL_REMOVE: "skill_remove",
-  RECRUITER_CONTACT_CREATE: "recruiter_contact_create",
-  RECRUITER_CONTACT_UPDATE: "recruiter_contact_update",
-  RECRUITER_CONTACT_DELETE: "recruiter_contact_delete",
+  PREP_LOG_CREATE: "PREP_LOG_CREATE",
+  PREP_LOG_UPDATE: "PREP_LOG_UPDATE",
+  PREP_LOG_DELETE: "PREP_LOG_DELETE",
+  CHALLENGE_CREATE: "CHALLENGE_CREATE",
+  CHALLENGE_UPDATE: "CHALLENGE_UPDATE",
+  CHALLENGE_DELETE: "CHALLENGE_DELETE",
+  CHALLENGE_LOG_CREATE: "CHALLENGE_LOG_CREATE",
+  SKILL_ADD: "SKILL_ADD",
+  SKILL_REMOVE: "SKILL_REMOVE",
+  RECRUITER_CONTACT_CREATE: "RECRUITER_CONTACT_CREATE",
+  RECRUITER_CONTACT_UPDATE: "RECRUITER_CONTACT_UPDATE",
+  RECRUITER_CONTACT_DELETE: "RECRUITER_CONTACT_DELETE",
 
   // Resources
-  SHARE_RESOURCE: "share_resource",
+  SHARE_RESOURCE: "SHARE_RESOURCE",
 
   // DSA Yatra (Phase 3)
-  DSA_QUESTION_VIEW: "dsa_question_view",
+  DSA_QUESTION_VIEW: "DSA_QUESTION_VIEW",
 
   // Resume Yatra (Phase 3)
-  RESUME_BUILDER_COMPLETE: "resume_builder_complete",
-  RESUME_SHARE: "resume_share",
+  RESUME_BUILDER_COMPLETE: "RESUME_BUILDER_COMPLETE",
+  RESUME_SHARE: "RESUME_SHARE",
 
   // Legacy SCREAMING_SNAKE events (retained for GA4 historical continuity)
   USER_LOGIN: "USER_LOGIN",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,7 +17,10 @@
     "./mdx": "./src/mdx/index.ts",
     "./content-id": "./src/content-id.ts",
     "./onboarding": "./src/onboarding.ts",
-    "./array": "./src/array.ts"
+    "./array": "./src/array.ts",
+    "./challenges": "./src/challenges.ts",
+    "./quiz": "./src/quiz.ts",
+    "./prepLogs": "./src/prepLogs.ts"
   },
   "scripts": {
     "lint": "eslint ."


### PR DESCRIPTION
## Description
Standardize modern Google Analytics event names in the central registry to uppercase (`SCREAMING_SNAKE_CASE`) and fix path alias compiler warnings in tests.

## Changes
- **Constants**: Converted modern event values in `ANALYTICS_EVENTS` registry to uppercase.
- **Utils**: Exported missing entry points (`challenges`, `quiz`, `prepLogs`) in `packages/utils/package.json`.
- **Testing**: Added `@api/*` path mapping in `apps/testing/tsconfig.json` and updated all unit tests to match uppercase event expectations.
