### PR TITLE
fix: prevent undefined initials from multi-space names

### DIFF
--- a/apps/dsayatra/src/pages/dashboard.tsx
+++ b/apps/dsayatra/src/pages/dashboard.tsx
@@ -132,9 +132,13 @@ const DsaClient = () => {
                     ) : (
                       <div className="flex size-full items-center justify-center bg-gradient-to-br from-[#ff5757] to-[#cc4444] text-2xl font-black text-white sm:text-3xl">
                         {user?.name
-                          ?.split(" ")
+                          ?.trim()
+                          .split(/\s+/)
+                          .filter(Boolean)
                           .map((n) => n[0])
-                          .join("") || "SJ"}
+                          .join("")
+                          .toUpperCase()
+                          .slice(0, 2) || "SJ"}
                       </div>
                     )}
                   </div>

--- a/apps/quizes/src/pages/dashboard/leaderboard/index.tsx
+++ b/apps/quizes/src/pages/dashboard/leaderboard/index.tsx
@@ -84,12 +84,15 @@ function LeaderboardEntry({
   onViewProfile,
 }: LeaderboardEntryProps) {
   const getInitials = (name: string) => {
-    return name
-      .split(" ")
+    const initials = name
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
       .map((n) => n[0])
       .join("")
       .toUpperCase()
       .slice(0, 2);
+    return initials || "U";
   };
 
   const formatTime = (seconds: number) => {
@@ -179,12 +182,15 @@ function UserProfileModal({ profile, isOpen, onClose }: UserProfileModalProps) {
   if (!isOpen || !profile) return null;
 
   const getInitials = (name: string) => {
-    return name
-      .split(" ")
+    const initials = name
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
       .map((n) => n[0])
       .join("")
       .toUpperCase()
       .slice(0, 2);
+    return initials || "U";
   };
 
   return (

--- a/packages/components/src/prepyatra/dashboard/ProfileSection.tsx
+++ b/packages/components/src/prepyatra/dashboard/ProfileSection.tsx
@@ -3,13 +3,16 @@ import React from "react";
 import { toast } from "sonner";
 
 const getInitials = (name?: string): string => {
-  if (!name) return "PY";
-  return name
-    .split(" ")
+  if (!name?.trim()) return "PY";
+  const initials = name
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
     .map((p) => p[0])
     .join("")
     .toUpperCase()
     .slice(0, 2);
+  return initials || "PY";
 };
 
 // Inline SVG icons matching exact design spec

--- a/packages/components/src/quizes/layout/DashboardNav.tsx
+++ b/packages/components/src/quizes/layout/DashboardNav.tsx
@@ -35,12 +35,15 @@ export function DashboardNav() {
   };
 
   const getInitials = (name: string) => {
-    return name
-      .split(" ")
+    const initials = name
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
       .map((n) => n[0])
       .join("")
       .toUpperCase()
       .slice(0, 2);
+    return initials || "U";
   };
 
   return (


### PR DESCRIPTION
## Summary
- Filter empty name segments before building initials
- Fallback to safe defaults when name is blank

## Test plan
- [ ] Name with double spaces does not render 'undefined' in initials
- [ ] Blank name falls back to U/PY/SJ as appropriate

Fixes #1083

