### PR TITLE
fix: allow LinerProgressBar itemLabel for questions

### DIFF
--- a/apps/platform/src/pages/interview-prep/[sheetSlug]/index.tsx
+++ b/apps/platform/src/pages/interview-prep/[sheetSlug]/index.tsx
@@ -292,6 +292,7 @@ const SheetPage = ({ sheet, meta, slug, seoMeta }: SheetPageProps) => {
                   <LinerProgressBar
                     completedChapters={completedQuestions}
                     totalChapters={totalQuestions}
+                    itemLabel='Questions'
                   />
                 )}
               </div>

--- a/packages/components/src/common/ProgressBar/LinerProgressBar.tsx
+++ b/packages/components/src/common/ProgressBar/LinerProgressBar.tsx
@@ -3,6 +3,7 @@ import type { LinerProgressBarProps } from "@tbe/interface";
 const LinerProgressBar = ({
   totalChapters,
   completedChapters,
+  itemLabel = "Chapters",
 }: LinerProgressBarProps) => {
   const completionPercentage =
     totalChapters > 0
@@ -18,7 +19,7 @@ const LinerProgressBar = ({
         />
       </div>
       <div className="text-sm mt-1">
-        {completedChapters} / {totalChapters} Chapters Completed (
+        {completedChapters} / {totalChapters} {itemLabel} Completed (
         {completionPercentage}%)
       </div>
     </div>

--- a/packages/interface/src/Components.ts
+++ b/packages/interface/src/Components.ts
@@ -91,12 +91,7 @@ export interface LinkButtonProps extends LinkProps {
 }
 
 type ButtonVariant =
-  | "OUTLINE"
-  | "PRIMARY"
-  | "SECONDARY"
-  | "GHOST"
-  | "SUCCESS"
-  | "NEUTRAL";
+  "OUTLINE" | "PRIMARY" | "SECONDARY" | "GHOST" | "SUCCESS" | "NEUTRAL";
 
 export interface ButtonProps extends DelegatedInteractiveAnalyticsProps {
   variant: ButtonVariant;
@@ -491,6 +486,8 @@ export interface AlertProps {
 export interface LinerProgressBarProps {
   totalChapters: number;
   completedChapters: number;
+  /** Label for progress units, e.g. "Chapters" or "Questions". Defaults to "Chapters". */
+  itemLabel?: string;
 }
 
 export interface LearningSidebarPanelProps {

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -67,12 +67,7 @@ export interface LogoProps {
 
 export interface ButtonProps {
   variant:
-    | "PRIMARY"
-    | "OUTLINE"
-    | "GHOST"
-    | "SUCCESS"
-    | "SECONDARY"
-    | "NEUTRAL";
+    "PRIMARY" | "OUTLINE" | "GHOST" | "SUCCESS" | "SECONDARY" | "NEUTRAL";
   className?: string;
   text: string;
   onClick?: MouseEventHandler<HTMLButtonElement>;
@@ -493,6 +488,8 @@ export interface LoadingSpinnerProps {
 export interface LinerProgressBarProps {
   totalChapters: number;
   completedChapters: number;
+  /** Label for progress units, e.g. "Chapters" or "Questions". Defaults to "Chapters". */
+  itemLabel?: string;
 }
 
 export interface ProgressRingProps {


### PR DESCRIPTION
## Summary
- Add optional itemLabel prop to LinerProgressBar (default Chapters)
- Pass Questions label on interview prep sheet sidebar

## Test plan
- [ ] Open an interview sheet and confirm progress text shows Questions Completed
- [ ] Course/chapter pages still show Chapters Completed

Fixes #1079

