### PR TITLE
fix: add rel=noopener noreferrer to Link and LinkButton when target=_blank

### DIFF
--- a/packages/components/src/common/Buttons/LinkButton.tsx
+++ b/packages/components/src/common/Buttons/LinkButton.tsx
@@ -46,6 +46,7 @@ const LinkButton = ({
       className={className}
       href={href}
       target={target}
+      rel={target === "_blank" ? "noopener noreferrer" : undefined}
     >
       <Button {...themedButtonProps} isLoading={false} suppressGlobalUiClick />
     </Link>

--- a/packages/components/src/common/Typography/Link.tsx
+++ b/packages/components/src/common/Typography/Link.tsx
@@ -40,6 +40,7 @@ const LinkText = ({
       href={href}
       scroll={scroll}
       target={target}
+      rel={target === "_blank" ? "noopener noreferrer" : undefined}
       onClick={onClick}
       {...delegated}
     >


### PR DESCRIPTION
## Summary
Fixes #1080 — prevents tab-nabbing vulnerability on external links.

## Changes
- packages/components/src/common/Typography/Link.tsx: Added rel=noopener noreferrer when target=_blank
- packages/components/src/common/Buttons/LinkButton.tsx: Same fix

## Verification
When target=_blank, both components automatically set rel=noopener noreferrer. When target is not _blank, no rel attribute is added.