### PR TITLE
fix: add ellipsis to truncated question titles in Interview Sheets sidebar

### DIFF
--- a/packages/components/src/common/Learning/QuestionLink.tsx
+++ b/packages/components/src/common/Learning/QuestionLink.tsx
@@ -53,7 +53,7 @@ const QuestionLink = ({
       analyticsId={`learning_question_${questionId}`}
       analyticsLabel={`question:${title}`}
       key={questionId}
-      className={`flex items-center gap-1 w-full p-2 mb-1 rounded border text-left pre-title ${
+      className={`flex items-center gap-1 w-full p-2 mb-1 rounded border text-left pre-title overflow-hidden ${
         isLocked
           ? isDark
             ? "text-gray-500 cursor-not-allowed border-transparent"
@@ -114,7 +114,7 @@ const QuestionLink = ({
           />
         )}
       </div>
-      {title}
+      <span className="truncate min-w-0">{title}</span>
     </LinkText>
   );
 };


### PR DESCRIPTION
## What does this PR do?

Adds proper text-overflow ellipsis handling to question titles in the Interview Sheets sidebar. Long titles now show `...` instead of being cut off abruptly.

## Why?

Question titles in the Interview Sheets left sidebar were being truncated without any visual indicator when they exceeded the available width, making the UI look broken and reducing readability. Fixes #1071.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🎨 UI / styling change

---

## Screenshots / Recordings

**Before:** Long titles cut off mid-word with no indicator
**After:** Long titles end with `...` to indicate continuation

---

## Testing

### Does this PR include tests?

- [ ] No — this is a CSS-only change (adding Tailwind utility classes). The fix is purely visual and doesn't affect any logic.

### How to test manually

1. Go to the **Interview Sheets** section (oncampus or platform app)
2. Open any category with long question titles (e.g., **Database Interview Questions**)
3. Look at the list of questions in the left sidebar
4. Verify that long titles now display with `...` at the end instead of being abruptly cut off

---

## Checklist

- [x] I've tested this locally and it works as expected
- [x] I've checked for console errors / warnings
- [x] No unrelated changes snuck in
- [x] If UI change — tested on mobile viewport too

---

### Changes

**File:** `packages/components/src/common/Learning/QuestionLink.tsx`

- Added `overflow-hidden` to the parent `LinkText` flex container to prevent text from overflowing its bounds
- Wrapped `{title}` in a `<span className="truncate min-w-0">` — Tailwind's `truncate` applies `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`, and `min-w-0` allows the flex child to shrink below its content size

Since `QuestionLink` is a shared component from `@tbe/components`, this single fix propagates to all pages that use it (oncampus Interview Sheet workspace, DSA prep, and platform sheet page).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDYCsjrUdkUQ7KGX4UpHYo)_