### PR TITLE
fix(oncampus): move freemium banner to top layout container

### DIFF
--- a/apps/oncampus/src/pages/coresubjects/[[...params]].tsx
+++ b/apps/oncampus/src/pages/coresubjects/[[...params]].tsx
@@ -729,7 +729,18 @@ const CoreSubjectsPage = () => {
       backHref={routes.oncampus.dashboard}
       layoutMode="workspace"
     >
-      <div className="flex flex-col h-full w-full">
+      {selectedSubject?.chapters.some((ch) => ch.isLocked) && (
+        <FreemiumLockBanner
+          unlockedCount={
+            selectedSubject.chapters.filter((ch) => !ch.isLocked).length
+          }
+          message={`Freemium preview — ${
+            selectedSubject.chapters.filter((ch) => !ch.isLocked).length
+          } chapters unlocked. Subscribe to access all.`}
+          onUpgradeClick={() => router.push(routes.oncampus.pricing)}
+        />
+      )}
+      <div className="flex flex-col flex-1 min-h-0 w-full">
         {/* ── Top header bar & Mobile drawer (Hidden during study mode) ── */}
         {!selectedChapter && (
           <>
@@ -995,17 +1006,6 @@ const CoreSubjectsPage = () => {
           ) : (
             /* Chapter cards grid */
             <div className="flex-1 w-full overflow-y-auto bg-[#050505] p-4 lg:p-8 pb-[calc(5rem+env(safe-area-inset-bottom,0px))] lg:pb-8 scrollbar-thin-grey">
-              {selectedSubject?.chapters.some((ch) => ch.isLocked) && (
-                <FreemiumLockBanner
-                  unlockedCount={
-                    selectedSubject.chapters.filter((ch) => !ch.isLocked).length
-                  }
-                  message={`Freemium preview — ${
-                    selectedSubject.chapters.filter((ch) => !ch.isLocked).length
-                  } chapters unlocked. Subscribe to access all.`}
-                  onUpgradeClick={() => router.push(routes.oncampus.pricing)}
-                />
-              )}
               {/* Subject header */}
               <div className="mb-6">
                 <h2 className="text-2xl font-extrabold text-white tracking-tight mb-1">


### PR DESCRIPTION
### Description
Moves the `FreemiumLockBanner` on the Core Subjects page (`/coresubjects`) from the inner padded container to the top-level layout container (`OnCampusLearningLayout`). 

### Key Changes
- Moved `FreemiumLockBanner` to the top layout, matching the structure used in the DSA and Interview sheet pages.
- Fixed layout issues where the banner was not taking full width and had unwanted top/side spacing/padding.
- Added `flex-1 min-h-0` to the main inner container to prevent layout or overflow issues when the banner is visible.

### Verification
- Built the `@tbe/oncampus` application locally.
- Checked that layout remains clean and the banner positions correctly at the top.
<img width="1701" height="535" alt="image" src="https://github.com/user-attachments/assets/15f7f25c-6bd5-4d7e-b6b7-2997eefba658" />
