### PR TITLE
docs: publish user-facing release notes for v2.16.7

### DIFF
--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -1,0 +1,5 @@
+# Release Notes
+
+User-facing release notes for TBE Web, one file per published GitHub release.
+
+- [v2.16.7](./v2.16.7.md) — July 14, 2026

--- a/docs/release-notes/v2.16.7.md
+++ b/docs/release-notes/v2.16.7.md
@@ -1,0 +1,25 @@
+# TBE Web — Release v2.16.7
+
+**Release date:** July 14, 2026
+**Type:** Production release (stable)
+**Compare:** [v2.16.6...v2.16.7](https://github.com/The-Boring-Education/TBE-Web/compare/v2.16.6...v2.16.7)
+
+## Summary
+
+This is a small, internal-only maintenance release. There are no visible changes to the product experience — it focuses on making our analytics data more consistent and easier to audit internally.
+
+## New
+
+- None in this release.
+
+## Improved
+
+- Standardized all Google Analytics (GA4) event names across the platform to a consistent UPPERCASE naming convention. This makes event tracking easier to audit and reduces the chance of mismatched or duplicate events in analytics dashboards. Purely an internal data-quality change with no effect on how the site looks or behaves.
+
+## Fixed
+
+- None in this release.
+
+## Breaking Changes
+
+- None. This release is fully backward compatible; no action is required from users or integrators.


### PR DESCRIPTION
## What does this PR do?

Adds a `docs/release-notes/` location and publishes clear, user-facing release notes for the `v2.16.7` production release (published 2026-07-14), translating the auto-generated commit-log release body into categorized notes (New / Improved / Fixed / Breaking).

## Why?

The `release.yml` workflow auto-generates a GitHub Release on every push to `production`, but the body is a raw, developer-facing commit list grouped by conventional-commit type. This adds a human-readable summary for the release, so anyone (including non-engineers) can quickly see what changed without parsing commit messages.

v2.16.7 itself is a small, internal-only release: it standardizes GA4 analytics event names to UPPERCASE (`6a2863e`). There are no other new features, fixes, or breaking changes in this release.

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 Refactor / cleanup (no functional change)
- [ ] 🎨 UI / styling change
- [ ] 🔌 API change (new or modified endpoints, request/response shape changes)
- [ ] 📦 Dependency update
- [x] 📝 Documentation only

---

## Screenshots / Recordings

N/A — documentation-only change.

---

## Testing

### Does this PR include tests?

- [ ] Yes — unit tests
- [ ] Yes — integration / e2e tests
- [x] No — here's why: docs-only change, nothing to test.

### How to test manually

1. Open `docs/release-notes/v2.16.7.md` and confirm the notes accurately reflect the [v2.16.7 release](https://github.com/The-Boring-Education/TBE-Web/releases/tag/v2.16.7).
2. Open `docs/release-notes/README.md` and confirm the link resolves.

---

## Checklist

- [x] I've tested this locally and it works as expected
- [ ] I've checked for console errors / warnings
- [x] No unrelated changes snuck in
- [ ] If UI change — tested on mobile viewport too
- [ ] If API change — backward compatible or migration plan noted above


---
_Generated by [Claude Code](https://claude.ai/code/session_01ERyjtGThzkbvtX5WhWFjkp)_