### PR TITLE
fix(a11y): add accessible name to StarButton

### DIFF
--- a/packages/components/src/common/Buttons/StarButton.tsx
+++ b/packages/components/src/common/Buttons/StarButton.tsx
@@ -17,8 +17,13 @@ const StarButton = ({
     onClick={onToggle}
     disabled={isLoading}
     type="button"
+    aria-label={isStarred ? "Unstar question" : "Star question"}
+    aria-pressed={isStarred}
   >
-    <FaStar className={`${isStarred ? "text-yellow-500" : "text-gray-400"}`} />
+    <FaStar
+      aria-hidden="true"
+      className={`${isStarred ? "text-yellow-500" : "text-gray-400"}`}
+    />
   </Button>
 );
 


### PR DESCRIPTION
## Summary
- Add aria-label and aria-pressed to icon-only StarButton
- Mark star icon as aria-hidden

## Test plan
- [ ] Toggle star with screen reader / accessibility tree
- [ ] Confirm label switches between Star and Unstar

Fixes #1077

