### PR TITLE
fix(security): add rel=noopener noreferrer for blank target links

### DIFF
--- a/packages/components/src/common/Typography/Link.tsx
+++ b/packages/components/src/common/Typography/Link.tsx
@@ -40,6 +40,7 @@ const LinkText = ({
       href={href}
       scroll={scroll}
       target={target}
+      rel={target === "_blank" ? "noopener noreferrer" : undefined}
       onClick={onClick}
       {...delegated}
     >


### PR DESCRIPTION
## Summary
- Automatically set rel=noopener noreferrer when Link target is _blank
- Covers LinkButton and other callers that use shared Link

## Test plan
- [ ] Inspect a target=_blank link in the DOM for rel=noopener noreferrer
- [ ] Confirm normal in-app links are unchanged

Fixes #1080

