### PR TITLE
fix(mdx): null-safe YouTube embeds and responsive aspect-ratio

### DIFF
--- a/apps/oncampus/src/components/CoreSubjectMDXRenderer.tsx
+++ b/apps/oncampus/src/components/CoreSubjectMDXRenderer.tsx
@@ -196,20 +196,26 @@ export const CoreSubjectMDXRenderer = ({
 
     instance.renderer.rules.link_open = (tokens: any, idx: any) => {
       const token = tokens[idx];
-      const href = token.attrGet("href");
+      const href = token.attrGet("href") || "";
+      if (!href) {
+        return `<a class="text-primary underline strong-text">`;
+      }
       if (href.includes("youtube.com") || href.includes("youtu.be")) {
         if (href.includes("list=")) {
-          return `<a href=${href} target="_blank" class="text-primary underline strong-text">`;
-        } else {
-          let embedHref = href;
-          if (href.includes("watch")) {
-            const videoId = href.split("v=")[1].split("&")[0];
-            embedHref = `https://www.youtube.com/embed/${videoId}`;
-          }
-          return `<iframe width="100%" height="550" class="rounded" src="${embedHref}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>`;
+          return `<a href="${href}" target="_blank" rel="noopener noreferrer" class="text-primary underline strong-text">`;
+        }
+        let videoId: string | undefined;
+        if (href.includes("v=")) {
+          videoId = href.split("v=")[1]?.split("&")[0];
+        } else if (href.includes("youtu.be/")) {
+          videoId = href.split("youtu.be/")[1]?.split(/[?&#]/)[0];
+        }
+        if (videoId) {
+          const embedHref = `https://www.youtube.com/embed/${videoId}`;
+          return `<div class="relative w-full max-w-full overflow-hidden rounded aspect-video my-4"><iframe class="absolute inset-0 w-full h-full rounded" src="${embedHref}" title="YouTube video" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe></div>`;
         }
       }
-      return `<a href=${href} target="_blank" class="text-primary underline strong-text">`;
+      return `<a href="${href}" target="_blank" rel="noopener noreferrer" class="text-primary underline strong-text">`;
     };
 
     // Explicit image renderer

--- a/apps/platform/src/components/InterviewSheetMDXRenderer.tsx
+++ b/apps/platform/src/components/InterviewSheetMDXRenderer.tsx
@@ -258,20 +258,26 @@ export const InterviewSheetMDXRenderer = ({
 
     instance.renderer.rules.link_open = (tokens: any, idx: any) => {
       const token = tokens[idx];
-      const href = token.attrGet('href');
+      const href = token.attrGet('href') || '';
+      if (!href) {
+        return `<a class="text-primary underline strong-text">`;
+      }
       if (href.includes('youtube.com') || href.includes('youtu.be')) {
         if (href.includes('list=')) {
-          return `<a href=${href} target="_blank" class="text-primary underline strong-text">`;
-        } else {
-          let embedHref = href;
-          if (href.includes('watch')) {
-            const videoId = href.split('v=')[1].split('&')[0];
-            embedHref = `https://www.youtube.com/embed/${videoId}`;
-          }
-          return `<iframe width="100%" height="550" class="rounded" src="${embedHref}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>`;
+          return `<a href="${href}" target="_blank" rel="noopener noreferrer" class="text-primary underline strong-text">`;
+        }
+        let videoId: string | undefined;
+        if (href.includes('v=')) {
+          videoId = href.split('v=')[1]?.split('&')[0];
+        } else if (href.includes('youtu.be/')) {
+          videoId = href.split('youtu.be/')[1]?.split(/[?&#]/)[0];
+        }
+        if (videoId) {
+          const embedHref = `https://www.youtube.com/embed/${videoId}`;
+          return `<div class="relative w-full max-w-full overflow-hidden rounded aspect-video my-4"><iframe class="absolute inset-0 w-full h-full rounded" src="${embedHref}" title="YouTube video" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe></div>`;
         }
       }
-      return `<a href=${href} target="_blank" class="text-primary underline strong-text">`;
+      return `<a href="${href}" target="_blank" rel="noopener noreferrer" class="text-primary underline strong-text">`;
     };
 
     // Explicit image renderer

--- a/packages/components/src/common/MDXRenderer/index.tsx
+++ b/packages/components/src/common/MDXRenderer/index.tsx
@@ -354,28 +354,40 @@ const MDXRenderer = ({
 
   md.renderer.rules.link_open = (tokens: any, idx: any) => {
     const token = tokens[idx];
-    const href = token.attrGet("href");
+    const href = token.attrGet("href") || "";
+    if (!href) {
+      return `<a class="text-primary underline strong-text">`;
+    }
+
     if (href.includes("youtube.com") || href.includes("youtu.be")) {
       if (href.includes("list=")) {
-        return `<a href=${href} target="_blank" class="text-primary underline strong-text">`;
-      } else {
-        let embedHref = href;
-        if (href.includes("watch")) {
-          const videoId = href.split("v=")[1].split("&")[0];
-          embedHref = `https://www.youtube.com/embed/${videoId}`;
-        }
-        return `<iframe width="100%" height="550" class="rounded" src="${embedHref}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>`;
+        return `<a href="${href}" target="_blank" rel="noopener noreferrer" class="text-primary underline strong-text">`;
+      }
+
+      let videoId: string | undefined;
+      if (href.includes("v=")) {
+        videoId = href.split("v=")[1]?.split("&")[0];
+      } else if (href.includes("youtu.be/")) {
+        videoId = href.split("youtu.be/")[1]?.split(/[?&#]/)[0];
+      }
+
+      if (videoId) {
+        const embedHref = `https://www.youtube.com/embed/${videoId}`;
+        return `<div class="relative w-full max-w-full overflow-hidden rounded aspect-video my-4"><iframe class="absolute inset-0 w-full h-full rounded" src="${embedHref}" title="YouTube video" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe></div>`;
       }
     }
 
-    return `<a href=${href} target="_blank" class="text-primary underline strong-text">`;
+    return `<a href="${href}" target="_blank" rel="noopener noreferrer" class="text-primary underline strong-text">`;
   };
 
   md.renderer.rules.link_block = (tokens: any, idx: any) => {
     const token = tokens[idx];
-    const href = token.attrGet("href");
+    const href = token.attrGet("href") || "";
+    if (!href) {
+      return `<span></span>`;
+    }
 
-    return `<a href=${href} target="_blank">${href}</a>`;
+    return `<a href="${href}" target="_blank" rel="noopener noreferrer">${href}</a>`;
   };
 
   md.renderer.rules.fence = (tokens, idx) => {


### PR DESCRIPTION
## Summary
- Guard null/empty href and missing YouTube videoId in MDX link renderers
- Use responsive aspect-video embeds instead of fixed height=550
- Add rel=noopener noreferrer and quoted href attributes on external links

## Test plan
- [ ] Render MDX content with a standard YouTube watch URL
- [ ] Render short youtu.be links
- [ ] Confirm null/invalid links do not throw
- [ ] Confirm embeds scale correctly on mobile width

Fixes #1076
