### PR TITLE
fix(quiz): guard empty name in dashboard welcome greeting

### DIFF
--- a/apps/quizes/src/pages/dashboard/index.tsx
+++ b/apps/quizes/src/pages/dashboard/index.tsx
@@ -72,7 +72,9 @@ function DashboardContent() {
           {/* Welcome Header */}
           <div className="text-center mb-12">
             <h1 className="text-4xl font-bold text-gray-900 mb-4">
-              Welcome back, {user?.name?.split(" ")[0]}! 👋
+              Welcome back,{" "}
+              {user?.name?.trim().split(/\s+/).filter(Boolean)[0] || "there"}!
+              👋
             </h1>
             <p className="text-xl text-gray-600">
               Ready to test your knowledge? Choose a quiz below to get started.


### PR DESCRIPTION
## Summary
- Safely extract first name for quiz dashboard welcome text
- Fallback to 'there' when name is missing or blank

## Test plan
- [ ] User with normal name still greets with first name
- [ ] Empty/whitespace name shows Welcome back, there!

Fixes #1082

