### PR TITLE
docs: publish user-facing release notes for v2.16.8

### DIFF
--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -2,4 +2,5 @@
 
 User-facing release notes for TBE Web, one file per published GitHub release.
 
+- [v2.16.8](./v2.16.8.md) — July 14, 2026
 - [v2.16.7](./v2.16.7.md) — July 14, 2026

--- a/docs/release-notes/v2.16.8.md
+++ b/docs/release-notes/v2.16.8.md
@@ -1,0 +1,25 @@
+# TBE Web — Release v2.16.8
+
+**Release date:** July 14, 2026
+**Type:** Production release (stable)
+**Compare:** [v2.16.7...v2.16.8](https://github.com/The-Boring-Education/TBE-Web/compare/v2.16.7...v2.16.8)
+
+## Summary
+
+This is a documentation-only release. It publishes the user-facing release notes for v2.16.7 to the repository; there are no product or behavior changes.
+
+## New
+
+- None in this release.
+
+## Improved
+
+- None in this release.
+
+## Fixed
+
+- None in this release.
+
+## Breaking Changes
+
+- None. This release is fully backward compatible; no action is required from users or integrators.


### PR DESCRIPTION
## Summary
- Publishes user-facing release notes for `v2.16.8` (published July 14, 2026) under `docs/release-notes/v2.16.8.md`, following the existing per-release notes format.
- Updates `docs/release-notes/README.md` to link the new entry.
- `v2.16.8` is a documentation-only release (adds the `v2.16.7` release notes doc + version bump), so this file records that explicitly — no product/behavior changes, nothing new/improved/fixed, no breaking changes.

## Test plan
- [x] Verified `v2.16.8` contains no code changes beyond the prior release-notes commit and the version bump (`git diff --stat v2.16.7..v2.16.8`).
- [x] Followed the same structure/headings as `docs/release-notes/v2.16.7.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PHKYQgm2Jsb8kpb6BASrKf)_