### PR TITLE
fix(a11y): add aria-label to MDX code copy button

### DIFF
--- a/packages/components/src/common/MDXRenderer/index.tsx
+++ b/packages/components/src/common/MDXRenderer/index.tsx
@@ -430,6 +430,7 @@ const MDXRenderer = ({
       const btn = document.createElement("button");
       btn.innerText = "Copy";
       btn.type = "button";
+      btn.setAttribute("aria-label", "Copy code");
       btn.className =
         theme === "dark"
           ? "copy-button absolute top-2 right-2 px-2 py-1 bg-gray-800 text-white text-sm rounded border border-gray-700 hover:bg-gray-700 hover:scale-105 transition-all z-10 max-sm:top-1 max-sm:right-1 max-sm:px-1 max-sm:py-0.5 max-sm:text-xs"
@@ -438,8 +439,10 @@ const MDXRenderer = ({
         const textToCopy = codeElem.textContent || "";
         navigator.clipboard.writeText(textToCopy).then(() => {
           btn.innerText = "Copied!";
+          btn.setAttribute("aria-label", "Code copied");
           setTimeout(() => {
             btn.innerText = "Copy";
+            btn.setAttribute("aria-label", "Copy code");
           }, 1500);
         });
       };


### PR DESCRIPTION
## Summary
- Set aria-label on dynamically created MDX Copy buttons
- Update label when copy succeeds

## Test plan
- [ ] Open MDX page with a code block and inspect Copy button accessibility name
- [ ] After click, label becomes Code copied then resets

Fixes #1084

