### PR TITLE
fix(a11y): add aria-labels to navbar menu toggles

### DIFF
--- a/packages/components/src/layout/LearningNavbar.tsx
+++ b/packages/components/src/layout/LearningNavbar.tsx
@@ -39,6 +39,7 @@ const LearningNavbar = ({
             <button
               className={`flex items-center justify-center rounded-md p-[6px] ${theme === "dark" ? "text-white hover:bg-gray-800" : "text-black hover:bg-gray-100"}`}
               type="button"
+              aria-label="Open learning menu"
               onClick={onMenuToggle}
             >
               <Bars3Icon

--- a/packages/components/src/layout/Navbar.tsx
+++ b/packages/components/src/layout/Navbar.tsx
@@ -200,6 +200,7 @@ const Navbar = ({
                   : "text-black hover:bg-gray-100"
               }`}
               type="button"
+              aria-label="Open learning menu"
               onClick={() => setLearningSidebarOpen(true)}
             >
               <Bars3Icon
@@ -221,6 +222,7 @@ const Navbar = ({
               <button
                 className={`-m-[10px] flex items-center justify-center rounded-md p-[10px] ${theme === "dark" ? "text-white" : "text-black"}`}
                 type="button"
+                aria-label="Open menu"
                 onClick={() => setMobileMenuOpen(true)}
               >
                 <Bars3Icon
@@ -261,6 +263,7 @@ const Navbar = ({
               <button
                 className={`-m-[10px] flex items-center justify-center rounded-md p-[10px] ${theme === "dark" ? "text-white" : "text-black"}`}
                 type="button"
+                aria-label="Open menu"
                 onClick={() => setMobileMenuOpen(true)}
               >
                 <Bars3Icon


### PR DESCRIPTION
## Summary
- Add aria-label to Navbar hamburger and learning menu buttons
- Add aria-label to LearningNavbar menu toggle

## Test plan
- [ ] Inspect accessibility tree for Open menu / Open learning menu
- [ ] Confirm buttons still open the correct menus

Fixes #1078

