### PR TITLE
Dsayatra interactive visual

### DIFF
--- a/apps/api/src/lib/database/models/InterviewPrep/DSAQuestion.ts
+++ b/apps/api/src/lib/database/models/InterviewPrep/DSAQuestion.ts
@@ -77,6 +77,11 @@ const DSAQuestionSchema = new Schema<DSAQuestionModel>(
       default: false,
       index: true,
     },
+    visualizerId: {
+      type: String,
+      required: false,
+      default: null,
+    },
   },
   {
     timestamps: true,

--- a/apps/api/src/lib/database/models/InterviewPrep/DSAQuestion.ts
+++ b/apps/api/src/lib/database/models/InterviewPrep/DSAQuestion.ts
@@ -80,7 +80,6 @@ const DSAQuestionSchema = new Schema<DSAQuestionModel>(
     visualizerId: {
       type: String,
       required: false,
-      default: null,
     },
   },
   {

--- a/apps/api/src/lib/interfaces/database.ts
+++ b/apps/api/src/lib/interfaces/database.ts
@@ -344,6 +344,7 @@ export interface DSAQuestionModel extends Document {
   sections?: DSAQuestionSections;
   order?: number;
   isRealWorldProblem?: boolean;
+  visualizerId?: string;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -907,6 +908,7 @@ export interface UpdateDSAQuestionRequestPayloadProps {
   sections?: DSAQuestionSections;
   order?: number;
   isRealWorldProblem?: boolean;
+  visualizerId?: string;
 }
 
 export interface AddOnboardingPayloadProps {

--- a/apps/api/src/lib/validation/dsaSheet.ts
+++ b/apps/api/src/lib/validation/dsaSheet.ts
@@ -64,7 +64,7 @@ const dsaQuestionCreateSchema = z
     topics: z.union([z.array(topicEnum), topicEnum]),
     sections: z.unknown().optional(),
     isRealWorldProblem: z.boolean().optional(),
-    visualizerId: z.string().optional(),
+    visualizerId: z.string().trim().min(1).optional(),
   })
   .superRefine((data, ctx) => {
     if (!data.answer?.trim() && !data.content?.trim()) {

--- a/apps/api/src/lib/validation/dsaSheet.ts
+++ b/apps/api/src/lib/validation/dsaSheet.ts
@@ -64,6 +64,7 @@ const dsaQuestionCreateSchema = z
     topics: z.union([z.array(topicEnum), topicEnum]),
     sections: z.unknown().optional(),
     isRealWorldProblem: z.boolean().optional(),
+    visualizerId: z.string().optional(),
   })
   .superRefine((data, ctx) => {
     if (!data.answer?.trim() && !data.content?.trim()) {
@@ -84,6 +85,7 @@ export type DsaSheetCreateBody = {
   topics: DSATopicType[];
   sections?: unknown;
   isRealWorldProblem?: boolean;
+  visualizerId?: string;
 };
 
 export function parseDsaSheetCreateBody(
@@ -122,6 +124,7 @@ export function parseDsaSheetCreateBody(
       ...(d.isRealWorldProblem !== undefined
         ? { isRealWorldProblem: d.isRealWorldProblem }
         : {}),
+      ...(d.visualizerId !== undefined ? { visualizerId: d.visualizerId } : {}),
     },
   };
 }

--- a/packages/components/src/common/QuestionList/QuestionRow.tsx
+++ b/packages/components/src/common/QuestionList/QuestionRow.tsx
@@ -1,6 +1,6 @@
 import type { QuestionRowProps } from "@tbe/interface";
 import { cn } from "@tbe/utils";
-import { CheckCircle2, Circle, Globe, Lock, Sparkles } from "lucide-react";
+import { CheckCircle2, Circle, Eye, Globe, Lock, Sparkles } from "lucide-react";
 
 /**
  * Checklist row: completion toggle, title, optional "real world" badge, notes indicator.
@@ -15,6 +15,7 @@ export const QuestionRow = ({
   isRealWorldProblem = false,
   realWorldBadgeLabel = "Real World",
   isLocked = false,
+  hasVisualizer = false,
   className,
   onClick,
   onToggleComplete,
@@ -83,18 +84,31 @@ export const QuestionRow = ({
             <span className="min-w-0 break-words">{name}</span>
           </p>
 
-          {isRealWorldProblem && (
-            <span
-              data-testid="tbe-question-row-real-world"
-              className="inline-flex items-center gap-1 text-blue-400"
-              title="Real-world style problem"
-            >
-              <Globe className="w-2 h-2 shrink-0" />
-              <span className="text-[8px] font-bold uppercase tracking-wide">
-                {realWorldBadgeLabel}
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {isRealWorldProblem && (
+              <span
+                data-testid="tbe-question-row-real-world"
+                className="inline-flex items-center gap-1 text-blue-400"
+                title="Real-world style problem"
+              >
+                <Globe className="w-2 h-2 shrink-0" />
+                <span className="text-[8px] font-bold uppercase tracking-wide">
+                  {realWorldBadgeLabel}
+                </span>
               </span>
-            </span>
-          )}
+            )}
+
+            {hasVisualizer && (
+              <span
+                data-testid="tbe-question-row-visualizer"
+                className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-[9px] font-semibold tracking-widest uppercase text-[#FF5757] bg-[#FF5757]/10 ring-1 ring-[#FF5757]/30 shrink-0 transition-colors duration-200 group-hover:bg-[#FF5757]/15 group-hover:ring-[#FF5757]/45"
+                title="Interactive visualizer available"
+              >
+                <Eye className="w-2.5 h-2.5 text-[#FF5757] shrink-0" />
+                <span>Visualizer</span>
+              </span>
+            )}
+          </div>
         </div>
       </div>
 

--- a/packages/components/src/containers/Cards/DsaPrepWorkspace.tsx
+++ b/packages/components/src/containers/Cards/DsaPrepWorkspace.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../common/GroupedList";
 import { DifficultyQuestionList } from "../../common/QuestionList";
 import Text from "../../common/Typography/Text";
+import { VISUALIZER_MAP } from "../../visualizers";
 import FlexContainer from "../Page/common/FlexContainer";
 import DsaTopicSidebar from "./DsaTopicSidebar";
 import QuestionDetailPanel from "./QuestionDetailPanel";
@@ -368,10 +369,21 @@ const DsaPrepWorkspace = ({
                           ._priorityScore ?? 0) > 0;
                       const hasNotes =
                         !!question.notes || !!(localNotes && localNotes[qId]);
-                      const hasVisualizer = Boolean(
-                        question.visualizerId ||
-                        question.answer?.includes("```visualizer"),
-                      );
+                      const hasVisualizer = (() => {
+                        if (
+                          question.visualizerId &&
+                          VISUALIZER_MAP[question.visualizerId]
+                        ) {
+                          return true;
+                        }
+                        const match = question.answer?.match(
+                          /```visualizer\s*([\s\S]*?)```/,
+                        );
+                        const idMatch = match?.[1]?.match(/id:\s*([^\s\n]+)/);
+                        return Boolean(
+                          idMatch?.[1] && VISUALIZER_MAP[idMatch[1]],
+                        );
+                      })();
 
                       return {
                         name: question.name,

--- a/packages/components/src/containers/Cards/DsaPrepWorkspace.tsx
+++ b/packages/components/src/containers/Cards/DsaPrepWorkspace.tsx
@@ -368,6 +368,10 @@ const DsaPrepWorkspace = ({
                           ._priorityScore ?? 0) > 0;
                       const hasNotes =
                         !!question.notes || !!(localNotes && localNotes[qId]);
+                      const hasVisualizer = Boolean(
+                        question.visualizerId ||
+                        question.answer?.includes("```visualizer"),
+                      );
 
                       return {
                         name: question.name,
@@ -376,6 +380,7 @@ const DsaPrepWorkspace = ({
                         isRecommended,
                         hasNotes,
                         isRealWorldProblem: question.isRealWorldProblem,
+                        hasVisualizer,
                       };
                     }}
                     onItemClick={(question) => {

--- a/packages/components/src/containers/Cards/QuestionDetailPanel.tsx
+++ b/packages/components/src/containers/Cards/QuestionDetailPanel.tsx
@@ -25,6 +25,8 @@ import { Check, Crown, Loader2, Save, Sparkles } from "lucide-react";
 import markdownit from "markdown-it";
 import { useEffect, useState } from "react";
 
+import { VISUALIZER_MAP } from "../../visualizers";
+
 const md = markdownit();
 
 const LOCAL_NOTES_STORAGE_KEY = "dsayatra_question_notes";
@@ -35,6 +37,22 @@ const QUESTION_DETAIL_TABS: readonly DsaSectionTabs[] = [
   "companies",
   "notes",
 ] as const;
+
+function getQuestionVisualizerId(question: DsaQuestion): string | null {
+  if (question.visualizerId && VISUALIZER_MAP[question.visualizerId]) {
+    return question.visualizerId;
+  }
+  if (question.answer) {
+    const match = question.answer.match(/```visualizer\s*([\s\S]*?)```/);
+    if (match && match[1]) {
+      const idMatch = match[1].match(/id:\s*([^\s\n]+)/);
+      if (idMatch && idMatch[1] && VISUALIZER_MAP[idMatch[1]]) {
+        return idMatch[1];
+      }
+    }
+  }
+  return null;
+}
 
 /** Same key as DsaPrepWorkspace `localNotes[String(id || name)]`. */
 function getQuestionStableId(question: DsaQuestion): string {
@@ -311,12 +329,15 @@ const QuestionDetailPanel = ({
   const [isSavingNote, setIsSavingNote] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
 
+  const qStableId = question ? getQuestionStableId(question) : null;
+
   useEffect(() => {
     if (question) {
       setNoteText(question.notes ?? "");
       setSaveSuccess(false);
+      setActiveTab("description");
     }
-  }, [question]);
+  }, [qStableId]);
 
   if (!question) {
     return (
@@ -330,6 +351,19 @@ const QuestionDetailPanel = ({
   const hasStructured = hasStructuredSections(structured);
   const isRecommended = (question._priorityScore ?? 0) > 0;
   const showNotesTabDot = noteText.trim().length > 0;
+
+  const visualizerId = getQuestionVisualizerId(question);
+  const VisualizerComponent = visualizerId
+    ? VISUALIZER_MAP[visualizerId]
+    : null;
+
+  const detailTabs: readonly DsaSectionTabs[] = VisualizerComponent
+    ? ["description", "visualizer", "topics", "companies", "notes"]
+    : QUESTION_DETAIL_TABS;
+
+  const effectiveTab = detailTabs.includes(activeTab)
+    ? activeTab
+    : "description";
 
   const handleSaveNote = async () => {
     if (!isAuth || !user?.id) return;
@@ -412,19 +446,21 @@ const QuestionDetailPanel = ({
         {question.isRealWorldProblem && <RealWorldBanner />}
 
         <div className="flex flex-wrap gap-1.5 pb-1">
-          {QUESTION_DETAIL_TABS.map((tab) => (
+          {detailTabs.map((tab) => (
             <button
               key={tab}
               type="button"
               onClick={() => setActiveTab(tab)}
               className={cn(
                 "px-3 py-1.5 text-xs rounded-full border transition-all duration-200 font-medium whitespace-nowrap",
-                activeTab === tab
+                effectiveTab === tab
                   ? "border-red-500 text-red-400 bg-red-950/30"
                   : "border-gray-700/60 text-gray-400 hover:border-gray-500 hover:text-gray-200",
               )}
             >
-              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+              {tab === "visualizer"
+                ? "Visualizer"
+                : tab.charAt(0).toUpperCase() + tab.slice(1)}
               {tab === "notes" && showNotesTabDot && (
                 <span className="ml-1.5 w-1.5 h-1.5 rounded-full bg-red-500 inline-block" />
               )}
@@ -434,12 +470,28 @@ const QuestionDetailPanel = ({
       </div>
 
       <div className="space-y-4">
-        {activeTab === "description" && (
-          <div className="space-y-4 w-full">
+        {effectiveTab === "description" && (
+          <div className="space-y-6 w-full">
             {hasStructured && structured ? (
               <StructuredSections sections={structured} />
             ) : (
               <FallbackMarkdownDescription question={question} />
+            )}
+
+            {VisualizerComponent && (
+              <div className="space-y-3 pt-6 border-t border-gray-800/80">
+                <div className="flex items-center gap-2">
+                  <Text level="h2" className="text-red-500 font-bold text-sm">
+                    Interactive Visualizer
+                  </Text>
+                  <span className="text-[10px] font-bold px-2 py-0.5 rounded bg-red-950/40 border border-red-900/50 text-red-400 uppercase tracking-wider">
+                    Interactive
+                  </span>
+                </div>
+                <div className="rounded-xl overflow-hidden border border-gray-800 bg-[#0a0a0a]">
+                  <VisualizerComponent />
+                </div>
+              </div>
             )}
 
             {!hasStructured && !question.isRealWorldProblem && (
@@ -458,7 +510,20 @@ const QuestionDetailPanel = ({
           </div>
         )}
 
-        {activeTab === "topics" && (
+        {effectiveTab === "visualizer" && VisualizerComponent && (
+          <div className="space-y-4 w-full">
+            <div className="flex items-center justify-between">
+              <Text level="h2" className="text-red-500 font-bold text-sm">
+                Interactive Algorithm Visualizer
+              </Text>
+            </div>
+            <div className="rounded-xl overflow-hidden border border-gray-800 bg-[#0a0a0a]">
+              <VisualizerComponent />
+            </div>
+          </div>
+        )}
+
+        {effectiveTab === "topics" && (
           <div>
             <Text level="h2" className="text-red-500 font-semibold mb-3">
               TOPICS
@@ -481,7 +546,7 @@ const QuestionDetailPanel = ({
           </div>
         )}
 
-        {activeTab === "companies" && (
+        {effectiveTab === "companies" && (
           <div>
             <Text level="h2" className="text-red-500 font-semibold mb-3">
               COMPANIES
@@ -504,7 +569,7 @@ const QuestionDetailPanel = ({
           </div>
         )}
 
-        {activeTab === "notes" && (
+        {effectiveTab === "notes" && (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <Text level="h2" className="text-red-500 font-semibold">

--- a/packages/components/src/visualizers/BubbleSortVisualizer.tsx
+++ b/packages/components/src/visualizers/BubbleSortVisualizer.tsx
@@ -146,14 +146,12 @@ export default function BubbleSortVisualizer() {
     if (finished) setPlaying(false);
   }, [finished]);
 
-  /* reset to current base array */
   const reset = useCallback(() => {
     setPlaying(false);
     setSteps(generateSteps(baseArray));
     setIdx(0);
   }, [baseArray]);
 
-  /* generate a fresh random array of given size */
   const generate = useCallback((size: number) => {
     setPlaying(false);
     const arr = randomArray(size);
@@ -162,7 +160,6 @@ export default function BubbleSortVisualizer() {
     setIdx(0);
   }, []);
 
-  /* when size changes regenerate */
   const handleSizeChange = (size: number) => {
     setArraySize(size);
     generate(size);
@@ -176,11 +173,11 @@ export default function BubbleSortVisualizer() {
   const transMs = currentSpeed.transitionMs;
 
   return (
-    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl min-h-[500px] md:h-[520px]">
-      {/* ══ LEFT SIDEBAR / TOP CONTROLS ══ */}
-      <div className="flex flex-col gap-3.5 p-4 md:p-5 shrink-0 w-full md:w-[210px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#0A0A0B]">
-        {/* Array Size Block */}
-        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl md:h-[520px]">
+      {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
+      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[200px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#070709]">
+        {/* Array Size */}
+        <div>
           <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Array Size
           </p>
@@ -221,17 +218,17 @@ export default function BubbleSortVisualizer() {
           id="bsv-generate"
           type="button"
           onClick={() => generate(arraySize)}
-          className="w-full rounded-xl text-xs font-semibold py-2.5 bg-[#111113] hover:bg-zinc-800/80 border border-zinc-800/80 hover:border-zinc-700/60 text-zinc-200 transition-all active:scale-[0.98] cursor-pointer"
+          className="w-full rounded-xl text-xs font-semibold py-2 bg-[#111113] hover:bg-zinc-800/80 border border-zinc-800/80 hover:border-zinc-700/60 text-zinc-200 transition-all active:scale-[0.98] cursor-pointer"
         >
           ↻ Randomize
         </button>
 
-        {/* Speed Block */}
-        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+        {/* Speed */}
+        <div>
           <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Speed
           </p>
-          <div className="flex flex-row md:flex-col gap-1.5 overflow-x-auto scrollbar-none">
+          <div className="flex flex-row md:flex-col gap-1.5 overflow-x-auto scrollbar-none pb-1 md:pb-0">
             {SPEEDS.map(({ label }, i) => (
               <button
                 key={label}
@@ -252,11 +249,11 @@ export default function BubbleSortVisualizer() {
       </div>
 
       {/* ══ RIGHT — CHART + CONTROLS ══ */}
-      <div className="flex flex-col flex-1 min-w-0 justify-between h-full">
-        {/* Fixed height Status bar */}
-        <div className="h-[48px] shrink-0 flex items-center justify-center px-4 md:px-6 border-b border-zinc-800/80 bg-[#0a0a0b]">
+      <div className="flex flex-col flex-1 min-w-0 justify-between md:h-full">
+        {/* Status bar */}
+        <div className="min-h-[44px] md:h-[48px] shrink-0 flex items-center justify-center px-4 md:px-6 py-2 border-b border-zinc-800/80 bg-[#0a0a0b]">
           <span
-            className="text-xs md:text-[13px] font-semibold tracking-tight text-center leading-tight transition-colors duration-150 truncate max-w-full"
+            className="text-xs md:text-[13px] font-semibold tracking-tight text-center leading-tight transition-colors duration-150"
             style={{
               color: finished
                 ? "#10b981"
@@ -272,7 +269,7 @@ export default function BubbleSortVisualizer() {
         </div>
 
         {/* Bar chart container */}
-        <div className="flex items-end justify-center px-2 sm:px-6 pt-6 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[220px]">
+        <div className="flex items-end justify-center px-2 sm:px-6 pt-5 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[180px] md:min-h-[220px]">
           <div
             className="relative flex items-end justify-center max-w-full"
             style={{
@@ -327,7 +324,7 @@ export default function BubbleSortVisualizer() {
         </div>
 
         {/* Legend */}
-        <div className="h-[40px] shrink-0 flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
+        <div className="min-h-[38px] shrink-0 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
           {[
             { color: "#3f3f46", label: "Unsorted" },
             { color: "#fbbf24", label: "Comparing" },
@@ -336,10 +333,10 @@ export default function BubbleSortVisualizer() {
           ].map(({ color, label }) => (
             <div key={label} className="flex items-center gap-1.5">
               <span
-                className="rounded-sm inline-block w-2 h-2"
+                className="rounded-sm inline-block w-2 h-2 shrink-0"
                 style={{ background: color }}
               />
-              <span className="text-[10px] font-medium text-zinc-400">
+              <span className="text-[10px] font-medium text-zinc-400 whitespace-nowrap">
                 {label}
               </span>
             </div>
@@ -347,14 +344,13 @@ export default function BubbleSortVisualizer() {
         </div>
 
         {/* Play controls */}
-        <div className="h-[56px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
+        <div className="min-h-[52px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
           <button
             id="bsv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
-            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
+            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
             style={{
-              padding: "9px 20px",
               background: finished ? "#059669" : "#FF5757",
             }}
           >
@@ -372,18 +368,15 @@ export default function BubbleSortVisualizer() {
             <button
               type="button"
               onClick={reset}
-              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
-              style={{
-                padding: "9px 20px",
-              }}
+              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
             >
               Reset
             </button>
           )}
         </div>
 
-        {/* Step log container - fixed height prevents screen shifting */}
-        <div className="h-[135px] shrink-0 mx-4 sm:mx-6 mb-4 rounded-xl border border-zinc-800/80 bg-[#111113] overflow-hidden flex flex-col">
+        {/* Step log container */}
+        <div className="h-[135px] shrink-0 mx-3 sm:mx-6 mb-3 sm:mb-4 rounded-xl border border-zinc-800/80 bg-[#111113] overflow-hidden flex flex-col">
           <div className="px-4 py-2 border-b border-zinc-800/80 shrink-0 bg-[#0a0a0b]">
             <span className="text-[10px] font-semibold uppercase tracking-wider text-zinc-400">
               Step log

--- a/packages/components/src/visualizers/BubbleSortVisualizer.tsx
+++ b/packages/components/src/visualizers/BubbleSortVisualizer.tsx
@@ -176,31 +176,31 @@ export default function BubbleSortVisualizer() {
   const transMs = currentSpeed.transitionMs;
 
   return (
-    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#09090b] border border-gray-800 shadow-xl min-h-[380px]">
-      {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
-      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[190px] border-b md:border-b-0 md:border-r border-gray-800 bg-[#070709]">
-        {/* Array Size */}
-        <div>
-          <p className="text-[9px] font-black uppercase tracking-widest mb-2 text-gray-500">
+    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl min-h-[500px] md:h-[520px]">
+      {/* ══ LEFT SIDEBAR / TOP CONTROLS ══ */}
+      <div className="flex flex-col gap-3.5 p-4 md:p-5 shrink-0 w-full md:w-[210px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#0A0A0B]">
+        {/* Array Size Block */}
+        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+          <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Array Size
           </p>
-          <div className="flex items-center justify-between mb-1.5">
-            <span className="text-[11px] font-mono text-gray-400">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-medium text-zinc-400">
               {MIN_SIZE}
             </span>
-            <span className="text-lg md:text-xl font-black tabular-nums text-red-500">
+            <span className="text-xl font-bold tabular-nums text-[#FF5757]">
               {arraySize}
             </span>
-            <span className="text-[11px] font-mono text-gray-400">
+            <span className="text-xs font-medium text-zinc-400">
               {MAX_SIZE}
             </span>
           </div>
 
           {/* Custom styled range slider */}
           <div className="relative flex items-center" style={{ height: 20 }}>
-            <div className="absolute w-full rounded-full h-1 bg-gray-800" />
+            <div className="absolute w-full rounded-full h-1 bg-zinc-800" />
             <div
-              className="absolute rounded-full h-1 bg-red-500 transition-all duration-150"
+              className="absolute rounded-full h-1 bg-[#FF5757] transition-all duration-150"
               style={{
                 width: `${((arraySize - MIN_SIZE) / (MAX_SIZE - MIN_SIZE)) * 100}%`,
               }}
@@ -221,27 +221,27 @@ export default function BubbleSortVisualizer() {
           id="bsv-generate"
           type="button"
           onClick={() => generate(arraySize)}
-          className="w-full rounded-lg text-xs font-bold py-2 bg-gray-800 hover:bg-gray-700 border border-gray-700 text-gray-200 transition-all active:scale-95 cursor-pointer"
+          className="w-full rounded-xl text-xs font-semibold py-2.5 bg-[#111113] hover:bg-zinc-800/80 border border-zinc-800/80 hover:border-zinc-700/60 text-zinc-200 transition-all active:scale-[0.98] cursor-pointer"
         >
           ↻ Randomize
         </button>
 
-        {/* Speed */}
-        <div>
-          <p className="text-[9px] font-black uppercase tracking-widest mb-2 text-gray-500">
+        {/* Speed Block */}
+        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+          <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Speed
           </p>
-          <div className="flex flex-row md:flex-col gap-1 overflow-x-auto scrollbar-none pb-1 md:pb-0">
+          <div className="flex flex-row md:flex-col gap-1.5 overflow-x-auto scrollbar-none">
             {SPEEDS.map(({ label }, i) => (
               <button
                 key={label}
                 id={`bsv-speed-${i}`}
                 type="button"
                 onClick={() => setSpeedIdx(i)}
-                className={`flex-1 md:w-full rounded-md text-[11px] font-bold transition-all active:scale-95 cursor-pointer text-center md:text-left px-2.5 py-1.5 whitespace-nowrap ${
+                className={`flex-1 md:w-full rounded-lg text-xs transition-all active:scale-[0.98] cursor-pointer text-center md:text-left px-3 py-1.5 whitespace-nowrap ${
                   speedIdx === i
-                    ? "bg-gray-800 text-white border border-gray-700"
-                    : "bg-transparent text-gray-500 border border-transparent hover:text-gray-300"
+                    ? "bg-[#FF5757]/15 text-[#FF5757] border border-[#FF5757]/40 font-semibold shadow-sm"
+                    : "bg-[#111113] text-zinc-400 border border-zinc-800/80 hover:text-zinc-200 hover:border-zinc-700/60 font-medium"
                 }`}
               >
                 {label}
@@ -249,23 +249,14 @@ export default function BubbleSortVisualizer() {
             ))}
           </div>
         </div>
-
-        {/* Divider */}
-        <div className="hidden md:block border-t border-gray-800" />
-
-        {/* Stats */}
-        <div className="flex flex-row md:flex-col justify-between md:justify-start gap-4 md:gap-2 border-t md:border-t-0 border-gray-800 pt-3 md:pt-0">
-          <StatRow label="Steps" value={steps.length - 1} />
-          <StatRow label="Step" value={`${idx} / ${steps.length - 1}`} />
-        </div>
       </div>
 
       {/* ══ RIGHT — CHART + CONTROLS ══ */}
-      <div className="flex flex-col flex-1 min-w-0">
-        {/* Status bar */}
-        <div className="flex items-center justify-center px-4 md:px-6 py-2.5 min-h-[44px] border-b border-[#111113]">
+      <div className="flex flex-col flex-1 min-w-0 justify-between h-full">
+        {/* Fixed height Status bar */}
+        <div className="h-[48px] shrink-0 flex items-center justify-center px-4 md:px-6 border-b border-zinc-800/80 bg-[#0a0a0b]">
           <span
-            className="text-xs md:text-[13px] font-semibold tracking-wide text-center leading-tight transition-colors duration-150"
+            className="text-xs md:text-[13px] font-semibold tracking-tight text-center leading-tight transition-colors duration-150 truncate max-w-full"
             style={{
               color: finished
                 ? "#10b981"
@@ -273,15 +264,15 @@ export default function BubbleSortVisualizer() {
                   ? "#f87171"
                   : step.comparing
                     ? "#fbbf24"
-                    : "#6b7280",
+                    : "#a1a1aa",
             }}
           >
             {step.description}
           </span>
         </div>
 
-        {/* Bar chart */}
-        <div className="flex items-end justify-center px-2 sm:px-6 pt-5 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[200px]">
+        {/* Bar chart container */}
+        <div className="flex items-end justify-center px-2 sm:px-6 pt-6 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[220px]">
           <div
             className="relative flex items-end justify-center max-w-full"
             style={{
@@ -321,7 +312,7 @@ export default function BubbleSortVisualizer() {
                       width: "100%",
                       height: barH,
                       background: color,
-                      borderRadius: "5px 5px 2px 2px",
+                      borderRadius: "6px 6px 2px 2px",
                       transition: `background-color ${transMs}ms ease, height ${transMs}ms cubic-bezier(0.4,0,0.2,1)`,
                       boxShadow:
                         step.swapped && step.comparing?.includes(i)
@@ -336,9 +327,9 @@ export default function BubbleSortVisualizer() {
         </div>
 
         {/* Legend */}
-        <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2.5 px-3 border-t border-b border-gray-800/80">
+        <div className="h-[40px] shrink-0 flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
           {[
-            { color: "#374151", label: "Unsorted" },
+            { color: "#3f3f46", label: "Unsorted" },
             { color: "#fbbf24", label: "Comparing" },
             { color: "#f87171", label: "Swapping" },
             { color: "#10b981", label: "Sorted" },
@@ -348,21 +339,23 @@ export default function BubbleSortVisualizer() {
                 className="rounded-sm inline-block w-2 h-2"
                 style={{ background: color }}
               />
-              <span className="text-[10px] text-gray-500">{label}</span>
+              <span className="text-[10px] font-medium text-zinc-400">
+                {label}
+              </span>
             </div>
           ))}
         </div>
 
         {/* Play controls */}
-        <div className="flex items-center gap-3 px-4 sm:px-6 py-3 sm:py-4">
+        <div className="h-[56px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
           <button
             id="bsv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
-            className="flex items-center gap-2 rounded-lg text-white text-xs font-bold tracking-wide cursor-pointer active:scale-95 transition-all shadow-md"
+            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
             style={{
-              padding: "8px 18px",
-              background: finished ? "#059669" : "#ef4444",
+              padding: "9px 20px",
+              background: finished ? "#059669" : "#FF5757",
             }}
           >
             {finished ? <IconReset /> : playing ? <IconPause /> : <IconPlay />}
@@ -379,36 +372,39 @@ export default function BubbleSortVisualizer() {
             <button
               type="button"
               onClick={reset}
-              className="rounded-lg text-xs font-bold cursor-pointer active:scale-95 transition-all px-3.5 py-2 border border-gray-700 text-gray-400 hover:text-white bg-transparent"
+              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
+              style={{
+                padding: "9px 20px",
+              }}
             >
               Reset
             </button>
           )}
         </div>
 
-        {/* Step log */}
-        <div className="mx-4 sm:mx-6 mb-4 sm:mb-6 rounded-xl border border-gray-800 bg-[#050507] overflow-hidden flex-1">
-          <div className="px-4 py-2 border-b border-[#111113]">
-            <span className="text-[9px] font-black uppercase tracking-widest text-gray-600">
+        {/* Step log container - fixed height prevents screen shifting */}
+        <div className="h-[135px] shrink-0 mx-4 sm:mx-6 mb-4 rounded-xl border border-zinc-800/80 bg-[#111113] overflow-hidden flex flex-col">
+          <div className="px-4 py-2 border-b border-zinc-800/80 shrink-0 bg-[#0a0a0b]">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-zinc-400">
               Step log
             </span>
           </div>
-          <div>
+          <div className="flex-1 overflow-y-auto scrollbar-thin-grey">
             {log.map((s, i) => (
               <div
                 key={i}
                 className={`flex items-center gap-3 px-4 py-1.5 ${
-                  i === 0 ? "bg-white/[0.02]" : "bg-transparent"
-                } ${i < log.length - 1 ? "border-b border-[#0d0d0f]" : ""}`}
+                  i === 0 ? "bg-white/[0.03]" : "bg-transparent"
+                } ${i < log.length - 1 ? "border-b border-zinc-900" : ""}`}
               >
                 <span
                   className={`rounded-full shrink-0 w-1.5 h-1.5 inline-block ${
-                    i === 0 ? "bg-red-500" : "bg-gray-800"
+                    i === 0 ? "bg-[#FF5757]" : "bg-zinc-800"
                   }`}
                 />
                 <span
                   className={`text-[11px] font-mono ${
-                    i === 0 ? "text-gray-300 font-semibold" : "text-gray-600"
+                    i === 0 ? "text-zinc-200 font-semibold" : "text-zinc-500"
                   }`}
                 >
                   {s.description}

--- a/packages/components/src/visualizers/BubbleSortVisualizer.tsx
+++ b/packages/components/src/visualizers/BubbleSortVisualizer.tsx
@@ -175,7 +175,7 @@ export default function BubbleSortVisualizer() {
   return (
     <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl md:h-[520px]">
       {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
-      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[200px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#070709]">
+      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[200px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#0A0A0B]">
         {/* Array Size */}
         <div>
           <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
@@ -324,7 +324,7 @@ export default function BubbleSortVisualizer() {
         </div>
 
         {/* Legend */}
-        <div className="min-h-[38px] shrink-0 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
+        <div className="shrink-0 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/60">
           {[
             { color: "#3f3f46", label: "Unsorted" },
             { color: "#fbbf24", label: "Comparing" },
@@ -333,10 +333,10 @@ export default function BubbleSortVisualizer() {
           ].map(({ color, label }) => (
             <div key={label} className="flex items-center gap-1.5">
               <span
-                className="rounded-sm inline-block w-2 h-2 shrink-0"
+                className="rounded-full inline-block w-1.5 h-1.5 shrink-0"
                 style={{ background: color }}
               />
-              <span className="text-[10px] font-medium text-zinc-400 whitespace-nowrap">
+              <span className="text-[11px] font-medium text-zinc-400 whitespace-nowrap">
                 {label}
               </span>
             </div>
@@ -344,12 +344,12 @@ export default function BubbleSortVisualizer() {
         </div>
 
         {/* Play controls */}
-        <div className="min-h-[52px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
+        <div className="shrink-0 flex items-center gap-2.5 px-3 sm:px-6 py-2">
           <button
             id="bsv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
-            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
+            className="flex items-center gap-1.5 rounded-lg text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-3.5 py-1.5 shadow-[0_2px_10px_rgba(255,87,87,0.25)]"
             style={{
               background: finished ? "#059669" : "#FF5757",
             }}
@@ -368,7 +368,7 @@ export default function BubbleSortVisualizer() {
             <button
               type="button"
               onClick={reset}
-              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
+              className="flex items-center gap-1.5 rounded-lg text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-3.5 py-1.5 border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
             >
               Reset
             </button>

--- a/packages/components/src/visualizers/BubbleSortVisualizer.tsx
+++ b/packages/components/src/visualizers/BubbleSortVisualizer.tsx
@@ -100,11 +100,12 @@ const DEFAULT_SIZE = 7;
 ────────────────────────────────────────────────── */
 export default function BubbleSortVisualizer() {
   const [arraySize, setArraySize] = useState(DEFAULT_SIZE);
-  const [baseArray, setBaseArray] = useState<number[]>(() =>
-    randomArray(DEFAULT_SIZE),
+  const initialArray = useRef<number[]>(randomArray(DEFAULT_SIZE));
+  const [baseArray, setBaseArray] = useState<number[]>(
+    () => initialArray.current,
   );
   const [steps, setSteps] = useState<SortStep[]>(() =>
-    generateSteps(randomArray(DEFAULT_SIZE)),
+    generateSteps(initialArray.current),
   );
   const [idx, setIdx] = useState(0);
   const [playing, setPlaying] = useState(false);
@@ -414,21 +415,6 @@ export default function BubbleSortVisualizer() {
 /* ──────────────────────────────────────────────────
    Sub-components
 ────────────────────────────────────────────────── */
-function StatRow({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="flex items-center justify-between">
-      <span className="text-[10px]" style={{ color: "#4b5563" }}>
-        {label}
-      </span>
-      <span
-        className="text-[11px] font-mono font-bold"
-        style={{ color: "#9ca3af" }}
-      >
-        {value}
-      </span>
-    </div>
-  );
-}
 
 function IconPlay() {
   return (

--- a/packages/components/src/visualizers/MergeSortVisualizer.tsx
+++ b/packages/components/src/visualizers/MergeSortVisualizer.tsx
@@ -261,11 +261,10 @@ export default function MergeSortVisualizer() {
   const transMs = currentSpeed.transitionMs;
 
   return (
-    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl min-h-[500px] md:h-[520px]">
-      {/* ══ LEFT SIDEBAR / TOP CONTROLS ══ */}
-      <div className="flex flex-col gap-3.5 p-4 md:p-5 shrink-0 w-full md:w-[210px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#0A0A0B]">
-        {/* Array Size Block */}
-        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl md:h-[520px]">
+      {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
+      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[200px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#070709]">
+        <div>
           <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Array Size
           </p>
@@ -304,17 +303,16 @@ export default function MergeSortVisualizer() {
           id="msv-generate"
           type="button"
           onClick={() => generate(arraySize)}
-          className="w-full rounded-xl text-xs font-semibold py-2.5 bg-[#111113] hover:bg-zinc-800/80 border border-zinc-800/80 hover:border-zinc-700/60 text-zinc-200 transition-all active:scale-[0.98] cursor-pointer"
+          className="w-full rounded-xl text-xs font-semibold py-2 bg-[#111113] hover:bg-zinc-800/80 border border-zinc-800/80 hover:border-zinc-700/60 text-zinc-200 transition-all active:scale-[0.98] cursor-pointer"
         >
           ↻ Randomize
         </button>
 
-        {/* Speed Block */}
-        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+        <div>
           <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Speed
           </p>
-          <div className="flex flex-row md:flex-col gap-1.5 overflow-x-auto scrollbar-none">
+          <div className="flex flex-row md:flex-col gap-1.5 overflow-x-auto scrollbar-none pb-1 md:pb-0">
             {SPEEDS.map(({ label }, i) => (
               <button
                 key={label}
@@ -335,11 +333,11 @@ export default function MergeSortVisualizer() {
       </div>
 
       {/* ══ RIGHT — CHART + CONTROLS ══ */}
-      <div className="flex flex-col flex-1 min-w-0 justify-between h-full">
+      <div className="flex flex-col flex-1 min-w-0 justify-between md:h-full">
         {/* Status bar */}
-        <div className="h-[48px] shrink-0 flex items-center justify-center px-4 md:px-6 border-b border-zinc-800/80 bg-[#0a0a0b]">
+        <div className="min-h-[44px] md:h-[48px] shrink-0 flex items-center justify-center px-4 md:px-6 py-2 border-b border-zinc-800/80 bg-[#0a0a0b]">
           <span
-            className="text-xs md:text-[13px] font-semibold tracking-tight text-center leading-tight transition-colors duration-150 truncate max-w-full"
+            className="text-xs md:text-[13px] font-semibold tracking-tight text-center leading-tight transition-colors duration-150"
             style={{
               color: finished
                 ? "#10b981"
@@ -357,7 +355,7 @@ export default function MergeSortVisualizer() {
         </div>
 
         {/* Bar chart container */}
-        <div className="flex items-end justify-center px-2 sm:px-6 pt-6 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[220px]">
+        <div className="flex items-end justify-center px-2 sm:px-6 pt-5 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[180px] md:min-h-[220px]">
           <div
             className="relative flex items-end justify-center max-w-full"
             style={{
@@ -412,7 +410,7 @@ export default function MergeSortVisualizer() {
         </div>
 
         {/* Legend */}
-        <div className="h-[40px] shrink-0 flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
+        <div className="min-h-[38px] shrink-0 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
           {[
             { color: "#3f3f46", label: "Unsorted" },
             { color: "#60a5fa", label: "Active Subarray" },
@@ -422,10 +420,10 @@ export default function MergeSortVisualizer() {
           ].map(({ color, label }) => (
             <div key={label} className="flex items-center gap-1.5">
               <span
-                className="rounded-sm inline-block w-2 h-2"
+                className="rounded-sm inline-block w-2 h-2 shrink-0"
                 style={{ background: color }}
               />
-              <span className="text-[10px] font-medium text-zinc-400">
+              <span className="text-[10px] font-medium text-zinc-400 whitespace-nowrap">
                 {label}
               </span>
             </div>
@@ -433,14 +431,13 @@ export default function MergeSortVisualizer() {
         </div>
 
         {/* Play controls */}
-        <div className="h-[56px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
+        <div className="min-h-[52px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
           <button
             id="msv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
-            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
+            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
             style={{
-              padding: "9px 20px",
               background: finished ? "#059669" : "#FF5757",
             }}
           >
@@ -458,10 +455,7 @@ export default function MergeSortVisualizer() {
             <button
               type="button"
               onClick={reset}
-              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
-              style={{
-                padding: "9px 20px",
-              }}
+              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
             >
               Reset
             </button>

--- a/packages/components/src/visualizers/MergeSortVisualizer.tsx
+++ b/packages/components/src/visualizers/MergeSortVisualizer.tsx
@@ -261,29 +261,30 @@ export default function MergeSortVisualizer() {
   const transMs = currentSpeed.transitionMs;
 
   return (
-    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#09090b] border border-gray-800 shadow-xl min-h-[380px]">
-      {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
-      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[190px] border-b md:border-b-0 md:border-r border-gray-800 bg-[#070709]">
-        <div>
-          <p className="text-[9px] font-black uppercase tracking-widest mb-2 text-gray-500">
+    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl min-h-[500px] md:h-[520px]">
+      {/* ══ LEFT SIDEBAR / TOP CONTROLS ══ */}
+      <div className="flex flex-col gap-3.5 p-4 md:p-5 shrink-0 w-full md:w-[210px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#0A0A0B]">
+        {/* Array Size Block */}
+        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+          <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Array Size
           </p>
-          <div className="flex items-center justify-between mb-1.5">
-            <span className="text-[11px] font-mono text-gray-400">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-medium text-zinc-400">
               {MIN_SIZE}
             </span>
-            <span className="text-lg md:text-xl font-black tabular-nums text-red-500">
+            <span className="text-xl font-bold tabular-nums text-[#FF5757]">
               {arraySize}
             </span>
-            <span className="text-[11px] font-mono text-gray-400">
+            <span className="text-xs font-medium text-zinc-400">
               {MAX_SIZE}
             </span>
           </div>
 
           <div className="relative flex items-center" style={{ height: 20 }}>
-            <div className="absolute w-full rounded-full h-1 bg-gray-800" />
+            <div className="absolute w-full rounded-full h-1 bg-zinc-800" />
             <div
-              className="absolute rounded-full h-1 bg-red-500 transition-all duration-150"
+              className="absolute rounded-full h-1 bg-[#FF5757] transition-all duration-150"
               style={{
                 width: `${((arraySize - MIN_SIZE) / (MAX_SIZE - MIN_SIZE)) * 100}%`,
               }}
@@ -303,26 +304,27 @@ export default function MergeSortVisualizer() {
           id="msv-generate"
           type="button"
           onClick={() => generate(arraySize)}
-          className="w-full rounded-lg text-xs font-bold py-2 bg-gray-800 hover:bg-gray-700 border border-gray-700 text-gray-200 transition-all active:scale-95 cursor-pointer"
+          className="w-full rounded-xl text-xs font-semibold py-2.5 bg-[#111113] hover:bg-zinc-800/80 border border-zinc-800/80 hover:border-zinc-700/60 text-zinc-200 transition-all active:scale-[0.98] cursor-pointer"
         >
           ↻ Randomize
         </button>
 
-        <div>
-          <p className="text-[9px] font-black uppercase tracking-widest mb-2 text-gray-500">
+        {/* Speed Block */}
+        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+          <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Speed
           </p>
-          <div className="flex flex-row md:flex-col gap-1 overflow-x-auto scrollbar-none pb-1 md:pb-0">
+          <div className="flex flex-row md:flex-col gap-1.5 overflow-x-auto scrollbar-none">
             {SPEEDS.map(({ label }, i) => (
               <button
                 key={label}
                 id={`msv-speed-${i}`}
                 type="button"
                 onClick={() => setSpeedIdx(i)}
-                className={`flex-1 md:w-full rounded-md text-[11px] font-bold transition-all active:scale-95 cursor-pointer text-center md:text-left px-2.5 py-1.5 whitespace-nowrap ${
+                className={`flex-1 md:w-full rounded-lg text-xs transition-all active:scale-[0.98] cursor-pointer text-center md:text-left px-3 py-1.5 whitespace-nowrap ${
                   speedIdx === i
-                    ? "bg-gray-800 text-white border border-gray-700"
-                    : "bg-transparent text-gray-500 border border-transparent hover:text-gray-300"
+                    ? "bg-[#FF5757]/15 text-[#FF5757] border border-[#FF5757]/40 font-semibold shadow-sm"
+                    : "bg-[#111113] text-zinc-400 border border-zinc-800/80 hover:text-zinc-200 hover:border-zinc-700/60 font-medium"
                 }`}
               >
                 {label}
@@ -330,20 +332,14 @@ export default function MergeSortVisualizer() {
             ))}
           </div>
         </div>
-
-        <div className="hidden md:block border-t border-gray-800" />
-
-        <div className="flex flex-row md:flex-col justify-between md:justify-start gap-4 md:gap-2 border-t md:border-t-0 border-gray-800 pt-3 md:pt-0">
-          <StatRow label="Steps" value={steps.length - 1} />
-          <StatRow label="Step" value={`${idx} / ${steps.length - 1}`} />
-        </div>
       </div>
 
       {/* ══ RIGHT — CHART + CONTROLS ══ */}
-      <div className="flex flex-col flex-1 min-w-0">
-        <div className="flex items-center justify-center px-4 md:px-6 py-2.5 min-h-[44px] border-b border-[#111113]">
+      <div className="flex flex-col flex-1 min-w-0 justify-between h-full">
+        {/* Status bar */}
+        <div className="h-[48px] shrink-0 flex items-center justify-center px-4 md:px-6 border-b border-zinc-800/80 bg-[#0a0a0b]">
           <span
-            className="text-xs md:text-[13px] font-semibold tracking-wide text-center leading-tight transition-colors duration-150"
+            className="text-xs md:text-[13px] font-semibold tracking-tight text-center leading-tight transition-colors duration-150 truncate max-w-full"
             style={{
               color: finished
                 ? "#10b981"
@@ -353,14 +349,15 @@ export default function MergeSortVisualizer() {
                     ? "#fbbf24"
                     : step.activeRange !== null
                       ? "#60a5fa"
-                      : "#6b7280",
+                      : "#a1a1aa",
             }}
           >
             {step.description}
           </span>
         </div>
 
-        <div className="flex items-end justify-center px-2 sm:px-6 pt-5 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[200px]">
+        {/* Bar chart container */}
+        <div className="flex items-end justify-center px-2 sm:px-6 pt-6 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[220px]">
           <div
             className="relative flex items-end justify-center max-w-full"
             style={{
@@ -400,7 +397,7 @@ export default function MergeSortVisualizer() {
                       width: "100%",
                       height: barH,
                       background: color,
-                      borderRadius: "5px 5px 2px 2px",
+                      borderRadius: "6px 6px 2px 2px",
                       transition: `background-color ${transMs}ms ease, height ${transMs}ms cubic-bezier(0.4,0,0.2,1)`,
                       boxShadow:
                         step.writingIndex === i || step.comparing?.includes(i)
@@ -414,9 +411,10 @@ export default function MergeSortVisualizer() {
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2.5 px-3 border-t border-b border-gray-800/80">
+        {/* Legend */}
+        <div className="h-[40px] shrink-0 flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
           {[
-            { color: "#374151", label: "Unsorted" },
+            { color: "#3f3f46", label: "Unsorted" },
             { color: "#60a5fa", label: "Active Subarray" },
             { color: "#fbbf24", label: "Comparing" },
             { color: "#06b6d4", label: "Writing Merged" },
@@ -427,20 +425,23 @@ export default function MergeSortVisualizer() {
                 className="rounded-sm inline-block w-2 h-2"
                 style={{ background: color }}
               />
-              <span className="text-[10px] text-gray-500">{label}</span>
+              <span className="text-[10px] font-medium text-zinc-400">
+                {label}
+              </span>
             </div>
           ))}
         </div>
 
-        <div className="flex items-center gap-3 px-4 sm:px-6 py-3 sm:py-4">
+        {/* Play controls */}
+        <div className="h-[56px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
           <button
             id="msv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
-            className="flex items-center gap-2 rounded-lg text-white text-xs font-bold tracking-wide cursor-pointer active:scale-95 transition-all shadow-md"
+            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
             style={{
-              padding: "8px 18px",
-              background: finished ? "#059669" : "#ef4444",
+              padding: "9px 20px",
+              background: finished ? "#059669" : "#FF5757",
             }}
           >
             {finished ? <IconReset /> : playing ? <IconPause /> : <IconPlay />}
@@ -457,35 +458,39 @@ export default function MergeSortVisualizer() {
             <button
               type="button"
               onClick={reset}
-              className="rounded-lg text-xs font-bold cursor-pointer active:scale-95 transition-all px-3.5 py-2 border border-gray-700 text-gray-400 hover:text-white bg-transparent"
+              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
+              style={{
+                padding: "9px 20px",
+              }}
             >
               Reset
             </button>
           )}
         </div>
 
-        <div className="mx-4 sm:mx-6 mb-4 sm:mb-6 rounded-xl border border-gray-800 bg-[#050507] overflow-hidden flex-1">
-          <div className="px-4 py-2 border-b border-[#111113]">
-            <span className="text-[9px] font-black uppercase tracking-widest text-gray-600">
+        {/* Step log container - fixed height prevents screen shifting */}
+        <div className="h-[135px] shrink-0 mx-4 sm:mx-6 mb-4 rounded-xl border border-zinc-800/80 bg-[#111113] overflow-hidden flex flex-col">
+          <div className="px-4 py-2 border-b border-zinc-800/80 shrink-0 bg-[#0a0a0b]">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-zinc-400">
               Step log
             </span>
           </div>
-          <div>
+          <div className="flex-1 overflow-y-auto scrollbar-thin-grey">
             {log.map((s, i) => (
               <div
                 key={i}
                 className={`flex items-center gap-3 px-4 py-1.5 ${
-                  i === 0 ? "bg-white/[0.02]" : "bg-transparent"
-                } ${i < log.length - 1 ? "border-b border-[#0d0d0f]" : ""}`}
+                  i === 0 ? "bg-white/[0.03]" : "bg-transparent"
+                } ${i < log.length - 1 ? "border-b border-zinc-900" : ""}`}
               >
                 <span
                   className={`rounded-full shrink-0 w-1.5 h-1.5 inline-block ${
-                    i === 0 ? "bg-red-500" : "bg-gray-800"
+                    i === 0 ? "bg-[#FF5757]" : "bg-zinc-800"
                   }`}
                 />
                 <span
                   className={`text-[11px] font-mono ${
-                    i === 0 ? "text-gray-300 font-semibold" : "text-gray-600"
+                    i === 0 ? "text-zinc-200 font-semibold" : "text-zinc-500"
                   }`}
                 >
                   {s.description}
@@ -502,10 +507,8 @@ export default function MergeSortVisualizer() {
 function StatRow({ label, value }: { label: string; value: string | number }) {
   return (
     <div className="flex items-center justify-between">
-      <span className="text-[10px] text-gray-500">{label}</span>
-      <span className="text-[11px] font-mono font-bold text-gray-400">
-        {value}
-      </span>
+      <span className="text-xs font-medium text-zinc-400">{label}</span>
+      <span className="text-xs font-semibold text-zinc-200">{value}</span>
     </div>
   );
 }

--- a/packages/components/src/visualizers/MergeSortVisualizer.tsx
+++ b/packages/components/src/visualizers/MergeSortVisualizer.tsx
@@ -191,11 +191,12 @@ const DEFAULT_SIZE = 7;
 ────────────────────────────────────────────────── */
 export default function MergeSortVisualizer() {
   const [arraySize, setArraySize] = useState(DEFAULT_SIZE);
-  const [baseArray, setBaseArray] = useState<number[]>(() =>
-    randomArray(DEFAULT_SIZE),
+  const initialArray = useRef<number[]>(randomArray(DEFAULT_SIZE));
+  const [baseArray, setBaseArray] = useState<number[]>(
+    () => initialArray.current,
   );
   const [steps, setSteps] = useState<SortStep[]>(() =>
-    generateMergeSortSteps(randomArray(DEFAULT_SIZE)),
+    generateMergeSortSteps(initialArray.current),
   );
   const [idx, setIdx] = useState(0);
   const [playing, setPlaying] = useState(false);
@@ -494,15 +495,6 @@ export default function MergeSortVisualizer() {
           </div>
         </div>
       </div>
-    </div>
-  );
-}
-
-function StatRow({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="flex items-center justify-between">
-      <span className="text-xs font-medium text-zinc-400">{label}</span>
-      <span className="text-xs font-semibold text-zinc-200">{value}</span>
     </div>
   );
 }

--- a/packages/components/src/visualizers/MergeSortVisualizer.tsx
+++ b/packages/components/src/visualizers/MergeSortVisualizer.tsx
@@ -263,7 +263,7 @@ export default function MergeSortVisualizer() {
   return (
     <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl md:h-[520px]">
       {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
-      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[200px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#070709]">
+      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[200px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#0A0A0B]">
         <div>
           <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Array Size
@@ -410,7 +410,7 @@ export default function MergeSortVisualizer() {
         </div>
 
         {/* Legend */}
-        <div className="min-h-[38px] shrink-0 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
+        <div className="shrink-0 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/60">
           {[
             { color: "#3f3f46", label: "Unsorted" },
             { color: "#60a5fa", label: "Active Subarray" },
@@ -420,10 +420,10 @@ export default function MergeSortVisualizer() {
           ].map(({ color, label }) => (
             <div key={label} className="flex items-center gap-1.5">
               <span
-                className="rounded-sm inline-block w-2 h-2 shrink-0"
+                className="rounded-full inline-block w-1.5 h-1.5 shrink-0"
                 style={{ background: color }}
               />
-              <span className="text-[10px] font-medium text-zinc-400 whitespace-nowrap">
+              <span className="text-[11px] font-medium text-zinc-400 whitespace-nowrap">
                 {label}
               </span>
             </div>
@@ -431,12 +431,12 @@ export default function MergeSortVisualizer() {
         </div>
 
         {/* Play controls */}
-        <div className="min-h-[52px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
+        <div className="shrink-0 flex items-center gap-2.5 px-3 sm:px-6 py-2">
           <button
             id="msv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
-            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
+            className="flex items-center gap-1.5 rounded-lg text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-3.5 py-1.5 shadow-[0_2px_10px_rgba(255,87,87,0.25)]"
             style={{
               background: finished ? "#059669" : "#FF5757",
             }}
@@ -455,7 +455,7 @@ export default function MergeSortVisualizer() {
             <button
               type="button"
               onClick={reset}
-              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
+              className="flex items-center gap-1.5 rounded-lg text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-3.5 py-1.5 border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
             >
               Reset
             </button>

--- a/packages/components/src/visualizers/MergeSortVisualizer.tsx
+++ b/packages/components/src/visualizers/MergeSortVisualizer.tsx
@@ -5,64 +5,148 @@ import { useCallback, useEffect, useRef, useState } from "react";
 ────────────────────────────────────────────────── */
 interface SortStep {
   array: number[];
+  activeRange: [number, number] | null;
   comparing: [number, number] | null;
-  swapped: boolean;
-  sortedValues: number[];
+  writingIndex: number | null;
+  sortedIndices: number[];
   description: string;
 }
 
 /* ──────────────────────────────────────────────────
-   Step generator
+   Step generator for Merge Sort
 ────────────────────────────────────────────────── */
-function generateSteps(input: number[]): SortStep[] {
+function generateMergeSortSteps(input: number[]): SortStep[] {
   const steps: SortStep[] = [];
   const arr = [...input];
-  const n = arr.length;
   const sortedSet = new Set<number>();
 
   const snap = (
+    activeRange: [number, number] | null,
     comparing: [number, number] | null,
-    swapped: boolean,
+    writingIndex: number | null,
     description: string,
   ) =>
     steps.push({
       array: [...arr],
+      activeRange,
       comparing,
-      swapped,
-      sortedValues: Array.from(sortedSet),
+      writingIndex,
+      sortedIndices: Array.from(sortedSet),
       description,
     });
 
-  snap(null, false, "Ready — press Start");
+  snap(null, null, null, "Ready — press Start");
 
-  for (let i = 0; i < n - 1; i++) {
-    let didSwap = false;
-    for (let j = 0; j < n - i - 1; j++) {
-      const val1 = arr[j];
-      const val2 = arr[j + 1];
-      if (val1 !== undefined && val2 !== undefined) {
-        snap([j, j + 1], false, `Comparing  ${val1}  and  ${val2}`);
-        if (val1 > val2) {
-          arr[j] = val2;
-          arr[j + 1] = val1;
-          didSwap = true;
-          snap([j, j + 1], true, `Swap  ${val2}  ↔  ${val1}`);
-        }
+  function merge(left: number, mid: number, right: number) {
+    const leftArr = arr.slice(left, mid + 1);
+    const rightArr = arr.slice(mid + 1, right + 1);
+
+    snap(
+      [left, right],
+      null,
+      null,
+      `Merging subarray [${left}..${mid}] and [${mid + 1}..${right}]`,
+    );
+
+    let i = 0;
+    let j = 0;
+    let k = left;
+
+    while (i < leftArr.length && j < rightArr.length) {
+      const leftVal = leftArr[i]!;
+      const rightVal = rightArr[j]!;
+      const actualLeftIdx = left + i;
+      const actualRightIdx = mid + 1 + j;
+
+      snap(
+        [left, right],
+        [actualLeftIdx, actualRightIdx],
+        k,
+        `Comparing left element ${leftVal} with right element ${rightVal}`,
+      );
+
+      if (leftVal <= rightVal) {
+        snap(
+          [left, right],
+          [actualLeftIdx, actualRightIdx],
+          k,
+          `Writing smaller element ${leftVal} to position ${k}`,
+        );
+        arr[k] = leftVal;
+        i++;
+      } else {
+        snap(
+          [left, right],
+          [actualLeftIdx, actualRightIdx],
+          k,
+          `Writing smaller element ${rightVal} to position ${k}`,
+        );
+        arr[k] = rightVal;
+        j++;
       }
+      k++;
     }
-    const finalVal = arr[n - 1 - i];
-    if (finalVal !== undefined) {
-      sortedSet.add(finalVal);
-      snap(null, false, `${finalVal} is in its final position`);
+
+    while (i < leftArr.length) {
+      const leftVal = leftArr[i]!;
+      snap(
+        [left, right],
+        null,
+        k,
+        `Copying remaining left element ${leftVal} to position ${k}`,
+      );
+      arr[k] = leftVal;
+      i++;
+      k++;
     }
-    if (!didSwap) {
-      arr.forEach((v) => sortedSet.add(v));
-      break;
+
+    while (j < rightArr.length) {
+      const rightVal = rightArr[j]!;
+      snap(
+        [left, right],
+        null,
+        k,
+        `Copying remaining right element ${rightVal} to position ${k}`,
+      );
+      arr[k] = rightVal;
+      j++;
+      k++;
+    }
+
+    // Mark sub-range as temporary sorted if it's full merge step
+    if (left === 0 && right === input.length - 1) {
+      for (let m = left; m <= right; m++) sortedSet.add(m);
+      snap(null, null, null, "Entire array is now merged and sorted!");
+    } else {
+      snap(
+        [left, right],
+        null,
+        null,
+        `Subarray [${left}..${right}] merged successfully`,
+      );
     }
   }
 
-  arr.forEach((v) => sortedSet.add(v));
-  snap(null, false, "✓  Array sorted!");
+  function mergeSort(left: number, right: number) {
+    if (left >= right) return;
+
+    const mid = Math.floor((left + right) / 2);
+    snap(
+      [left, right],
+      null,
+      null,
+      `Dividing [${left}..${right}] at mid index ${mid}`,
+    );
+
+    mergeSort(left, mid);
+    mergeSort(mid + 1, right);
+    merge(left, mid, right);
+  }
+
+  mergeSort(0, arr.length - 1);
+  for (let k = 0; k < arr.length; k++) sortedSet.add(k);
+  snap(null, null, null, "✓ Array sorted!");
+
   return steps;
 }
 
@@ -82,13 +166,20 @@ const SPEEDS: { label: string; stepMs: number; transitionMs: number }[] = [
   { label: "4×", stepMs: 130, transitionMs: 80 },
 ];
 
-const CHART_H = 180; // px
+const CHART_H = 180;
 
-function barColor(value: number, index: number, step: SortStep): string {
-  if (step.sortedValues.includes(value)) return "#10b981";
-  if (step.comparing?.includes(index))
-    return step.swapped ? "#f87171" : "#fbbf24";
-  return "#374151";
+function barColor(index: number, step: SortStep): string {
+  if (step.sortedIndices.includes(index)) return "#10b981"; // Sorted: Green
+  if (step.writingIndex === index) return "#06b6d4"; // Writing/Overwriting: Cyan
+  if (step.comparing?.includes(index)) return "#fbbf24"; // Comparing: Yellow
+  if (
+    step.activeRange &&
+    index >= step.activeRange[0] &&
+    index <= step.activeRange[1]
+  ) {
+    return "#60a5fa"; // Active Subarray Range: Blue
+  }
+  return "#374151"; // Inactive: Dark Gray
 }
 
 const MIN_SIZE = 4;
@@ -98,13 +189,13 @@ const DEFAULT_SIZE = 7;
 /* ──────────────────────────────────────────────────
    Component
 ────────────────────────────────────────────────── */
-export default function BubbleSortVisualizer() {
+export default function MergeSortVisualizer() {
   const [arraySize, setArraySize] = useState(DEFAULT_SIZE);
   const [baseArray, setBaseArray] = useState<number[]>(() =>
     randomArray(DEFAULT_SIZE),
   );
   const [steps, setSteps] = useState<SortStep[]>(() =>
-    generateSteps(randomArray(DEFAULT_SIZE)),
+    generateMergeSortSteps(randomArray(DEFAULT_SIZE)),
   );
   const [idx, setIdx] = useState(0);
   const [playing, setPlaying] = useState(false);
@@ -116,11 +207,9 @@ export default function BubbleSortVisualizer() {
   const n = step.array.length;
   const maxVal = Math.max(...step.array);
 
-  /* bar geometry — shrink bar width for large arrays */
-  const barW = Math.max(20, Math.min(48, Math.floor(300 / n)));
-  const barGap = Math.max(4, Math.min(12, Math.floor(40 / n)));
+  const barW = Math.max(14, Math.min(44, Math.floor(260 / n)));
+  const barGap = Math.max(2, Math.min(10, Math.floor(30 / n)));
 
-  /* advance */
   const advance = useCallback(() => {
     setIdx((prev) => {
       if (prev >= steps.length - 1) {
@@ -131,7 +220,6 @@ export default function BubbleSortVisualizer() {
     });
   }, [steps.length]);
 
-  /* autoplay */
   useEffect(() => {
     if (timerRef.current) clearTimeout(timerRef.current);
     if (!playing) return;
@@ -146,23 +234,20 @@ export default function BubbleSortVisualizer() {
     if (finished) setPlaying(false);
   }, [finished]);
 
-  /* reset to current base array */
   const reset = useCallback(() => {
     setPlaying(false);
-    setSteps(generateSteps(baseArray));
+    setSteps(generateMergeSortSteps(baseArray));
     setIdx(0);
   }, [baseArray]);
 
-  /* generate a fresh random array of given size */
   const generate = useCallback((size: number) => {
     setPlaying(false);
     const arr = randomArray(size);
     setBaseArray(arr);
-    setSteps(generateSteps(arr));
+    setSteps(generateMergeSortSteps(arr));
     setIdx(0);
   }, []);
 
-  /* when size changes regenerate */
   const handleSizeChange = (size: number) => {
     setArraySize(size);
     generate(size);
@@ -179,7 +264,6 @@ export default function BubbleSortVisualizer() {
     <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#09090b] border border-gray-800 shadow-xl min-h-[380px]">
       {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
       <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[190px] border-b md:border-b-0 md:border-r border-gray-800 bg-[#070709]">
-        {/* Array Size */}
         <div>
           <p className="text-[9px] font-black uppercase tracking-widest mb-2 text-gray-500">
             Array Size
@@ -196,7 +280,6 @@ export default function BubbleSortVisualizer() {
             </span>
           </div>
 
-          {/* Custom styled range slider */}
           <div className="relative flex items-center" style={{ height: 20 }}>
             <div className="absolute w-full rounded-full h-1 bg-gray-800" />
             <div
@@ -216,9 +299,8 @@ export default function BubbleSortVisualizer() {
           </div>
         </div>
 
-        {/* Generate button */}
         <button
-          id="bsv-generate"
+          id="msv-generate"
           type="button"
           onClick={() => generate(arraySize)}
           className="w-full rounded-lg text-xs font-bold py-2 bg-gray-800 hover:bg-gray-700 border border-gray-700 text-gray-200 transition-all active:scale-95 cursor-pointer"
@@ -226,7 +308,6 @@ export default function BubbleSortVisualizer() {
           ↻ Randomize
         </button>
 
-        {/* Speed */}
         <div>
           <p className="text-[9px] font-black uppercase tracking-widest mb-2 text-gray-500">
             Speed
@@ -235,7 +316,7 @@ export default function BubbleSortVisualizer() {
             {SPEEDS.map(({ label }, i) => (
               <button
                 key={label}
-                id={`bsv-speed-${i}`}
+                id={`msv-speed-${i}`}
                 type="button"
                 onClick={() => setSpeedIdx(i)}
                 className={`flex-1 md:w-full rounded-md text-[11px] font-bold transition-all active:scale-95 cursor-pointer text-center md:text-left px-2.5 py-1.5 whitespace-nowrap ${
@@ -250,10 +331,8 @@ export default function BubbleSortVisualizer() {
           </div>
         </div>
 
-        {/* Divider */}
         <div className="hidden md:block border-t border-gray-800" />
 
-        {/* Stats */}
         <div className="flex flex-row md:flex-col justify-between md:justify-start gap-4 md:gap-2 border-t md:border-t-0 border-gray-800 pt-3 md:pt-0">
           <StatRow label="Steps" value={steps.length - 1} />
           <StatRow label="Step" value={`${idx} / ${steps.length - 1}`} />
@@ -262,25 +341,25 @@ export default function BubbleSortVisualizer() {
 
       {/* ══ RIGHT — CHART + CONTROLS ══ */}
       <div className="flex flex-col flex-1 min-w-0">
-        {/* Status bar */}
         <div className="flex items-center justify-center px-4 md:px-6 py-2.5 min-h-[44px] border-b border-[#111113]">
           <span
             className="text-xs md:text-[13px] font-semibold tracking-wide text-center leading-tight transition-colors duration-150"
             style={{
               color: finished
                 ? "#10b981"
-                : step.swapped
-                  ? "#f87171"
-                  : step.comparing
+                : step.writingIndex !== null
+                  ? "#06b6d4"
+                  : step.comparing !== null
                     ? "#fbbf24"
-                    : "#6b7280",
+                    : step.activeRange !== null
+                      ? "#60a5fa"
+                      : "#6b7280",
             }}
           >
             {step.description}
           </span>
         </div>
 
-        {/* Bar chart */}
         <div className="flex items-end justify-center px-2 sm:px-6 pt-5 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[200px]">
           <div
             className="relative flex items-end justify-center max-w-full"
@@ -294,7 +373,7 @@ export default function BubbleSortVisualizer() {
                 14,
                 Math.round((val / maxVal) * (CHART_H - 30)),
               );
-              const color = barColor(val, i, step);
+              const color = barColor(i, step);
 
               return (
                 <div
@@ -324,7 +403,7 @@ export default function BubbleSortVisualizer() {
                       borderRadius: "5px 5px 2px 2px",
                       transition: `background-color ${transMs}ms ease, height ${transMs}ms cubic-bezier(0.4,0,0.2,1)`,
                       boxShadow:
-                        step.swapped && step.comparing?.includes(i)
+                        step.writingIndex === i || step.comparing?.includes(i)
                           ? `0 0 12px ${color}80`
                           : "none",
                     }}
@@ -335,12 +414,12 @@ export default function BubbleSortVisualizer() {
           </div>
         </div>
 
-        {/* Legend */}
         <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2.5 px-3 border-t border-b border-gray-800/80">
           {[
             { color: "#374151", label: "Unsorted" },
+            { color: "#60a5fa", label: "Active Subarray" },
             { color: "#fbbf24", label: "Comparing" },
-            { color: "#f87171", label: "Swapping" },
+            { color: "#06b6d4", label: "Writing Merged" },
             { color: "#10b981", label: "Sorted" },
           ].map(({ color, label }) => (
             <div key={label} className="flex items-center gap-1.5">
@@ -353,10 +432,9 @@ export default function BubbleSortVisualizer() {
           ))}
         </div>
 
-        {/* Play controls */}
         <div className="flex items-center gap-3 px-4 sm:px-6 py-3 sm:py-4">
           <button
-            id="bsv-play"
+            id="msv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
             className="flex items-center gap-2 rounded-lg text-white text-xs font-bold tracking-wide cursor-pointer active:scale-95 transition-all shadow-md"
@@ -386,7 +464,6 @@ export default function BubbleSortVisualizer() {
           )}
         </div>
 
-        {/* Step log */}
         <div className="mx-4 sm:mx-6 mb-4 sm:mb-6 rounded-xl border border-gray-800 bg-[#050507] overflow-hidden flex-1">
           <div className="px-4 py-2 border-b border-[#111113]">
             <span className="text-[9px] font-black uppercase tracking-widest text-gray-600">
@@ -422,19 +499,11 @@ export default function BubbleSortVisualizer() {
   );
 }
 
-/* ──────────────────────────────────────────────────
-   Sub-components
-────────────────────────────────────────────────── */
 function StatRow({ label, value }: { label: string; value: string | number }) {
   return (
     <div className="flex items-center justify-between">
-      <span className="text-[10px]" style={{ color: "#4b5563" }}>
-        {label}
-      </span>
-      <span
-        className="text-[11px] font-mono font-bold"
-        style={{ color: "#9ca3af" }}
-      >
+      <span className="text-[10px] text-gray-500">{label}</span>
+      <span className="text-[11px] font-mono font-bold text-gray-400">
         {value}
       </span>
     </div>

--- a/packages/components/src/visualizers/QuickSortVisualizer.tsx
+++ b/packages/components/src/visualizers/QuickSortVisualizer.tsx
@@ -259,7 +259,7 @@ export default function QuickSortVisualizer() {
   return (
     <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl md:h-[520px]">
       {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
-      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[200px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#070709]">
+      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[200px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#0A0A0B]">
         <div>
           <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Array Size
@@ -406,7 +406,7 @@ export default function QuickSortVisualizer() {
         </div>
 
         {/* Legend */}
-        <div className="min-h-[38px] shrink-0 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
+        <div className="shrink-0 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/60">
           {[
             { color: "#3f3f46", label: "Active Partition" },
             { color: "#a855f7", label: "Pivot" },
@@ -417,10 +417,10 @@ export default function QuickSortVisualizer() {
           ].map(({ color, label }) => (
             <div key={label} className="flex items-center gap-1.5">
               <span
-                className="rounded-sm inline-block w-2 h-2 shrink-0"
+                className="rounded-full inline-block w-1.5 h-1.5 shrink-0"
                 style={{ background: color }}
               />
-              <span className="text-[10px] font-medium text-zinc-400 whitespace-nowrap">
+              <span className="text-[11px] font-medium text-zinc-400 whitespace-nowrap">
                 {label}
               </span>
             </div>
@@ -428,12 +428,12 @@ export default function QuickSortVisualizer() {
         </div>
 
         {/* Play controls */}
-        <div className="min-h-[52px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
+        <div className="shrink-0 flex items-center gap-2.5 px-3 sm:px-6 py-2">
           <button
             id="qsv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
-            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
+            className="flex items-center gap-1.5 rounded-lg text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-3.5 py-1.5 shadow-[0_2px_10px_rgba(255,87,87,0.25)]"
             style={{
               background: finished ? "#059669" : "#FF5757",
             }}
@@ -452,7 +452,7 @@ export default function QuickSortVisualizer() {
             <button
               type="button"
               onClick={reset}
-              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
+              className="flex items-center gap-1.5 rounded-lg text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-3.5 py-1.5 border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
             >
               Reset
             </button>

--- a/packages/components/src/visualizers/QuickSortVisualizer.tsx
+++ b/packages/components/src/visualizers/QuickSortVisualizer.tsx
@@ -257,11 +257,10 @@ export default function QuickSortVisualizer() {
   const transMs = currentSpeed.transitionMs;
 
   return (
-    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl min-h-[500px] md:h-[520px]">
-      {/* ══ LEFT SIDEBAR / TOP CONTROLS ══ */}
-      <div className="flex flex-col gap-3.5 p-4 md:p-5 shrink-0 w-full md:w-[210px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#0A0A0B]">
-        {/* Array Size Block */}
-        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl md:h-[520px]">
+      {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
+      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[200px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#070709]">
+        <div>
           <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Array Size
           </p>
@@ -300,17 +299,16 @@ export default function QuickSortVisualizer() {
           id="qsv-generate"
           type="button"
           onClick={() => generate(arraySize)}
-          className="w-full rounded-xl text-xs font-semibold py-2.5 bg-[#111113] hover:bg-zinc-800/80 border border-zinc-800/80 hover:border-zinc-700/60 text-zinc-200 transition-all active:scale-[0.98] cursor-pointer"
+          className="w-full rounded-xl text-xs font-semibold py-2 bg-[#111113] hover:bg-zinc-800/80 border border-zinc-800/80 hover:border-zinc-700/60 text-zinc-200 transition-all active:scale-[0.98] cursor-pointer"
         >
           ↻ Randomize
         </button>
 
-        {/* Speed Block */}
-        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+        <div>
           <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Speed
           </p>
-          <div className="flex flex-row md:flex-col gap-1.5 overflow-x-auto scrollbar-none">
+          <div className="flex flex-row md:flex-col gap-1.5 overflow-x-auto scrollbar-none pb-1 md:pb-0">
             {SPEEDS.map(({ label }, i) => (
               <button
                 key={label}
@@ -331,11 +329,11 @@ export default function QuickSortVisualizer() {
       </div>
 
       {/* ══ RIGHT — CHART + CONTROLS ══ */}
-      <div className="flex flex-col flex-1 min-w-0 justify-between h-full">
+      <div className="flex flex-col flex-1 min-w-0 justify-between md:h-full">
         {/* Status bar */}
-        <div className="h-[48px] shrink-0 flex items-center justify-center px-4 md:px-6 border-b border-zinc-800/80 bg-[#0a0a0b]">
+        <div className="min-h-[44px] md:h-[48px] shrink-0 flex items-center justify-center px-4 md:px-6 py-2 border-b border-zinc-800/80 bg-[#0a0a0b]">
           <span
-            className="text-xs md:text-[13px] font-semibold tracking-tight text-center leading-tight transition-colors duration-150 truncate max-w-full"
+            className="text-xs md:text-[13px] font-semibold tracking-tight text-center leading-tight transition-colors duration-150"
             style={{
               color: finished
                 ? "#10b981"
@@ -353,7 +351,7 @@ export default function QuickSortVisualizer() {
         </div>
 
         {/* Bar chart container */}
-        <div className="flex items-end justify-center px-2 sm:px-6 pt-6 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[220px]">
+        <div className="flex items-end justify-center px-2 sm:px-6 pt-5 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[180px] md:min-h-[220px]">
           <div
             className="relative flex items-end justify-center max-w-full"
             style={{
@@ -408,7 +406,7 @@ export default function QuickSortVisualizer() {
         </div>
 
         {/* Legend */}
-        <div className="h-[40px] shrink-0 flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
+        <div className="min-h-[38px] shrink-0 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
           {[
             { color: "#3f3f46", label: "Active Partition" },
             { color: "#a855f7", label: "Pivot" },
@@ -419,10 +417,10 @@ export default function QuickSortVisualizer() {
           ].map(({ color, label }) => (
             <div key={label} className="flex items-center gap-1.5">
               <span
-                className="rounded-sm inline-block w-2 h-2"
+                className="rounded-sm inline-block w-2 h-2 shrink-0"
                 style={{ background: color }}
               />
-              <span className="text-[10px] font-medium text-zinc-400">
+              <span className="text-[10px] font-medium text-zinc-400 whitespace-nowrap">
                 {label}
               </span>
             </div>
@@ -430,14 +428,13 @@ export default function QuickSortVisualizer() {
         </div>
 
         {/* Play controls */}
-        <div className="h-[56px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
+        <div className="min-h-[52px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
           <button
             id="qsv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
-            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
+            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
             style={{
-              padding: "9px 20px",
               background: finished ? "#059669" : "#FF5757",
             }}
           >
@@ -455,10 +452,7 @@ export default function QuickSortVisualizer() {
             <button
               type="button"
               onClick={reset}
-              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
-              style={{
-                padding: "9px 20px",
-              }}
+              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
             >
               Reset
             </button>

--- a/packages/components/src/visualizers/QuickSortVisualizer.tsx
+++ b/packages/components/src/visualizers/QuickSortVisualizer.tsx
@@ -257,29 +257,30 @@ export default function QuickSortVisualizer() {
   const transMs = currentSpeed.transitionMs;
 
   return (
-    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#09090b] border border-gray-800 shadow-xl min-h-[380px]">
-      {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
-      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[190px] border-b md:border-b-0 md:border-r border-gray-800 bg-[#070709]">
-        <div>
-          <p className="text-[9px] font-black uppercase tracking-widest mb-2 text-gray-500">
+    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl min-h-[500px] md:h-[520px]">
+      {/* ══ LEFT SIDEBAR / TOP CONTROLS ══ */}
+      <div className="flex flex-col gap-3.5 p-4 md:p-5 shrink-0 w-full md:w-[210px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#0A0A0B]">
+        {/* Array Size Block */}
+        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+          <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Array Size
           </p>
-          <div className="flex items-center justify-between mb-1.5">
-            <span className="text-[11px] font-mono text-gray-400">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-medium text-zinc-400">
               {MIN_SIZE}
             </span>
-            <span className="text-lg md:text-xl font-black tabular-nums text-red-500">
+            <span className="text-xl font-bold tabular-nums text-[#FF5757]">
               {arraySize}
             </span>
-            <span className="text-[11px] font-mono text-gray-400">
+            <span className="text-xs font-medium text-zinc-400">
               {MAX_SIZE}
             </span>
           </div>
 
           <div className="relative flex items-center" style={{ height: 20 }}>
-            <div className="absolute w-full rounded-full h-1 bg-gray-800" />
+            <div className="absolute w-full rounded-full h-1 bg-zinc-800" />
             <div
-              className="absolute rounded-full h-1 bg-red-500 transition-all duration-150"
+              className="absolute rounded-full h-1 bg-[#FF5757] transition-all duration-150"
               style={{
                 width: `${((arraySize - MIN_SIZE) / (MAX_SIZE - MIN_SIZE)) * 100}%`,
               }}
@@ -299,26 +300,27 @@ export default function QuickSortVisualizer() {
           id="qsv-generate"
           type="button"
           onClick={() => generate(arraySize)}
-          className="w-full rounded-lg text-xs font-bold py-2 bg-gray-800 hover:bg-gray-700 border border-gray-700 text-gray-200 transition-all active:scale-95 cursor-pointer"
+          className="w-full rounded-xl text-xs font-semibold py-2.5 bg-[#111113] hover:bg-zinc-800/80 border border-zinc-800/80 hover:border-zinc-700/60 text-zinc-200 transition-all active:scale-[0.98] cursor-pointer"
         >
           ↻ Randomize
         </button>
 
-        <div>
-          <p className="text-[9px] font-black uppercase tracking-widest mb-2 text-gray-500">
+        {/* Speed Block */}
+        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+          <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Speed
           </p>
-          <div className="flex flex-row md:flex-col gap-1 overflow-x-auto scrollbar-none pb-1 md:pb-0">
+          <div className="flex flex-row md:flex-col gap-1.5 overflow-x-auto scrollbar-none">
             {SPEEDS.map(({ label }, i) => (
               <button
                 key={label}
                 id={`qsv-speed-${i}`}
                 type="button"
                 onClick={() => setSpeedIdx(i)}
-                className={`flex-1 md:w-full rounded-md text-[11px] font-bold transition-all active:scale-95 cursor-pointer text-center md:text-left px-2.5 py-1.5 whitespace-nowrap ${
+                className={`flex-1 md:w-full rounded-lg text-xs transition-all active:scale-[0.98] cursor-pointer text-center md:text-left px-3 py-1.5 whitespace-nowrap ${
                   speedIdx === i
-                    ? "bg-gray-800 text-white border border-gray-700"
-                    : "bg-transparent text-gray-500 border border-transparent hover:text-gray-300"
+                    ? "bg-[#FF5757]/15 text-[#FF5757] border border-[#FF5757]/40 font-semibold shadow-sm"
+                    : "bg-[#111113] text-zinc-400 border border-zinc-800/80 hover:text-zinc-200 hover:border-zinc-700/60 font-medium"
                 }`}
               >
                 {label}
@@ -326,20 +328,14 @@ export default function QuickSortVisualizer() {
             ))}
           </div>
         </div>
-
-        <div className="hidden md:block border-t border-gray-800" />
-
-        <div className="flex flex-row md:flex-col justify-between md:justify-start gap-4 md:gap-2 border-t md:border-t-0 border-gray-800 pt-3 md:pt-0">
-          <StatRow label="Steps" value={steps.length - 1} />
-          <StatRow label="Step" value={`${idx} / ${steps.length - 1}`} />
-        </div>
       </div>
 
       {/* ══ RIGHT — CHART + CONTROLS ══ */}
-      <div className="flex flex-col flex-1 min-w-0">
-        <div className="flex items-center justify-center px-4 md:px-6 py-2.5 min-h-[44px] border-b border-[#111113]">
+      <div className="flex flex-col flex-1 min-w-0 justify-between h-full">
+        {/* Status bar */}
+        <div className="h-[48px] shrink-0 flex items-center justify-center px-4 md:px-6 border-b border-zinc-800/80 bg-[#0a0a0b]">
           <span
-            className="text-xs md:text-[13px] font-semibold tracking-wide text-center leading-tight transition-colors duration-150"
+            className="text-xs md:text-[13px] font-semibold tracking-tight text-center leading-tight transition-colors duration-150 truncate max-w-full"
             style={{
               color: finished
                 ? "#10b981"
@@ -349,14 +345,15 @@ export default function QuickSortVisualizer() {
                     ? "#f87171"
                     : step.comparing !== null
                       ? "#fbbf24"
-                      : "#6b7280",
+                      : "#a1a1aa",
             }}
           >
             {step.description}
           </span>
         </div>
 
-        <div className="flex items-end justify-center px-2 sm:px-6 pt-5 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[200px]">
+        {/* Bar chart container */}
+        <div className="flex items-end justify-center px-2 sm:px-6 pt-6 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[220px]">
           <div
             className="relative flex items-end justify-center max-w-full"
             style={{
@@ -396,7 +393,7 @@ export default function QuickSortVisualizer() {
                       width: "100%",
                       height: barH,
                       background: color,
-                      borderRadius: "5px 5px 2px 2px",
+                      borderRadius: "6px 6px 2px 2px",
                       transition: `background-color ${transMs}ms ease, height ${transMs}ms cubic-bezier(0.4,0,0.2,1)`,
                       boxShadow:
                         step.swapping?.includes(i) || step.pivotIndex === i
@@ -410,9 +407,10 @@ export default function QuickSortVisualizer() {
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2.5 px-3 border-t border-b border-gray-800/80">
+        {/* Legend */}
+        <div className="h-[40px] shrink-0 flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
           {[
-            { color: "#4b5563", label: "Active Partition" },
+            { color: "#3f3f46", label: "Active Partition" },
             { color: "#a855f7", label: "Pivot" },
             { color: "#60a5fa", label: "Boundary Pointer" },
             { color: "#fbbf24", label: "Comparing" },
@@ -424,20 +422,23 @@ export default function QuickSortVisualizer() {
                 className="rounded-sm inline-block w-2 h-2"
                 style={{ background: color }}
               />
-              <span className="text-[10px] text-gray-500">{label}</span>
+              <span className="text-[10px] font-medium text-zinc-400">
+                {label}
+              </span>
             </div>
           ))}
         </div>
 
-        <div className="flex items-center gap-3 px-4 sm:px-6 py-3 sm:py-4">
+        {/* Play controls */}
+        <div className="h-[56px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
           <button
             id="qsv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
-            className="flex items-center gap-2 rounded-lg text-white text-xs font-bold tracking-wide cursor-pointer active:scale-95 transition-all shadow-md"
+            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
             style={{
-              padding: "8px 18px",
-              background: finished ? "#059669" : "#ef4444",
+              padding: "9px 20px",
+              background: finished ? "#059669" : "#FF5757",
             }}
           >
             {finished ? <IconReset /> : playing ? <IconPause /> : <IconPlay />}
@@ -454,35 +455,39 @@ export default function QuickSortVisualizer() {
             <button
               type="button"
               onClick={reset}
-              className="rounded-lg text-xs font-bold cursor-pointer active:scale-95 transition-all px-3.5 py-2 border border-gray-700 text-gray-400 hover:text-white bg-transparent"
+              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
+              style={{
+                padding: "9px 20px",
+              }}
             >
               Reset
             </button>
           )}
         </div>
 
-        <div className="mx-4 sm:mx-6 mb-4 sm:mb-6 rounded-xl border border-gray-800 bg-[#050507] overflow-hidden flex-1">
-          <div className="px-4 py-2 border-b border-[#111113]">
-            <span className="text-[9px] font-black uppercase tracking-widest text-gray-600">
+        {/* Step log container - fixed height prevents screen shifting */}
+        <div className="h-[135px] shrink-0 mx-4 sm:mx-6 mb-4 rounded-xl border border-zinc-800/80 bg-[#111113] overflow-hidden flex flex-col">
+          <div className="px-4 py-2 border-b border-zinc-800/80 shrink-0 bg-[#0a0a0b]">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-zinc-400">
               Step log
             </span>
           </div>
-          <div>
+          <div className="flex-1 overflow-y-auto scrollbar-thin-grey">
             {log.map((s, i) => (
               <div
                 key={i}
                 className={`flex items-center gap-3 px-4 py-1.5 ${
-                  i === 0 ? "bg-white/[0.02]" : "bg-transparent"
-                } ${i < log.length - 1 ? "border-b border-[#0d0d0f]" : ""}`}
+                  i === 0 ? "bg-white/[0.03]" : "bg-transparent"
+                } ${i < log.length - 1 ? "border-b border-zinc-900" : ""}`}
               >
                 <span
                   className={`rounded-full shrink-0 w-1.5 h-1.5 inline-block ${
-                    i === 0 ? "bg-red-500" : "bg-gray-800"
+                    i === 0 ? "bg-[#FF5757]" : "bg-zinc-800"
                   }`}
                 />
                 <span
                   className={`text-[11px] font-mono ${
-                    i === 0 ? "text-gray-300 font-semibold" : "text-gray-600"
+                    i === 0 ? "text-zinc-200 font-semibold" : "text-zinc-500"
                   }`}
                 >
                   {s.description}
@@ -499,10 +504,8 @@ export default function QuickSortVisualizer() {
 function StatRow({ label, value }: { label: string; value: string | number }) {
   return (
     <div className="flex items-center justify-between">
-      <span className="text-[10px] text-gray-500">{label}</span>
-      <span className="text-[11px] font-mono font-bold text-gray-400">
-        {value}
-      </span>
+      <span className="text-xs font-medium text-zinc-400">{label}</span>
+      <span className="text-xs font-semibold text-zinc-200">{value}</span>
     </div>
   );
 }

--- a/packages/components/src/visualizers/QuickSortVisualizer.tsx
+++ b/packages/components/src/visualizers/QuickSortVisualizer.tsx
@@ -187,11 +187,12 @@ const DEFAULT_SIZE = 7;
 ────────────────────────────────────────────────── */
 export default function QuickSortVisualizer() {
   const [arraySize, setArraySize] = useState(DEFAULT_SIZE);
-  const [baseArray, setBaseArray] = useState<number[]>(() =>
-    randomArray(DEFAULT_SIZE),
+  const initialArray = useRef<number[]>(randomArray(DEFAULT_SIZE));
+  const [baseArray, setBaseArray] = useState<number[]>(
+    () => initialArray.current,
   );
   const [steps, setSteps] = useState<SortStep[]>(() =>
-    generateQuickSortSteps(randomArray(DEFAULT_SIZE)),
+    generateQuickSortSteps(initialArray.current),
   );
   const [idx, setIdx] = useState(0);
   const [playing, setPlaying] = useState(false);
@@ -491,15 +492,6 @@ export default function QuickSortVisualizer() {
           </div>
         </div>
       </div>
-    </div>
-  );
-}
-
-function StatRow({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="flex items-center justify-between">
-      <span className="text-xs font-medium text-zinc-400">{label}</span>
-      <span className="text-xs font-semibold text-zinc-200">{value}</span>
     </div>
   );
 }

--- a/packages/components/src/visualizers/QuickSortVisualizer.tsx
+++ b/packages/components/src/visualizers/QuickSortVisualizer.tsx
@@ -5,64 +5,142 @@ import { useCallback, useEffect, useRef, useState } from "react";
 ────────────────────────────────────────────────── */
 interface SortStep {
   array: number[];
-  comparing: [number, number] | null;
-  swapped: boolean;
-  sortedValues: number[];
+  pivotIndex: number | null;
+  comparing: number | null;
+  iPointer: number | null;
+  swapping: [number, number] | null;
+  sortedIndices: number[];
+  activeRange: [number, number] | null;
   description: string;
 }
 
 /* ──────────────────────────────────────────────────
-   Step generator
+   Step generator for Quick Sort
 ────────────────────────────────────────────────── */
-function generateSteps(input: number[]): SortStep[] {
+function generateQuickSortSteps(input: number[]): SortStep[] {
   const steps: SortStep[] = [];
   const arr = [...input];
-  const n = arr.length;
   const sortedSet = new Set<number>();
 
   const snap = (
-    comparing: [number, number] | null,
-    swapped: boolean,
+    pivotIndex: number | null,
+    comparing: number | null,
+    iPointer: number | null,
+    swapping: [number, number] | null,
+    activeRange: [number, number] | null,
     description: string,
   ) =>
     steps.push({
       array: [...arr],
+      pivotIndex,
       comparing,
-      swapped,
-      sortedValues: Array.from(sortedSet),
+      iPointer,
+      swapping,
+      sortedIndices: Array.from(sortedSet),
+      activeRange,
       description,
     });
 
-  snap(null, false, "Ready — press Start");
+  snap(null, null, null, null, null, "Ready — press Start");
 
-  for (let i = 0; i < n - 1; i++) {
-    let didSwap = false;
-    for (let j = 0; j < n - i - 1; j++) {
-      const val1 = arr[j];
-      const val2 = arr[j + 1];
-      if (val1 !== undefined && val2 !== undefined) {
-        snap([j, j + 1], false, `Comparing  ${val1}  and  ${val2}`);
-        if (val1 > val2) {
-          arr[j] = val2;
-          arr[j + 1] = val1;
-          didSwap = true;
-          snap([j, j + 1], true, `Swap  ${val2}  ↔  ${val1}`);
+  function partition(low: number, high: number): number {
+    const pivot = arr[high]!;
+    snap(
+      high,
+      null,
+      low - 1,
+      null,
+      [low, high],
+      `Subarray [${low}..${high}]: Chosen pivot ${pivot} at index ${high}`,
+    );
+
+    let i = low - 1;
+    for (let j = low; j < high; j++) {
+      snap(
+        high,
+        j,
+        i >= low ? i : null,
+        null,
+        [low, high],
+        `Comparing ${arr[j]} with pivot ${pivot}`,
+      );
+
+      if (arr[j]! < pivot) {
+        i++;
+        if (i !== j) {
+          snap(
+            high,
+            j,
+            i,
+            [i, j],
+            [low, high],
+            `${arr[j]} < ${pivot}: Swapping index ${j} (${arr[j]}) with boundary index ${i} (${arr[i]})`,
+          );
+          const temp = arr[i]!;
+          arr[i] = arr[j]!;
+          arr[j] = temp;
+        } else {
+          snap(
+            high,
+            j,
+            i,
+            null,
+            [low, high],
+            `${arr[j]} < ${pivot}: Already at boundary index ${i}`,
+          );
         }
       }
     }
-    const finalVal = arr[n - 1 - i];
-    if (finalVal !== undefined) {
-      sortedSet.add(finalVal);
-      snap(null, false, `${finalVal} is in its final position`);
+
+    if (i + 1 !== high) {
+      snap(
+        high,
+        null,
+        i + 1,
+        [i + 1, high],
+        [low, high],
+        `Placing pivot ${pivot} at its correct position index ${i + 1}`,
+      );
+      const temp = arr[i + 1]!;
+      arr[i + 1] = arr[high]!;
+      arr[high] = temp;
     }
-    if (!didSwap) {
-      arr.forEach((v) => sortedSet.add(v));
-      break;
+
+    const pivotPos = i + 1;
+    sortedSet.add(pivotPos);
+    snap(
+      null,
+      null,
+      null,
+      null,
+      [low, high],
+      `Pivot ${pivot} is now fixed at index ${pivotPos}`,
+    );
+    return pivotPos;
+  }
+
+  function quickSort(low: number, high: number) {
+    if (low < high) {
+      const pi = partition(low, high);
+      quickSort(low, pi - 1);
+      quickSort(pi + 1, high);
+    } else if (low === high) {
+      sortedSet.add(low);
+      snap(
+        null,
+        null,
+        null,
+        null,
+        [low, high],
+        `Single element ${arr[low]} at index ${low} is sorted`,
+      );
     }
   }
 
-  arr.forEach((v) => sortedSet.add(v));
-  snap(null, false, "✓  Array sorted!");
+  quickSort(0, arr.length - 1);
+  for (let k = 0; k < arr.length; k++) sortedSet.add(k);
+  snap(null, null, null, null, null, "✓ Array sorted!");
+
   return steps;
 }
 
@@ -82,13 +160,22 @@ const SPEEDS: { label: string; stepMs: number; transitionMs: number }[] = [
   { label: "4×", stepMs: 130, transitionMs: 80 },
 ];
 
-const CHART_H = 180; // px
+const CHART_H = 180;
 
-function barColor(value: number, index: number, step: SortStep): string {
-  if (step.sortedValues.includes(value)) return "#10b981";
-  if (step.comparing?.includes(index))
-    return step.swapped ? "#f87171" : "#fbbf24";
-  return "#374151";
+function barColor(index: number, step: SortStep): string {
+  if (step.sortedIndices.includes(index)) return "#10b981"; // Sorted: Green
+  if (step.swapping?.includes(index)) return "#f87171"; // Swapping: Red
+  if (step.pivotIndex === index) return "#a855f7"; // Pivot: Purple
+  if (step.comparing === index) return "#fbbf24"; // Comparing: Yellow
+  if (step.iPointer === index) return "#60a5fa"; // Boundary pointer: Blue
+  if (
+    step.activeRange &&
+    index >= step.activeRange[0] &&
+    index <= step.activeRange[1]
+  ) {
+    return "#4b5563"; // Active partition range: Lighter Gray
+  }
+  return "#1f2937"; // Inactive range: Dark Gray
 }
 
 const MIN_SIZE = 4;
@@ -98,13 +185,13 @@ const DEFAULT_SIZE = 7;
 /* ──────────────────────────────────────────────────
    Component
 ────────────────────────────────────────────────── */
-export default function BubbleSortVisualizer() {
+export default function QuickSortVisualizer() {
   const [arraySize, setArraySize] = useState(DEFAULT_SIZE);
   const [baseArray, setBaseArray] = useState<number[]>(() =>
     randomArray(DEFAULT_SIZE),
   );
   const [steps, setSteps] = useState<SortStep[]>(() =>
-    generateSteps(randomArray(DEFAULT_SIZE)),
+    generateQuickSortSteps(randomArray(DEFAULT_SIZE)),
   );
   const [idx, setIdx] = useState(0);
   const [playing, setPlaying] = useState(false);
@@ -116,11 +203,9 @@ export default function BubbleSortVisualizer() {
   const n = step.array.length;
   const maxVal = Math.max(...step.array);
 
-  /* bar geometry — shrink bar width for large arrays */
-  const barW = Math.max(20, Math.min(48, Math.floor(300 / n)));
-  const barGap = Math.max(4, Math.min(12, Math.floor(40 / n)));
+  const barW = Math.max(14, Math.min(44, Math.floor(260 / n)));
+  const barGap = Math.max(2, Math.min(10, Math.floor(30 / n)));
 
-  /* advance */
   const advance = useCallback(() => {
     setIdx((prev) => {
       if (prev >= steps.length - 1) {
@@ -131,7 +216,6 @@ export default function BubbleSortVisualizer() {
     });
   }, [steps.length]);
 
-  /* autoplay */
   useEffect(() => {
     if (timerRef.current) clearTimeout(timerRef.current);
     if (!playing) return;
@@ -146,23 +230,20 @@ export default function BubbleSortVisualizer() {
     if (finished) setPlaying(false);
   }, [finished]);
 
-  /* reset to current base array */
   const reset = useCallback(() => {
     setPlaying(false);
-    setSteps(generateSteps(baseArray));
+    setSteps(generateQuickSortSteps(baseArray));
     setIdx(0);
   }, [baseArray]);
 
-  /* generate a fresh random array of given size */
   const generate = useCallback((size: number) => {
     setPlaying(false);
     const arr = randomArray(size);
     setBaseArray(arr);
-    setSteps(generateSteps(arr));
+    setSteps(generateQuickSortSteps(arr));
     setIdx(0);
   }, []);
 
-  /* when size changes regenerate */
   const handleSizeChange = (size: number) => {
     setArraySize(size);
     generate(size);
@@ -179,7 +260,6 @@ export default function BubbleSortVisualizer() {
     <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#09090b] border border-gray-800 shadow-xl min-h-[380px]">
       {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
       <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[190px] border-b md:border-b-0 md:border-r border-gray-800 bg-[#070709]">
-        {/* Array Size */}
         <div>
           <p className="text-[9px] font-black uppercase tracking-widest mb-2 text-gray-500">
             Array Size
@@ -196,7 +276,6 @@ export default function BubbleSortVisualizer() {
             </span>
           </div>
 
-          {/* Custom styled range slider */}
           <div className="relative flex items-center" style={{ height: 20 }}>
             <div className="absolute w-full rounded-full h-1 bg-gray-800" />
             <div
@@ -216,9 +295,8 @@ export default function BubbleSortVisualizer() {
           </div>
         </div>
 
-        {/* Generate button */}
         <button
-          id="bsv-generate"
+          id="qsv-generate"
           type="button"
           onClick={() => generate(arraySize)}
           className="w-full rounded-lg text-xs font-bold py-2 bg-gray-800 hover:bg-gray-700 border border-gray-700 text-gray-200 transition-all active:scale-95 cursor-pointer"
@@ -226,7 +304,6 @@ export default function BubbleSortVisualizer() {
           ↻ Randomize
         </button>
 
-        {/* Speed */}
         <div>
           <p className="text-[9px] font-black uppercase tracking-widest mb-2 text-gray-500">
             Speed
@@ -235,7 +312,7 @@ export default function BubbleSortVisualizer() {
             {SPEEDS.map(({ label }, i) => (
               <button
                 key={label}
-                id={`bsv-speed-${i}`}
+                id={`qsv-speed-${i}`}
                 type="button"
                 onClick={() => setSpeedIdx(i)}
                 className={`flex-1 md:w-full rounded-md text-[11px] font-bold transition-all active:scale-95 cursor-pointer text-center md:text-left px-2.5 py-1.5 whitespace-nowrap ${
@@ -250,10 +327,8 @@ export default function BubbleSortVisualizer() {
           </div>
         </div>
 
-        {/* Divider */}
         <div className="hidden md:block border-t border-gray-800" />
 
-        {/* Stats */}
         <div className="flex flex-row md:flex-col justify-between md:justify-start gap-4 md:gap-2 border-t md:border-t-0 border-gray-800 pt-3 md:pt-0">
           <StatRow label="Steps" value={steps.length - 1} />
           <StatRow label="Step" value={`${idx} / ${steps.length - 1}`} />
@@ -262,25 +337,25 @@ export default function BubbleSortVisualizer() {
 
       {/* ══ RIGHT — CHART + CONTROLS ══ */}
       <div className="flex flex-col flex-1 min-w-0">
-        {/* Status bar */}
         <div className="flex items-center justify-center px-4 md:px-6 py-2.5 min-h-[44px] border-b border-[#111113]">
           <span
             className="text-xs md:text-[13px] font-semibold tracking-wide text-center leading-tight transition-colors duration-150"
             style={{
               color: finished
                 ? "#10b981"
-                : step.swapped
-                  ? "#f87171"
-                  : step.comparing
-                    ? "#fbbf24"
-                    : "#6b7280",
+                : step.pivotIndex !== null
+                  ? "#a855f7"
+                  : step.swapping
+                    ? "#f87171"
+                    : step.comparing !== null
+                      ? "#fbbf24"
+                      : "#6b7280",
             }}
           >
             {step.description}
           </span>
         </div>
 
-        {/* Bar chart */}
         <div className="flex items-end justify-center px-2 sm:px-6 pt-5 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[200px]">
           <div
             className="relative flex items-end justify-center max-w-full"
@@ -294,7 +369,7 @@ export default function BubbleSortVisualizer() {
                 14,
                 Math.round((val / maxVal) * (CHART_H - 30)),
               );
-              const color = barColor(val, i, step);
+              const color = barColor(i, step);
 
               return (
                 <div
@@ -324,7 +399,7 @@ export default function BubbleSortVisualizer() {
                       borderRadius: "5px 5px 2px 2px",
                       transition: `background-color ${transMs}ms ease, height ${transMs}ms cubic-bezier(0.4,0,0.2,1)`,
                       boxShadow:
-                        step.swapped && step.comparing?.includes(i)
+                        step.swapping?.includes(i) || step.pivotIndex === i
                           ? `0 0 12px ${color}80`
                           : "none",
                     }}
@@ -335,13 +410,14 @@ export default function BubbleSortVisualizer() {
           </div>
         </div>
 
-        {/* Legend */}
         <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2.5 px-3 border-t border-b border-gray-800/80">
           {[
-            { color: "#374151", label: "Unsorted" },
+            { color: "#4b5563", label: "Active Partition" },
+            { color: "#a855f7", label: "Pivot" },
+            { color: "#60a5fa", label: "Boundary Pointer" },
             { color: "#fbbf24", label: "Comparing" },
             { color: "#f87171", label: "Swapping" },
-            { color: "#10b981", label: "Sorted" },
+            { color: "#10b981", label: "Fixed / Sorted" },
           ].map(({ color, label }) => (
             <div key={label} className="flex items-center gap-1.5">
               <span
@@ -353,10 +429,9 @@ export default function BubbleSortVisualizer() {
           ))}
         </div>
 
-        {/* Play controls */}
         <div className="flex items-center gap-3 px-4 sm:px-6 py-3 sm:py-4">
           <button
-            id="bsv-play"
+            id="qsv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
             className="flex items-center gap-2 rounded-lg text-white text-xs font-bold tracking-wide cursor-pointer active:scale-95 transition-all shadow-md"
@@ -386,7 +461,6 @@ export default function BubbleSortVisualizer() {
           )}
         </div>
 
-        {/* Step log */}
         <div className="mx-4 sm:mx-6 mb-4 sm:mb-6 rounded-xl border border-gray-800 bg-[#050507] overflow-hidden flex-1">
           <div className="px-4 py-2 border-b border-[#111113]">
             <span className="text-[9px] font-black uppercase tracking-widest text-gray-600">
@@ -422,19 +496,11 @@ export default function BubbleSortVisualizer() {
   );
 }
 
-/* ──────────────────────────────────────────────────
-   Sub-components
-────────────────────────────────────────────────── */
 function StatRow({ label, value }: { label: string; value: string | number }) {
   return (
     <div className="flex items-center justify-between">
-      <span className="text-[10px]" style={{ color: "#4b5563" }}>
-        {label}
-      </span>
-      <span
-        className="text-[11px] font-mono font-bold"
-        style={{ color: "#9ca3af" }}
-      >
+      <span className="text-[10px] text-gray-500">{label}</span>
+      <span className="text-[11px] font-mono font-bold text-gray-400">
         {value}
       </span>
     </div>

--- a/packages/components/src/visualizers/SelectionSortVisualizer.tsx
+++ b/packages/components/src/visualizers/SelectionSortVisualizer.tsx
@@ -5,64 +5,91 @@ import { useCallback, useEffect, useRef, useState } from "react";
 ────────────────────────────────────────────────── */
 interface SortStep {
   array: number[];
-  comparing: [number, number] | null;
-  swapped: boolean;
-  sortedValues: number[];
+  comparing: number | null;
+  currentMinIndex: number | null;
+  swapping: [number, number] | null;
+  sortedIndices: number[];
+  currentI: number | null;
   description: string;
 }
 
 /* ──────────────────────────────────────────────────
-   Step generator
+   Step generator for Selection Sort
 ────────────────────────────────────────────────── */
-function generateSteps(input: number[]): SortStep[] {
+function generateSelectionSortSteps(input: number[]): SortStep[] {
   const steps: SortStep[] = [];
   const arr = [...input];
   const n = arr.length;
   const sortedSet = new Set<number>();
 
   const snap = (
-    comparing: [number, number] | null,
-    swapped: boolean,
+    comparing: number | null,
+    currentMinIndex: number | null,
+    swapping: [number, number] | null,
+    currentI: number | null,
     description: string,
   ) =>
     steps.push({
       array: [...arr],
       comparing,
-      swapped,
-      sortedValues: Array.from(sortedSet),
+      currentMinIndex,
+      swapping,
+      sortedIndices: Array.from(sortedSet),
+      currentI,
       description,
     });
 
-  snap(null, false, "Ready — press Start");
+  snap(null, null, null, null, "Ready — press Start");
 
   for (let i = 0; i < n - 1; i++) {
-    let didSwap = false;
-    for (let j = 0; j < n - i - 1; j++) {
-      const val1 = arr[j];
-      const val2 = arr[j + 1];
-      if (val1 !== undefined && val2 !== undefined) {
-        snap([j, j + 1], false, `Comparing  ${val1}  and  ${val2}`);
-        if (val1 > val2) {
-          arr[j] = val2;
-          arr[j + 1] = val1;
-          didSwap = true;
-          snap([j, j + 1], true, `Swap  ${val2}  ↔  ${val1}`);
-        }
+    let minIdx = i;
+    snap(
+      null,
+      minIdx,
+      null,
+      i,
+      `Pass ${i + 1}: Assume minimum is ${arr[i]} at index ${i}`,
+    );
+
+    for (let j = i + 1; j < n; j++) {
+      snap(
+        j,
+        minIdx,
+        null,
+        i,
+        `Comparing ${arr[j]} with current min ${arr[minIdx]}`,
+      );
+      if (arr[j]! < arr[minIdx]!) {
+        minIdx = j;
+        snap(
+          null,
+          minIdx,
+          null,
+          i,
+          `New minimum found: ${arr[minIdx]} at index ${minIdx}`,
+        );
       }
     }
-    const finalVal = arr[n - 1 - i];
-    if (finalVal !== undefined) {
-      sortedSet.add(finalVal);
-      snap(null, false, `${finalVal} is in its final position`);
+
+    if (minIdx !== i) {
+      snap(
+        null,
+        minIdx,
+        [i, minIdx],
+        i,
+        `Swapping min ${arr[minIdx]} (index ${minIdx}) with ${arr[i]} (index ${i})`,
+      );
+      const temp = arr[i]!;
+      arr[i] = arr[minIdx]!;
+      arr[minIdx] = temp;
     }
-    if (!didSwap) {
-      arr.forEach((v) => sortedSet.add(v));
-      break;
-    }
+
+    sortedSet.add(i);
+    snap(null, null, null, i, `${arr[i]} is now in its final position`);
   }
 
-  arr.forEach((v) => sortedSet.add(v));
-  snap(null, false, "✓  Array sorted!");
+  sortedSet.add(n - 1);
+  snap(null, null, null, null, "✓ Array sorted!");
   return steps;
 }
 
@@ -82,13 +109,15 @@ const SPEEDS: { label: string; stepMs: number; transitionMs: number }[] = [
   { label: "4×", stepMs: 130, transitionMs: 80 },
 ];
 
-const CHART_H = 180; // px
+const CHART_H = 180;
 
-function barColor(value: number, index: number, step: SortStep): string {
-  if (step.sortedValues.includes(value)) return "#10b981";
-  if (step.comparing?.includes(index))
-    return step.swapped ? "#f87171" : "#fbbf24";
-  return "#374151";
+function barColor(index: number, step: SortStep): string {
+  if (step.sortedIndices.includes(index)) return "#10b981"; // Sorted: Green
+  if (step.swapping?.includes(index)) return "#f87171"; // Swapping: Red
+  if (step.currentMinIndex === index) return "#a855f7"; // Min Element: Purple
+  if (step.comparing === index) return "#fbbf24"; // Comparing: Yellow
+  if (step.currentI === index) return "#60a5fa"; // Current Pass Target: Blue
+  return "#374151"; // Unsorted: Gray
 }
 
 const MIN_SIZE = 4;
@@ -98,13 +127,13 @@ const DEFAULT_SIZE = 7;
 /* ──────────────────────────────────────────────────
    Component
 ────────────────────────────────────────────────── */
-export default function BubbleSortVisualizer() {
+export default function SelectionSortVisualizer() {
   const [arraySize, setArraySize] = useState(DEFAULT_SIZE);
   const [baseArray, setBaseArray] = useState<number[]>(() =>
     randomArray(DEFAULT_SIZE),
   );
   const [steps, setSteps] = useState<SortStep[]>(() =>
-    generateSteps(randomArray(DEFAULT_SIZE)),
+    generateSelectionSortSteps(randomArray(DEFAULT_SIZE)),
   );
   const [idx, setIdx] = useState(0);
   const [playing, setPlaying] = useState(false);
@@ -116,11 +145,9 @@ export default function BubbleSortVisualizer() {
   const n = step.array.length;
   const maxVal = Math.max(...step.array);
 
-  /* bar geometry — shrink bar width for large arrays */
-  const barW = Math.max(20, Math.min(48, Math.floor(300 / n)));
-  const barGap = Math.max(4, Math.min(12, Math.floor(40 / n)));
+  const barW = Math.max(14, Math.min(44, Math.floor(260 / n)));
+  const barGap = Math.max(2, Math.min(10, Math.floor(30 / n)));
 
-  /* advance */
   const advance = useCallback(() => {
     setIdx((prev) => {
       if (prev >= steps.length - 1) {
@@ -131,7 +158,6 @@ export default function BubbleSortVisualizer() {
     });
   }, [steps.length]);
 
-  /* autoplay */
   useEffect(() => {
     if (timerRef.current) clearTimeout(timerRef.current);
     if (!playing) return;
@@ -146,23 +172,20 @@ export default function BubbleSortVisualizer() {
     if (finished) setPlaying(false);
   }, [finished]);
 
-  /* reset to current base array */
   const reset = useCallback(() => {
     setPlaying(false);
-    setSteps(generateSteps(baseArray));
+    setSteps(generateSelectionSortSteps(baseArray));
     setIdx(0);
   }, [baseArray]);
 
-  /* generate a fresh random array of given size */
   const generate = useCallback((size: number) => {
     setPlaying(false);
     const arr = randomArray(size);
     setBaseArray(arr);
-    setSteps(generateSteps(arr));
+    setSteps(generateSelectionSortSteps(arr));
     setIdx(0);
   }, []);
 
-  /* when size changes regenerate */
   const handleSizeChange = (size: number) => {
     setArraySize(size);
     generate(size);
@@ -179,7 +202,6 @@ export default function BubbleSortVisualizer() {
     <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#09090b] border border-gray-800 shadow-xl min-h-[380px]">
       {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
       <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[190px] border-b md:border-b-0 md:border-r border-gray-800 bg-[#070709]">
-        {/* Array Size */}
         <div>
           <p className="text-[9px] font-black uppercase tracking-widest mb-2 text-gray-500">
             Array Size
@@ -196,7 +218,6 @@ export default function BubbleSortVisualizer() {
             </span>
           </div>
 
-          {/* Custom styled range slider */}
           <div className="relative flex items-center" style={{ height: 20 }}>
             <div className="absolute w-full rounded-full h-1 bg-gray-800" />
             <div
@@ -216,9 +237,8 @@ export default function BubbleSortVisualizer() {
           </div>
         </div>
 
-        {/* Generate button */}
         <button
-          id="bsv-generate"
+          id="ssv-generate"
           type="button"
           onClick={() => generate(arraySize)}
           className="w-full rounded-lg text-xs font-bold py-2 bg-gray-800 hover:bg-gray-700 border border-gray-700 text-gray-200 transition-all active:scale-95 cursor-pointer"
@@ -226,7 +246,6 @@ export default function BubbleSortVisualizer() {
           ↻ Randomize
         </button>
 
-        {/* Speed */}
         <div>
           <p className="text-[9px] font-black uppercase tracking-widest mb-2 text-gray-500">
             Speed
@@ -235,7 +254,7 @@ export default function BubbleSortVisualizer() {
             {SPEEDS.map(({ label }, i) => (
               <button
                 key={label}
-                id={`bsv-speed-${i}`}
+                id={`ssv-speed-${i}`}
                 type="button"
                 onClick={() => setSpeedIdx(i)}
                 className={`flex-1 md:w-full rounded-md text-[11px] font-bold transition-all active:scale-95 cursor-pointer text-center md:text-left px-2.5 py-1.5 whitespace-nowrap ${
@@ -250,10 +269,8 @@ export default function BubbleSortVisualizer() {
           </div>
         </div>
 
-        {/* Divider */}
         <div className="hidden md:block border-t border-gray-800" />
 
-        {/* Stats */}
         <div className="flex flex-row md:flex-col justify-between md:justify-start gap-4 md:gap-2 border-t md:border-t-0 border-gray-800 pt-3 md:pt-0">
           <StatRow label="Steps" value={steps.length - 1} />
           <StatRow label="Step" value={`${idx} / ${steps.length - 1}`} />
@@ -262,25 +279,25 @@ export default function BubbleSortVisualizer() {
 
       {/* ══ RIGHT — CHART + CONTROLS ══ */}
       <div className="flex flex-col flex-1 min-w-0">
-        {/* Status bar */}
         <div className="flex items-center justify-center px-4 md:px-6 py-2.5 min-h-[44px] border-b border-[#111113]">
           <span
             className="text-xs md:text-[13px] font-semibold tracking-wide text-center leading-tight transition-colors duration-150"
             style={{
               color: finished
                 ? "#10b981"
-                : step.swapped
+                : step.swapping
                   ? "#f87171"
-                  : step.comparing
-                    ? "#fbbf24"
-                    : "#6b7280",
+                  : step.currentMinIndex !== null
+                    ? "#a855f7"
+                    : step.comparing !== null
+                      ? "#fbbf24"
+                      : "#6b7280",
             }}
           >
             {step.description}
           </span>
         </div>
 
-        {/* Bar chart */}
         <div className="flex items-end justify-center px-2 sm:px-6 pt-5 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[200px]">
           <div
             className="relative flex items-end justify-center max-w-full"
@@ -294,7 +311,7 @@ export default function BubbleSortVisualizer() {
                 14,
                 Math.round((val / maxVal) * (CHART_H - 30)),
               );
-              const color = barColor(val, i, step);
+              const color = barColor(i, step);
 
               return (
                 <div
@@ -324,7 +341,7 @@ export default function BubbleSortVisualizer() {
                       borderRadius: "5px 5px 2px 2px",
                       transition: `background-color ${transMs}ms ease, height ${transMs}ms cubic-bezier(0.4,0,0.2,1)`,
                       boxShadow:
-                        step.swapped && step.comparing?.includes(i)
+                        step.swapping?.includes(i) || step.currentMinIndex === i
                           ? `0 0 12px ${color}80`
                           : "none",
                     }}
@@ -335,11 +352,12 @@ export default function BubbleSortVisualizer() {
           </div>
         </div>
 
-        {/* Legend */}
         <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2.5 px-3 border-t border-b border-gray-800/80">
           {[
             { color: "#374151", label: "Unsorted" },
+            { color: "#60a5fa", label: "Target Pos" },
             { color: "#fbbf24", label: "Comparing" },
+            { color: "#a855f7", label: "Current Min" },
             { color: "#f87171", label: "Swapping" },
             { color: "#10b981", label: "Sorted" },
           ].map(({ color, label }) => (
@@ -353,10 +371,9 @@ export default function BubbleSortVisualizer() {
           ))}
         </div>
 
-        {/* Play controls */}
         <div className="flex items-center gap-3 px-4 sm:px-6 py-3 sm:py-4">
           <button
-            id="bsv-play"
+            id="ssv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
             className="flex items-center gap-2 rounded-lg text-white text-xs font-bold tracking-wide cursor-pointer active:scale-95 transition-all shadow-md"
@@ -386,7 +403,6 @@ export default function BubbleSortVisualizer() {
           )}
         </div>
 
-        {/* Step log */}
         <div className="mx-4 sm:mx-6 mb-4 sm:mb-6 rounded-xl border border-gray-800 bg-[#050507] overflow-hidden flex-1">
           <div className="px-4 py-2 border-b border-[#111113]">
             <span className="text-[9px] font-black uppercase tracking-widest text-gray-600">
@@ -422,19 +438,11 @@ export default function BubbleSortVisualizer() {
   );
 }
 
-/* ──────────────────────────────────────────────────
-   Sub-components
-────────────────────────────────────────────────── */
 function StatRow({ label, value }: { label: string; value: string | number }) {
   return (
     <div className="flex items-center justify-between">
-      <span className="text-[10px]" style={{ color: "#4b5563" }}>
-        {label}
-      </span>
-      <span
-        className="text-[11px] font-mono font-bold"
-        style={{ color: "#9ca3af" }}
-      >
+      <span className="text-[10px] text-gray-500">{label}</span>
+      <span className="text-[11px] font-mono font-bold text-gray-400">
         {value}
       </span>
     </div>

--- a/packages/components/src/visualizers/SelectionSortVisualizer.tsx
+++ b/packages/components/src/visualizers/SelectionSortVisualizer.tsx
@@ -199,29 +199,30 @@ export default function SelectionSortVisualizer() {
   const transMs = currentSpeed.transitionMs;
 
   return (
-    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#09090b] border border-gray-800 shadow-xl min-h-[380px]">
-      {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
-      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[190px] border-b md:border-b-0 md:border-r border-gray-800 bg-[#070709]">
-        <div>
-          <p className="text-[9px] font-black uppercase tracking-widest mb-2 text-gray-500">
+    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl min-h-[500px] md:h-[520px]">
+      {/* ══ LEFT SIDEBAR / TOP CONTROLS ══ */}
+      <div className="flex flex-col gap-3.5 p-4 md:p-5 shrink-0 w-full md:w-[210px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#0A0A0B]">
+        {/* Array Size Block */}
+        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+          <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Array Size
           </p>
-          <div className="flex items-center justify-between mb-1.5">
-            <span className="text-[11px] font-mono text-gray-400">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-medium text-zinc-400">
               {MIN_SIZE}
             </span>
-            <span className="text-lg md:text-xl font-black tabular-nums text-red-500">
+            <span className="text-xl font-bold tabular-nums text-[#FF5757]">
               {arraySize}
             </span>
-            <span className="text-[11px] font-mono text-gray-400">
+            <span className="text-xs font-medium text-zinc-400">
               {MAX_SIZE}
             </span>
           </div>
 
           <div className="relative flex items-center" style={{ height: 20 }}>
-            <div className="absolute w-full rounded-full h-1 bg-gray-800" />
+            <div className="absolute w-full rounded-full h-1 bg-zinc-800" />
             <div
-              className="absolute rounded-full h-1 bg-red-500 transition-all duration-150"
+              className="absolute rounded-full h-1 bg-[#FF5757] transition-all duration-150"
               style={{
                 width: `${((arraySize - MIN_SIZE) / (MAX_SIZE - MIN_SIZE)) * 100}%`,
               }}
@@ -241,26 +242,27 @@ export default function SelectionSortVisualizer() {
           id="ssv-generate"
           type="button"
           onClick={() => generate(arraySize)}
-          className="w-full rounded-lg text-xs font-bold py-2 bg-gray-800 hover:bg-gray-700 border border-gray-700 text-gray-200 transition-all active:scale-95 cursor-pointer"
+          className="w-full rounded-xl text-xs font-semibold py-2.5 bg-[#111113] hover:bg-zinc-800/80 border border-zinc-800/80 hover:border-zinc-700/60 text-zinc-200 transition-all active:scale-[0.98] cursor-pointer"
         >
           ↻ Randomize
         </button>
 
-        <div>
-          <p className="text-[9px] font-black uppercase tracking-widest mb-2 text-gray-500">
+        {/* Speed Block */}
+        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+          <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Speed
           </p>
-          <div className="flex flex-row md:flex-col gap-1 overflow-x-auto scrollbar-none pb-1 md:pb-0">
+          <div className="flex flex-row md:flex-col gap-1.5 overflow-x-auto scrollbar-none">
             {SPEEDS.map(({ label }, i) => (
               <button
                 key={label}
                 id={`ssv-speed-${i}`}
                 type="button"
                 onClick={() => setSpeedIdx(i)}
-                className={`flex-1 md:w-full rounded-md text-[11px] font-bold transition-all active:scale-95 cursor-pointer text-center md:text-left px-2.5 py-1.5 whitespace-nowrap ${
+                className={`flex-1 md:w-full rounded-lg text-xs transition-all active:scale-[0.98] cursor-pointer text-center md:text-left px-3 py-1.5 whitespace-nowrap ${
                   speedIdx === i
-                    ? "bg-gray-800 text-white border border-gray-700"
-                    : "bg-transparent text-gray-500 border border-transparent hover:text-gray-300"
+                    ? "bg-[#FF5757]/15 text-[#FF5757] border border-[#FF5757]/40 font-semibold shadow-sm"
+                    : "bg-[#111113] text-zinc-400 border border-zinc-800/80 hover:text-zinc-200 hover:border-zinc-700/60 font-medium"
                 }`}
               >
                 {label}
@@ -268,20 +270,14 @@ export default function SelectionSortVisualizer() {
             ))}
           </div>
         </div>
-
-        <div className="hidden md:block border-t border-gray-800" />
-
-        <div className="flex flex-row md:flex-col justify-between md:justify-start gap-4 md:gap-2 border-t md:border-t-0 border-gray-800 pt-3 md:pt-0">
-          <StatRow label="Steps" value={steps.length - 1} />
-          <StatRow label="Step" value={`${idx} / ${steps.length - 1}`} />
-        </div>
       </div>
 
       {/* ══ RIGHT — CHART + CONTROLS ══ */}
-      <div className="flex flex-col flex-1 min-w-0">
-        <div className="flex items-center justify-center px-4 md:px-6 py-2.5 min-h-[44px] border-b border-[#111113]">
+      <div className="flex flex-col flex-1 min-w-0 justify-between h-full">
+        {/* Status bar */}
+        <div className="h-[48px] shrink-0 flex items-center justify-center px-4 md:px-6 border-b border-zinc-800/80 bg-[#0a0a0b]">
           <span
-            className="text-xs md:text-[13px] font-semibold tracking-wide text-center leading-tight transition-colors duration-150"
+            className="text-xs md:text-[13px] font-semibold tracking-tight text-center leading-tight transition-colors duration-150 truncate max-w-full"
             style={{
               color: finished
                 ? "#10b981"
@@ -291,14 +287,15 @@ export default function SelectionSortVisualizer() {
                     ? "#a855f7"
                     : step.comparing !== null
                       ? "#fbbf24"
-                      : "#6b7280",
+                      : "#a1a1aa",
             }}
           >
             {step.description}
           </span>
         </div>
 
-        <div className="flex items-end justify-center px-2 sm:px-6 pt-5 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[200px]">
+        {/* Bar chart container */}
+        <div className="flex items-end justify-center px-2 sm:px-6 pt-6 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[220px]">
           <div
             className="relative flex items-end justify-center max-w-full"
             style={{
@@ -338,7 +335,7 @@ export default function SelectionSortVisualizer() {
                       width: "100%",
                       height: barH,
                       background: color,
-                      borderRadius: "5px 5px 2px 2px",
+                      borderRadius: "6px 6px 2px 2px",
                       transition: `background-color ${transMs}ms ease, height ${transMs}ms cubic-bezier(0.4,0,0.2,1)`,
                       boxShadow:
                         step.swapping?.includes(i) || step.currentMinIndex === i
@@ -352,9 +349,10 @@ export default function SelectionSortVisualizer() {
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2.5 px-3 border-t border-b border-gray-800/80">
+        {/* Legend */}
+        <div className="h-[40px] shrink-0 flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
           {[
-            { color: "#374151", label: "Unsorted" },
+            { color: "#3f3f46", label: "Unsorted" },
             { color: "#60a5fa", label: "Target Pos" },
             { color: "#fbbf24", label: "Comparing" },
             { color: "#a855f7", label: "Current Min" },
@@ -366,20 +364,23 @@ export default function SelectionSortVisualizer() {
                 className="rounded-sm inline-block w-2 h-2"
                 style={{ background: color }}
               />
-              <span className="text-[10px] text-gray-500">{label}</span>
+              <span className="text-[10px] font-medium text-zinc-400">
+                {label}
+              </span>
             </div>
           ))}
         </div>
 
-        <div className="flex items-center gap-3 px-4 sm:px-6 py-3 sm:py-4">
+        {/* Play controls */}
+        <div className="h-[56px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
           <button
             id="ssv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
-            className="flex items-center gap-2 rounded-lg text-white text-xs font-bold tracking-wide cursor-pointer active:scale-95 transition-all shadow-md"
+            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
             style={{
-              padding: "8px 18px",
-              background: finished ? "#059669" : "#ef4444",
+              padding: "9px 20px",
+              background: finished ? "#059669" : "#FF5757",
             }}
           >
             {finished ? <IconReset /> : playing ? <IconPause /> : <IconPlay />}
@@ -396,35 +397,39 @@ export default function SelectionSortVisualizer() {
             <button
               type="button"
               onClick={reset}
-              className="rounded-lg text-xs font-bold cursor-pointer active:scale-95 transition-all px-3.5 py-2 border border-gray-700 text-gray-400 hover:text-white bg-transparent"
+              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
+              style={{
+                padding: "9px 20px",
+              }}
             >
               Reset
             </button>
           )}
         </div>
 
-        <div className="mx-4 sm:mx-6 mb-4 sm:mb-6 rounded-xl border border-gray-800 bg-[#050507] overflow-hidden flex-1">
-          <div className="px-4 py-2 border-b border-[#111113]">
-            <span className="text-[9px] font-black uppercase tracking-widest text-gray-600">
+        {/* Step log container - fixed height prevents screen shifting */}
+        <div className="h-[135px] shrink-0 mx-4 sm:mx-6 mb-4 rounded-xl border border-zinc-800/80 bg-[#111113] overflow-hidden flex flex-col">
+          <div className="px-4 py-2 border-b border-zinc-800/80 shrink-0 bg-[#0a0a0b]">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-zinc-400">
               Step log
             </span>
           </div>
-          <div>
+          <div className="flex-1 overflow-y-auto scrollbar-thin-grey">
             {log.map((s, i) => (
               <div
                 key={i}
                 className={`flex items-center gap-3 px-4 py-1.5 ${
-                  i === 0 ? "bg-white/[0.02]" : "bg-transparent"
-                } ${i < log.length - 1 ? "border-b border-[#0d0d0f]" : ""}`}
+                  i === 0 ? "bg-white/[0.03]" : "bg-transparent"
+                } ${i < log.length - 1 ? "border-b border-zinc-900" : ""}`}
               >
                 <span
                   className={`rounded-full shrink-0 w-1.5 h-1.5 inline-block ${
-                    i === 0 ? "bg-red-500" : "bg-gray-800"
+                    i === 0 ? "bg-[#FF5757]" : "bg-zinc-800"
                   }`}
                 />
                 <span
                   className={`text-[11px] font-mono ${
-                    i === 0 ? "text-gray-300 font-semibold" : "text-gray-600"
+                    i === 0 ? "text-zinc-200 font-semibold" : "text-zinc-500"
                   }`}
                 >
                   {s.description}
@@ -441,10 +446,8 @@ export default function SelectionSortVisualizer() {
 function StatRow({ label, value }: { label: string; value: string | number }) {
   return (
     <div className="flex items-center justify-between">
-      <span className="text-[10px] text-gray-500">{label}</span>
-      <span className="text-[11px] font-mono font-bold text-gray-400">
-        {value}
-      </span>
+      <span className="text-xs font-medium text-zinc-400">{label}</span>
+      <span className="text-xs font-semibold text-zinc-200">{value}</span>
     </div>
   );
 }

--- a/packages/components/src/visualizers/SelectionSortVisualizer.tsx
+++ b/packages/components/src/visualizers/SelectionSortVisualizer.tsx
@@ -129,11 +129,12 @@ const DEFAULT_SIZE = 7;
 ────────────────────────────────────────────────── */
 export default function SelectionSortVisualizer() {
   const [arraySize, setArraySize] = useState(DEFAULT_SIZE);
-  const [baseArray, setBaseArray] = useState<number[]>(() =>
-    randomArray(DEFAULT_SIZE),
+  const initialArray = useRef<number[]>(randomArray(DEFAULT_SIZE));
+  const [baseArray, setBaseArray] = useState<number[]>(
+    () => initialArray.current,
   );
   const [steps, setSteps] = useState<SortStep[]>(() =>
-    generateSelectionSortSteps(randomArray(DEFAULT_SIZE)),
+    generateSelectionSortSteps(initialArray.current),
   );
   const [idx, setIdx] = useState(0);
   const [playing, setPlaying] = useState(false);
@@ -434,15 +435,6 @@ export default function SelectionSortVisualizer() {
           </div>
         </div>
       </div>
-    </div>
-  );
-}
-
-function StatRow({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="flex items-center justify-between">
-      <span className="text-xs font-medium text-zinc-400">{label}</span>
-      <span className="text-xs font-semibold text-zinc-200">{value}</span>
     </div>
   );
 }

--- a/packages/components/src/visualizers/SelectionSortVisualizer.tsx
+++ b/packages/components/src/visualizers/SelectionSortVisualizer.tsx
@@ -201,7 +201,7 @@ export default function SelectionSortVisualizer() {
   return (
     <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl md:h-[520px]">
       {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
-      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[200px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#070709]">
+      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[200px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#0A0A0B]">
         {/* Array Size */}
         <div>
           <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
@@ -349,7 +349,7 @@ export default function SelectionSortVisualizer() {
         </div>
 
         {/* Legend */}
-        <div className="min-h-[38px] shrink-0 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
+        <div className="shrink-0 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/60">
           {[
             { color: "#3f3f46", label: "Unsorted" },
             { color: "#60a5fa", label: "Target Pos" },
@@ -360,10 +360,10 @@ export default function SelectionSortVisualizer() {
           ].map(({ color, label }) => (
             <div key={label} className="flex items-center gap-1.5">
               <span
-                className="rounded-sm inline-block w-2 h-2 shrink-0"
+                className="rounded-full inline-block w-1.5 h-1.5 shrink-0"
                 style={{ background: color }}
               />
-              <span className="text-[10px] font-medium text-zinc-400 whitespace-nowrap">
+              <span className="text-[11px] font-medium text-zinc-400 whitespace-nowrap">
                 {label}
               </span>
             </div>
@@ -371,12 +371,12 @@ export default function SelectionSortVisualizer() {
         </div>
 
         {/* Play controls */}
-        <div className="min-h-[52px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
+        <div className="shrink-0 flex items-center gap-2.5 px-3 sm:px-6 py-2">
           <button
             id="ssv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
-            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
+            className="flex items-center gap-1.5 rounded-lg text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-3.5 py-1.5 shadow-[0_2px_10px_rgba(255,87,87,0.25)]"
             style={{
               background: finished ? "#059669" : "#FF5757",
             }}
@@ -395,7 +395,7 @@ export default function SelectionSortVisualizer() {
             <button
               type="button"
               onClick={reset}
-              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
+              className="flex items-center gap-1.5 rounded-lg text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-3.5 py-1.5 border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
             >
               Reset
             </button>

--- a/packages/components/src/visualizers/SelectionSortVisualizer.tsx
+++ b/packages/components/src/visualizers/SelectionSortVisualizer.tsx
@@ -199,11 +199,11 @@ export default function SelectionSortVisualizer() {
   const transMs = currentSpeed.transitionMs;
 
   return (
-    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl min-h-[500px] md:h-[520px]">
-      {/* ══ LEFT SIDEBAR / TOP CONTROLS ══ */}
-      <div className="flex flex-col gap-3.5 p-4 md:p-5 shrink-0 w-full md:w-[210px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#0A0A0B]">
-        {/* Array Size Block */}
-        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+    <div className="w-full rounded-2xl overflow-hidden flex flex-col md:flex-row bg-[#0a0a0b] border border-zinc-800/80 shadow-2xl md:h-[520px]">
+      {/* ══ LEFT SIDEBAR / TOP CONTROLS ON MOBILE ══ */}
+      <div className="flex flex-col gap-4 md:gap-5 p-4 md:p-5 shrink-0 w-full md:w-[200px] border-b md:border-b-0 md:border-r border-zinc-800/80 bg-[#070709]">
+        {/* Array Size */}
+        <div>
           <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Array Size
           </p>
@@ -242,17 +242,16 @@ export default function SelectionSortVisualizer() {
           id="ssv-generate"
           type="button"
           onClick={() => generate(arraySize)}
-          className="w-full rounded-xl text-xs font-semibold py-2.5 bg-[#111113] hover:bg-zinc-800/80 border border-zinc-800/80 hover:border-zinc-700/60 text-zinc-200 transition-all active:scale-[0.98] cursor-pointer"
+          className="w-full rounded-xl text-xs font-semibold py-2 bg-[#111113] hover:bg-zinc-800/80 border border-zinc-800/80 hover:border-zinc-700/60 text-zinc-200 transition-all active:scale-[0.98] cursor-pointer"
         >
           ↻ Randomize
         </button>
 
-        {/* Speed Block */}
-        <div className="p-3.5 rounded-xl border border-zinc-800/80 bg-[#0A0A0B]">
+        <div>
           <p className="text-[10px] font-semibold uppercase tracking-wider mb-2 text-zinc-400">
             Speed
           </p>
-          <div className="flex flex-row md:flex-col gap-1.5 overflow-x-auto scrollbar-none">
+          <div className="flex flex-row md:flex-col gap-1.5 overflow-x-auto scrollbar-none pb-1 md:pb-0">
             {SPEEDS.map(({ label }, i) => (
               <button
                 key={label}
@@ -273,11 +272,11 @@ export default function SelectionSortVisualizer() {
       </div>
 
       {/* ══ RIGHT — CHART + CONTROLS ══ */}
-      <div className="flex flex-col flex-1 min-w-0 justify-between h-full">
+      <div className="flex flex-col flex-1 min-w-0 justify-between md:h-full">
         {/* Status bar */}
-        <div className="h-[48px] shrink-0 flex items-center justify-center px-4 md:px-6 border-b border-zinc-800/80 bg-[#0a0a0b]">
+        <div className="min-h-[44px] md:h-[48px] shrink-0 flex items-center justify-center px-4 md:px-6 py-2 border-b border-zinc-800/80 bg-[#0a0a0b]">
           <span
-            className="text-xs md:text-[13px] font-semibold tracking-tight text-center leading-tight transition-colors duration-150 truncate max-w-full"
+            className="text-xs md:text-[13px] font-semibold tracking-tight text-center leading-tight transition-colors duration-150"
             style={{
               color: finished
                 ? "#10b981"
@@ -295,7 +294,7 @@ export default function SelectionSortVisualizer() {
         </div>
 
         {/* Bar chart container */}
-        <div className="flex items-end justify-center px-2 sm:px-6 pt-6 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[220px]">
+        <div className="flex items-end justify-center px-2 sm:px-6 pt-5 pb-4 overflow-x-auto scrollbar-none flex-1 min-h-[180px] md:min-h-[220px]">
           <div
             className="relative flex items-end justify-center max-w-full"
             style={{
@@ -350,7 +349,7 @@ export default function SelectionSortVisualizer() {
         </div>
 
         {/* Legend */}
-        <div className="h-[40px] shrink-0 flex flex-wrap items-center justify-center gap-3 sm:gap-4 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
+        <div className="min-h-[38px] shrink-0 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 py-2 px-3 border-t border-b border-zinc-800/80 bg-[#111113]/50">
           {[
             { color: "#3f3f46", label: "Unsorted" },
             { color: "#60a5fa", label: "Target Pos" },
@@ -361,10 +360,10 @@ export default function SelectionSortVisualizer() {
           ].map(({ color, label }) => (
             <div key={label} className="flex items-center gap-1.5">
               <span
-                className="rounded-sm inline-block w-2 h-2"
+                className="rounded-sm inline-block w-2 h-2 shrink-0"
                 style={{ background: color }}
               />
-              <span className="text-[10px] font-medium text-zinc-400">
+              <span className="text-[10px] font-medium text-zinc-400 whitespace-nowrap">
                 {label}
               </span>
             </div>
@@ -372,14 +371,13 @@ export default function SelectionSortVisualizer() {
         </div>
 
         {/* Play controls */}
-        <div className="h-[56px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
+        <div className="min-h-[52px] shrink-0 flex items-center gap-3 px-4 sm:px-6 py-2.5">
           <button
             id="ssv-play"
             type="button"
             onClick={() => (finished ? reset() : setPlaying((p) => !p))}
-            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
+            className="flex items-center gap-2 rounded-xl text-white text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 shadow-[0_4px_14px_rgba(255,87,87,0.25)]"
             style={{
-              padding: "9px 20px",
               background: finished ? "#059669" : "#FF5757",
             }}
           >
@@ -397,10 +395,7 @@ export default function SelectionSortVisualizer() {
             <button
               type="button"
               onClick={reset}
-              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
-              style={{
-                padding: "9px 20px",
-              }}
+              className="flex items-center gap-2 rounded-xl text-xs font-semibold tracking-wide cursor-pointer active:scale-[0.98] transition-all shrink-0 px-4 py-2 border border-zinc-800/80 text-zinc-300 hover:text-white bg-[#111113] hover:bg-zinc-800/80"
             >
               Reset
             </button>

--- a/packages/components/src/visualizers/index.ts
+++ b/packages/components/src/visualizers/index.ts
@@ -1,9 +1,20 @@
 import type React from "react";
 
 import BubbleSortVisualizer from "./BubbleSortVisualizer";
+import MergeSortVisualizer from "./MergeSortVisualizer";
+import QuickSortVisualizer from "./QuickSortVisualizer";
+import SelectionSortVisualizer from "./SelectionSortVisualizer";
 
 export const VISUALIZER_MAP: Record<string, React.ComponentType> = {
   "bubble-sort": BubbleSortVisualizer,
+  "selection-sort": SelectionSortVisualizer,
+  "quick-sort": QuickSortVisualizer,
+  "merge-sort": MergeSortVisualizer,
 };
 
-export { BubbleSortVisualizer };
+export {
+  BubbleSortVisualizer,
+  MergeSortVisualizer,
+  QuickSortVisualizer,
+  SelectionSortVisualizer,
+};

--- a/packages/interface/src/Components.ts
+++ b/packages/interface/src/Components.ts
@@ -91,12 +91,7 @@ export interface LinkButtonProps extends LinkProps {
 }
 
 type ButtonVariant =
-  | "OUTLINE"
-  | "PRIMARY"
-  | "SECONDARY"
-  | "GHOST"
-  | "SUCCESS"
-  | "NEUTRAL";
+  "OUTLINE" | "PRIMARY" | "SECONDARY" | "GHOST" | "SUCCESS" | "NEUTRAL";
 
 export interface ButtonProps extends DelegatedInteractiveAnalyticsProps {
   variant: ButtonVariant;
@@ -1022,6 +1017,7 @@ export interface DsaQuestion {
   notes?: string;
   _priorityScore?: number;
   isRealWorldProblem?: boolean;
+  visualizerId?: string;
   /** Whether this question is locked behind a paywall (freemium gating) */
   isLocked?: boolean;
   sections?: {
@@ -1092,6 +1088,8 @@ export interface QuestionRowProps {
   realWorldBadgeLabel?: string;
   /** Indicates a freemium-locked question (paid content) */
   isLocked?: boolean;
+  /** Indicates an interactive visualizer is available for this question */
+  hasVisualizer?: boolean;
   className?: string;
   onClick?: () => void;
   onToggleComplete?: (e: React.MouseEvent) => void;

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -67,12 +67,7 @@ export interface LogoProps {
 
 export interface ButtonProps {
   variant:
-    | "PRIMARY"
-    | "OUTLINE"
-    | "GHOST"
-    | "SUCCESS"
-    | "SECONDARY"
-    | "NEUTRAL";
+    "PRIMARY" | "OUTLINE" | "GHOST" | "SUCCESS" | "SECONDARY" | "NEUTRAL";
   className?: string;
   text: string;
   onClick?: MouseEventHandler<HTMLButtonElement>;
@@ -1018,6 +1013,7 @@ export interface DSAQuestion {
   leetcodeLink?: string;
   youtubeSearchLink?: string;
   isRealWorldProblem?: boolean;
+  visualizerId?: string;
 }
 
 export interface DSAQuestionSidebarProps {
@@ -1156,4 +1152,5 @@ export interface MainNavbarProps {
 
 export type QuestionDifficulty = "EASY" | "MEDIUM" | "HARD";
 
-export type DsaSectionTabs = "description" | "topics" | "companies" | "notes";
+export type DsaSectionTabs =
+  "description" | "visualizer" | "topics" | "companies" | "notes";

--- a/packages/utils/src/dsaHelpers.ts
+++ b/packages/utils/src/dsaHelpers.ts
@@ -14,6 +14,7 @@ export const transformDsaQuestion = (question: any): DsaQuestion => {
       companyType: question.companyTypes,
       isRealWorldProblem: Boolean(question.isRealWorldProblem),
       isLocked: true,
+      visualizerId: question.visualizerId,
     };
   }
 
@@ -59,6 +60,7 @@ export const transformDsaQuestion = (question: any): DsaQuestion => {
     _priorityScore: question._priorityScore,
     isRealWorldProblem: Boolean(question.isRealWorldProblem),
     isLocked: false,
+    visualizerId: question.visualizerId,
   };
 };
 

--- a/packages/utils/src/dsaHelpers.ts
+++ b/packages/utils/src/dsaHelpers.ts
@@ -14,7 +14,7 @@ export const transformDsaQuestion = (question: any): DsaQuestion => {
       companyType: question.companyTypes,
       isRealWorldProblem: Boolean(question.isRealWorldProblem),
       isLocked: true,
-      visualizerId: question.visualizerId,
+      visualizerId: question.visualizerId ?? undefined,
     };
   }
 
@@ -60,7 +60,7 @@ export const transformDsaQuestion = (question: any): DsaQuestion => {
     _priorityScore: question._priorityScore,
     isRealWorldProblem: Boolean(question.isRealWorldProblem),
     isLocked: false,
-    visualizerId: question.visualizerId,
+    visualizerId: question.visualizerId ?? undefined,
   };
 };
 


### PR DESCRIPTION
## What does this PR do?

Adds interactive, mobile-responsive algorithm visualizer components for **Bubble Sort**, **Selection Sort**, **Quick Sort**, and **Merge Sort** to DSAYatra question pages driven by database configuration (`visualizerId`). Also adds a minimalist **VISUALIZER** badge tag in the question sidebar.

## Why?

Allows users to interactively step through algorithm execution, speed controls, array size adjustments, and step-by-step logs directly within the DSA question workspace.

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 Refactor / cleanup (no functional change)
- [x] 🎨 UI / styling change
- [ ] 🔌 API change (new or modified endpoints, request/response shape changes)
- [ ] 📦 Dependency update
- [ ] 📝 Documentation only

---

## Testing

### Does this PR include tests?

- [ ] Yes — unit tests
- [ ] Yes — integration / e2e tests
- [x] No — UI visualizer feature verified manually across desktop and mobile viewports.

### How to test manually

1. Open DSAYatra question workspace for Bubble, Selection, Quick, or Merge Sort.
2. Verify the minimalist **VISUALIZER** badge appears in the left sidebar.
3. Open the **Visualizer** tab and test **Start / Pause / Reset**, **Speed**, and **Array Size** controls.
4. Switch to a question without a visualizer and verify tab state falls back to Description without blank screens.

---

## Checklist

- [x] I've tested this locally and it works as expected
- [x] I've checked for console errors / warnings
- [x] No unrelated changes snuck in
- [x] If UI change — tested on mobile viewport too
