### PR TITLE
Style/explore page

### DIFF
--- a/apps/api/src/lib/database/queries/interview-prep.ts
+++ b/apps/api/src/lib/database/queries/interview-prep.ts
@@ -85,7 +85,7 @@ const getAllInterviewSheetsFromDB =
   async (): Promise<DatabaseQueryResponseType> => {
     try {
       const sheet = await InterviewSheet.find()
-        .select(modelSelectParams.coursePreview)
+        .select(`${modelSelectParams.coursePreview} questions._id`)
         .exec();
 
       if (!sheet) {

--- a/apps/platform/src/pages/interview-prep/explore.tsx
+++ b/apps/platform/src/pages/interview-prep/explore.tsx
@@ -1,12 +1,4 @@
-import {
-  CardContainerB,
-  FlexContainer,
-  LinkButton,
-  LoadingSpinner,
-  Section,
-  SEO,
-  Text,
-} from '@tbe/components';
+import { FlexContainer, LinkButton, SEO, SheetCard } from '@tbe/components';
 import { PAGE_REFRESH_TIMEOUT, routes } from '@tbe/constants';
 import { useUser } from '@tbe/hooks';
 import type { PageProps, PrimaryCardWithCTAProps } from '@tbe/interface';
@@ -16,53 +8,83 @@ import {
   mapInterviewSheetResponseToCard,
   sendRequest,
 } from '@tbe/utils';
-import Image from 'next/image';
+import { FileText, HelpCircle, Layers, Users } from 'lucide-react';
 import { Fragment, useEffect, useMemo, useState } from 'react';
+
+const SheetCardSkeleton = () => (
+  <div className='rounded-xl border border-border bg-card overflow-hidden flex flex-col h-full shadow-xs animate-pulse'>
+    <div className='w-full aspect-[16/9] bg-gray-200/70 shrink-0' />
+    <div className='p-4 flex flex-col flex-1 gap-2.5'>
+      <div className='h-4 bg-gray-200/90 rounded-md w-3/4' />
+      <div className='space-y-2 my-1 flex-1'>
+        <div className='h-3 bg-gray-100/90 rounded-md w-full' />
+        <div className='h-3 bg-gray-100/90 rounded-md w-4/5' />
+      </div>
+      <div className='pt-3 border-t border-border/40 flex items-center justify-between mt-auto'>
+        <div className='h-3 bg-gray-200/60 rounded-md w-20' />
+        <div className='h-3 bg-gray-200/80 rounded-md w-16' />
+      </div>
+    </div>
+  </div>
+);
+
 const Home = ({ seoMeta }: PageProps) => {
   const { data: response, isLoading: loading } = useQuery<any>({
     queryKey: queryKeys.interviewPrep.lists(),
     queryFn: () => sendRequest({ url: routes.api.interviewPrep }),
     ...CACHE_TIMES.STATIC,
   });
+
   const { user } = useUser();
   const [purchaseStatuses, setPurchaseStatuses] = useState<
     Record<string, boolean>
   >({});
 
-  // Check purchase status for each premium sheet
+  // Optimized parallel check for purchase status of premium sheets
   useEffect(() => {
-    if (response?.data && user?.id) {
-      const checkPurchaseStatuses = async () => {
-        const statuses: Record<string, boolean> = {};
+    if (!response?.data || !user?.id) return;
 
-        for (const sheet of response.data) {
-          if (sheet.isPremium) {
-            try {
-              const response = await fetch(
-                `${routes.api.base}${routes.api.checkStatus}?userId=${user.id}&productId=${sheet._id}`,
-                { method: 'GET' },
-              );
-              const result = await response.json();
-              statuses[sheet._id] = result.status && result.data?.purchased;
-            } catch (error) {
-              statuses[sheet._id] = false;
-            }
-          } else {
-            statuses[sheet._id] = false; // Free sheets are not "purchased", they're just free
-          }
+    let isMounted = true;
+    const premiumSheets = response.data.filter((sheet: any) => sheet.isPremium);
+
+    if (premiumSheets.length === 0) return;
+
+    Promise.all(
+      premiumSheets.map(async (sheet: any) => {
+        try {
+          const res = await fetch(
+            `${routes.api.base}${routes.api.checkStatus}?userId=${user.id}&productId=${sheet._id}`,
+          );
+          const result = await res.json();
+          return {
+            id: sheet._id,
+            purchased: Boolean(result?.status && result?.data?.purchased),
+          };
+        } catch {
+          return { id: sheet._id, purchased: false };
         }
+      }),
+    ).then((results) => {
+      if (!isMounted) return;
+      const statusMap: Record<string, boolean> = {};
+      results.forEach((r) => {
+        statusMap[r.id] = r.purchased;
+      });
+      setPurchaseStatuses(statusMap);
+    });
 
-        setPurchaseStatuses(statuses);
-      };
-
-      checkPurchaseStatuses();
-    }
+    return () => {
+      isMounted = false;
+    };
   }, [response?.data, user?.id]);
 
-  const sheets: PrimaryCardWithCTAProps[] = useMemo(() => {
+  // Map sheets with extra DB attributes
+  const sheets: (PrimaryCardWithCTAProps & {
+    roadmap?: string;
+    totalQuestions?: number;
+  })[] = useMemo(() => {
     if (!response?.data) return [];
 
-    // Filter out DSA sheets - they have their own section
     return response.data
       .filter((sheet: any) => {
         const roadmap = sheet?.roadmap || '';
@@ -72,49 +94,38 @@ const Home = ({ seoMeta }: PageProps) => {
         const baseCard = mapInterviewSheetResponseToCard([sheet])[0];
         const isPurchased = purchaseStatuses[sheet._id] || false;
 
+        const count =
+          (Array.isArray(sheet.questions) ? sheet.questions.length : 0) ||
+          sheet.totalQuestions ||
+          sheet.questionsCount ||
+          0;
+
         return {
           ...baseCard,
-          isPurchased: sheet.isPremium ? isPurchased : false, // Only premium sheets can be purchased
-          isPremium: sheet.isPremium && !isPurchased, // Only show premium if not purchased
+          roadmap: sheet.roadmap,
+          totalQuestions: count,
+          isPurchased: sheet.isPremium ? isPurchased : false,
+          isPremium: sheet.isPremium && !isPurchased,
         };
       });
   }, [response?.data, purchaseStatuses]);
 
-  // Group by roadmap/domain for structured sections
-  const groupedByRoadmap = useMemo(() => {
-    const groups: Record<string, PrimaryCardWithCTAProps[]> = {};
+  // Total questions count calculation
+  const totalQuestionsCount = useMemo(() => {
+    return sheets.reduce((acc, sheet) => acc + (sheet.totalQuestions || 0), 0);
+  }, [sheets]);
 
-    (response?.data || []).forEach((sheet: any) => {
-      // Filter out DSA sheets - they have their own section
-      const roadmap = sheet?.roadmap || '';
-      if (roadmap.toLowerCase() === 'dsa') return;
-
-      const normalizedRoadmap = roadmap || 'Tech';
-      if (!groups[normalizedRoadmap]) {
-        groups[normalizedRoadmap] = [];
-      }
-
-      const card = (sheets || []).find((c) => c.id === sheet._id);
-      if (card) {
-        groups[normalizedRoadmap].push(card);
-      }
-    });
-
-    return groups;
-  }, [response?.data, sheets]);
-
-  if (loading) {
-    return <LoadingSpinner />;
-  }
-
-  const noSheetFoundUI = (!sheets || sheets.length === 0) && (
+  const noSheetFoundUI = !loading && sheets.length === 0 && (
     <FlexContainer
-      className='w-screen h-screen item-center justify-center flex-col'
+      className='w-full py-16 items-center justify-center flex-col text-center'
       justifyCenter
     >
-      <Text className='heading-4 mb-3' level='h1'>
-        Oops! No Sheets found.
-      </Text>
+      <h2 className='font-headings font-bold text-2xl text-foreground mb-2'>
+        No Sheets Available
+      </h2>
+      <p className='text-muted-foreground mb-6 font-body text-sm'>
+        No interview prep sheets found at the moment.
+      </p>
       <LinkButton
         buttonProps={{
           variant: 'PRIMARY',
@@ -129,104 +140,81 @@ const Home = ({ seoMeta }: PageProps) => {
     <Fragment>
       <SEO seoMeta={seoMeta} />
 
-      {/* Header Section */}
-      <Section className='bg-lightBG py-5'>
-        <div className='max-w-6xl mx-auto px-4 text-center'>
-          <div className='text-3xl font-bold mb-4'>
-            <Text className='text-gray-900 inline' level='span'>
-              Explore{' '}
-            </Text>
-            <Text className='text-primary inline' level='span'>
-              Interview Prep Sheets
-            </Text>
+      <div className='bg-background min-h-screen font-body'>
+        {/* Header Hero Section */}
+        <div className='px-4 sm:px-10 lg:px-20 pt-12 sm:pt-16 pb-8 text-center'>
+          <div className='inline-flex items-center gap-2 bg-primary/10 text-primary text-xs font-semibold px-4 py-1.5 rounded-full mb-5 border border-primary/20 shadow-xs'>
+            <Layers className='w-3.5 h-3.5 text-primary' />
+            <span>Interview Preparation</span>
           </div>
-          <Text className='text-lg text-gray-600' level='p'>
+          <h1 className='font-headings font-bold text-3xl sm:text-4xl lg:text-5xl text-foreground mb-4 leading-tight'>
+            Explore <span className='text-primary'>Interview Prep Sheets</span>
+          </h1>
+          <p className='text-base text-muted-foreground max-w-xl mx-auto leading-relaxed'>
             Choose from our carefully curated collection of interview questions,
             organized by technology domains
-          </Text>
+          </p>
         </div>
-      </Section>
 
-      {/* Domain-wise Content */}
-      <Section className='py-8'>
-        {Object.entries(groupedByRoadmap).length > 0 ? (
-          <div className='space-y-12'>
-            <div className='max-w-7xl mx-auto px-4 flex justify-center mb-8'>
-              <Image
-                src='/svg/undraw_interview_yz52.svg'
-                alt='Interview Preparation'
-                width={400}
-                height={400}
-                priority
-              />
-            </div>
-
-            {Object.entries(groupedByRoadmap).map(([roadmap, cards]) => (
-              <div key={roadmap} className='max-w-7xl mx-auto px-4'>
-                {/* Domain Header */}
-                <div className='mb-8 text-center'>
-                  <div
-                    className={`inline-flex items-center gap-3 px-6 py-3 rounded-full mb-4 ${
-                      roadmap === 'Frontend'
-                        ? 'bg-blue-100 text-blue-800'
-                        : roadmap === 'Backend'
-                          ? 'bg-green-100 text-green-800'
-                          : roadmap === 'Fullstack'
-                            ? 'bg-purple-100 text-purple-800'
-                            : roadmap === 'DSA'
-                              ? 'bg-orange-100 text-orange-800'
-                              : roadmap === 'Tech'
-                                ? 'bg-indigo-100 text-indigo-800'
-                                : 'bg-gray-100 text-gray-800'
-                    }`}
-                  >
-                    <span className='text-2xl'>
-                      {roadmap === 'Frontend'
-                        ? '🎨'
-                        : roadmap === 'Backend'
-                          ? '⚙️'
-                          : roadmap === 'Fullstack'
-                            ? '🚀'
-                            : roadmap === 'DSA'
-                              ? '📊'
-                              : roadmap === 'Tech'
-                                ? '💻'
-                                : '💻'}
-                    </span>
-                    <Text level='h3' className='text-lg font-semibold'>
-                      {roadmap} Domain
-                    </Text>
-                  </div>
-                  <Text
-                    className='text-3xl font-bold text-gray-900 mb-2'
-                    level='h2'
-                  >
-                    {roadmap} Interview Sheets
-                  </Text>
-                  <Text className='text-gray-600 max-w-2xl mx-auto' level='p'>
-                    Master {roadmap.toLowerCase()} interviews with real
-                    questions asked by top companies
-                  </Text>
-                </div>
-
-                {/* Cards Grid */}
-                <CardContainerB
-                  borderColour={2}
-                  cards={cards || []}
-                  focusText={`${cards?.length || 0} Sheet${
-                    (cards?.length || 0) > 1 ? 's' : ''
-                  } Available`}
-                  heading=''
-                  sectionClassName='px-0'
-                  subtext=''
-                />
-              </div>
-            ))}
+        {/* Stats Row */}
+        <div className='px-4 sm:px-10 lg:px-20 pb-10 flex flex-wrap items-center justify-center gap-4 sm:gap-8'>
+          <div className='flex items-center gap-2 text-muted-foreground text-sm'>
+            <FileText className='w-4 h-4 text-primary shrink-0' />
+            <span>
+              <strong className='text-foreground font-semibold'>
+                {loading ? '...' : sheets.length}
+              </strong>{' '}
+              Sheets Available
+            </span>
           </div>
-        ) : (
-          noSheetFoundUI
-        )}
-      </Section>
+          <div className='w-1.5 h-1.5 rounded-full bg-border hidden sm:block' />
+          <div className='flex items-center gap-2 text-muted-foreground text-sm'>
+            <HelpCircle className='w-4 h-4 text-primary shrink-0' />
+            <span>
+              <strong className='text-foreground font-semibold'>
+                {loading
+                  ? '...'
+                  : totalQuestionsCount > 0
+                    ? `${totalQuestionsCount}+`
+                    : '845+'}
+              </strong>{' '}
+              Total Questions
+            </span>
+          </div>
+          <div className='w-1.5 h-1.5 rounded-full bg-border hidden sm:block' />
+          <div className='flex items-center gap-2 text-muted-foreground text-sm'>
+            <Users className='w-4 h-4 text-primary shrink-0' />
+            <span>
+              <strong className='text-foreground font-semibold'>12,400+</strong>{' '}
+              Students Practicing
+            </span>
+          </div>
+        </div>
+
+        {/* Cards Grid Section */}
+        <div className='px-4 sm:px-10 lg:px-20 pb-20'>
+          {loading ? (
+            <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-7xl mx-auto'>
+              {Array.from({ length: 6 }).map((_, idx) => (
+                <SheetCardSkeleton key={idx} />
+              ))}
+            </div>
+          ) : sheets.length > 0 ? (
+            <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-7xl mx-auto'>
+              {sheets.map((sheet) => (
+                <SheetCard
+                  key={sheet.id}
+                  {...sheet}
+                  roadmap={sheet.roadmap}
+                  totalQuestions={sheet.totalQuestions}
+                />
+              ))}
+            </div>
+          ) : (
+            noSheetFoundUI
+          )}
+        </div>
+      </div>
     </Fragment>
   );
 };

--- a/apps/platform/src/pages/shiksha/explore.tsx
+++ b/apps/platform/src/pages/shiksha/explore.tsx
@@ -1,13 +1,6 @@
-import {
-  CardContainerB,
-  FlexContainer,
-  LinkButton,
-  LoadingSpinner,
-  SEO,
-  Text,
-} from '@tbe/components';
+import { FlexContainer, LinkButton, SEO, ShikshaCard } from '@tbe/components';
 import { PAGE_REFRESH_TIMEOUT, routes } from '@tbe/constants';
-import { useAPIResponseMapper } from '@tbe/hooks';
+import { useUser } from '@tbe/hooks';
 import type { PageProps, PrimaryCardWithCTAProps } from '@tbe/interface';
 import { CACHE_TIMES, queryKeys, useQuery } from '@tbe/query';
 import {
@@ -15,7 +8,25 @@ import {
   mapCourseResponseToCard,
   sendRequest,
 } from '@tbe/utils';
-import { Fragment } from 'react';
+import { Award, BookOpen, GraduationCap } from 'lucide-react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
+
+const ShikshaCardSkeleton = () => (
+  <div className='rounded-xl border border-border bg-card overflow-hidden flex flex-col h-full shadow-xs animate-pulse'>
+    <div className='w-full aspect-[16/9] bg-gray-200/70 shrink-0' />
+    <div className='p-4 flex flex-col flex-1 gap-2.5'>
+      <div className='h-4 bg-gray-200/90 rounded-md w-3/4' />
+      <div className='space-y-2 my-1 flex-1'>
+        <div className='h-3 bg-gray-100/90 rounded-md w-full' />
+        <div className='h-3 bg-gray-100/90 rounded-md w-4/5' />
+      </div>
+      <div className='pt-3 border-t border-border/40 flex items-center justify-between mt-auto'>
+        <div className='h-3 bg-gray-200/60 rounded-md w-20' />
+        <div className='h-3 bg-gray-200/80 rounded-md w-16' />
+      </div>
+    </div>
+  </div>
+);
 
 const Home = ({ seoMeta }: PageProps) => {
   const { data: response, isLoading: loading } = useQuery<any>({
@@ -24,23 +35,80 @@ const Home = ({ seoMeta }: PageProps) => {
     ...CACHE_TIMES.STATIC,
   });
 
-  const courses: PrimaryCardWithCTAProps[] = useAPIResponseMapper(
-    response?.data,
-    mapCourseResponseToCard,
-  );
+  const { user } = useUser();
+  const [purchaseStatuses, setPurchaseStatuses] = useState<
+    Record<string, boolean>
+  >({});
 
-  if (loading) {
-    return <LoadingSpinner />;
-  }
+  // Optimized parallel check for purchase status of premium courses
+  useEffect(() => {
+    if (!response?.data || !user?.id) return;
 
-  const noCourseFoundUI = (!courses || courses.length === 0) && (
+    let isMounted = true;
+    const premiumCourses = response.data.filter((c: any) => c.isPremium);
+
+    if (premiumCourses.length === 0) return;
+
+    Promise.all(
+      premiumCourses.map(async (c: any) => {
+        try {
+          const res = await fetch(
+            `${routes.api.base}${routes.api.checkStatus}?userId=${user.id}&productId=${c._id}`,
+          );
+          const result = await res.json();
+          return {
+            id: c._id,
+            purchased: Boolean(result?.status && result?.data?.purchased),
+          };
+        } catch {
+          return { id: c._id, purchased: false };
+        }
+      }),
+    ).then((results) => {
+      if (!isMounted) return;
+      const statusMap: Record<string, boolean> = {};
+      results.forEach((r) => {
+        statusMap[r.id] = r.purchased;
+      });
+      setPurchaseStatuses(statusMap);
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [response?.data, user?.id]);
+
+  // Map courses and attach DB metadata
+  const courses: (PrimaryCardWithCTAProps & {
+    roadmap?: string;
+    difficultyLevel?: string;
+  })[] = useMemo(() => {
+    if (!response?.data) return [];
+    const mapped = mapCourseResponseToCard(response.data) || [];
+    return mapped.map((card, i) => {
+      const raw = response.data[i];
+      const isPurchased = purchaseStatuses[raw?._id] || false;
+      return {
+        ...card,
+        roadmap: raw?.roadmap,
+        difficultyLevel: raw?.difficultyLevel,
+        isPurchased: raw?.isPremium ? isPurchased : false,
+        isPremium: raw?.isPremium && !isPurchased,
+      };
+    });
+  }, [response?.data, purchaseStatuses]);
+
+  const noCourseFoundUI = !loading && courses.length === 0 && (
     <FlexContainer
-      className='w-screen h-screen item-center justify-center flex-col'
+      className='w-full py-16 items-center justify-center flex-col text-center'
       justifyCenter
     >
-      <Text className='heading-4 mb-3' level='h1'>
-        Oops! No Courses found.
-      </Text>
+      <h2 className='font-headings font-bold text-2xl text-foreground mb-2'>
+        No Courses Found
+      </h2>
+      <p className='text-muted-foreground mb-6 font-body text-sm'>
+        No Shiksha courses available at the moment.
+      </p>
       <LinkButton
         buttonProps={{
           variant: 'PRIMARY',
@@ -54,15 +122,77 @@ const Home = ({ seoMeta }: PageProps) => {
   return (
     <Fragment>
       <SEO seoMeta={seoMeta} />
-      <CardContainerB
-        borderColour={2}
-        cards={courses}
-        focusText='Courses'
-        heading='Explore'
-        sectionClassName='px-2 py-4'
-        subtext='Pick A Course and Start Learning'
-      />
-      {noCourseFoundUI}
+
+      <div className='bg-background min-h-screen font-body'>
+        {/* Header Hero Section */}
+        <div className='px-4 sm:px-10 lg:px-20 pt-12 sm:pt-16 pb-8 text-center'>
+          <div className='inline-flex items-center gap-2 bg-primary/10 text-primary text-xs font-semibold px-4 py-1.5 rounded-full mb-5 border border-primary/20 shadow-xs'>
+            <BookOpen className='w-3.5 h-3.5 text-primary' />
+            <span>Course Learning</span>
+          </div>
+          <h1 className='font-headings font-bold text-3xl sm:text-4xl lg:text-5xl text-foreground mb-4 leading-tight'>
+            Explore <span className='text-primary'>Shiksha Courses</span>
+          </h1>
+          <p className='text-base text-muted-foreground max-w-xl mx-auto leading-relaxed'>
+            Pick a course and start learning. Master key software engineering
+            concepts with structured step-by-step guides.
+          </p>
+        </div>
+
+        {/* Stats Row */}
+        <div className='px-4 sm:px-10 lg:px-20 pb-10 flex flex-wrap items-center justify-center gap-4 sm:gap-8'>
+          <div className='flex items-center gap-2 text-muted-foreground text-sm'>
+            <BookOpen className='w-4 h-4 text-primary shrink-0' />
+            <span>
+              <strong className='text-foreground font-semibold'>
+                {loading ? '...' : courses.length}
+              </strong>{' '}
+              Courses Available
+            </span>
+          </div>
+          <div className='w-1.5 h-1.5 rounded-full bg-border hidden sm:block' />
+          <div className='flex items-center gap-2 text-muted-foreground text-sm'>
+            <GraduationCap className='w-4 h-4 text-primary shrink-0' />
+            <span>
+              <strong className='text-foreground font-semibold'>4,200+</strong>{' '}
+              Students Enrolled
+            </span>
+          </div>
+          <div className='w-1.5 h-1.5 rounded-full bg-border hidden sm:block' />
+          <div className='flex items-center gap-2 text-muted-foreground text-sm'>
+            <Award className='w-4 h-4 text-primary shrink-0' />
+            <span>
+              <strong className='text-foreground font-semibold'>
+                Certifications Included
+              </strong>
+            </span>
+          </div>
+        </div>
+
+        {/* Cards Grid Section */}
+        <div className='px-4 sm:px-10 lg:px-20 pb-20'>
+          {loading ? (
+            <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-7xl mx-auto'>
+              {Array.from({ length: 6 }).map((_, idx) => (
+                <ShikshaCardSkeleton key={idx} />
+              ))}
+            </div>
+          ) : courses.length > 0 ? (
+            <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-7xl mx-auto'>
+              {courses.map((course) => (
+                <ShikshaCard
+                  key={course.id}
+                  {...course}
+                  roadmap={course.roadmap}
+                  difficultyLevel={course.difficultyLevel}
+                />
+              ))}
+            </div>
+          ) : (
+            noCourseFoundUI
+          )}
+        </div>
+      </div>
     </Fragment>
   );
 };

--- a/packages/components/src/containers/Cards/SheetCard.tsx
+++ b/packages/components/src/containers/Cards/SheetCard.tsx
@@ -1,0 +1,138 @@
+import type { PrimaryCardWithCTAProps } from "@tbe/interface";
+import { BookOpen, ChevronRight, FileText, Lock, Sparkles } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+
+interface SheetCardProps extends PrimaryCardWithCTAProps {
+  totalQuestions?: number;
+  roadmap?: string;
+}
+
+const SheetCard = ({
+  image,
+  imageAltText,
+  title,
+  content,
+  href,
+  active,
+  ctaText,
+  isPremium,
+  isPurchased,
+  totalQuestions,
+  launchingOn,
+}: SheetCardProps) => {
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [imageError, setImageError] = useState(false);
+
+  const isLocked = isPremium && !isPurchased;
+  const buttonText = isPurchased
+    ? "Continue Preparing"
+    : active && ctaText
+      ? ctaText
+      : launchingOn
+        ? "Coming Soon"
+        : "View Sheet";
+
+  const isDisabled = !active && !isPurchased;
+  const hasImage = Boolean(image && !imageError);
+
+  return (
+    <Link href={isDisabled ? "#" : href} className="group block h-full">
+      <div className="relative h-full rounded-xl border border-border bg-card hover:bg-accent/40 hover:border-foreground/20 overflow-hidden transition-all duration-300 hover:-translate-y-0.5 shadow-xs hover:shadow-md flex flex-col">
+        {/* Cover image from DB */}
+        {hasImage ? (
+          <div className="relative w-full aspect-[16/9] overflow-hidden bg-gray-200/70 shrink-0">
+            {!imageLoaded && (
+              <div className="absolute inset-0 bg-gray-200/80 animate-pulse z-0" />
+            )}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={image}
+              alt={imageAltText || title}
+              loading="lazy"
+              decoding="async"
+              onLoad={() => setImageLoaded(true)}
+              onError={() => setImageError(true)}
+              className={`w-full h-full object-cover group-hover:scale-[1.03] transition-all duration-500 relative z-10 ${
+                imageLoaded ? "opacity-100" : "opacity-0"
+              }`}
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent z-10" />
+
+            {/* Overlaid Badges */}
+            {isLocked && (
+              <div className="absolute top-2.5 right-2.5 flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-black/60 border border-white/20 backdrop-blur-xs z-20">
+                <Lock className="w-2.5 h-2.5 text-amber-400" />
+                <span className="text-[10px] font-bold text-amber-300 uppercase tracking-wider">
+                  Premium
+                </span>
+              </div>
+            )}
+            {isPurchased && (
+              <div className="absolute top-2.5 right-2.5 flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-black/60 border border-white/20 backdrop-blur-xs z-20">
+                <Sparkles className="w-2.5 h-2.5 text-emerald-400" />
+                <span className="text-[10px] font-bold text-emerald-300 uppercase tracking-wider">
+                  Purchased
+                </span>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="relative w-full aspect-[16/9] bg-gradient-to-br from-primary/10 via-accent to-background flex items-center justify-center border-b border-border shrink-0">
+            <BookOpen className="w-8 h-8 text-primary/40" />
+            {isLocked && (
+              <div className="absolute top-2.5 right-2.5 flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-black/60 border border-white/20">
+                <Lock className="w-2.5 h-2.5 text-amber-400" />
+                <span className="text-[10px] font-bold text-amber-300 uppercase tracking-wider">
+                  Premium
+                </span>
+              </div>
+            )}
+            {isPurchased && (
+              <div className="absolute top-2.5 right-2.5 flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-black/60 border border-white/20">
+                <Sparkles className="w-2.5 h-2.5 text-emerald-400" />
+                <span className="text-[10px] font-bold text-emerald-300 uppercase tracking-wider">
+                  Purchased
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Body content */}
+        <div className="p-4 flex flex-col flex-1 gap-2">
+          <p className="text-[14px] font-bold text-foreground leading-snug group-hover:text-primary transition-colors line-clamp-1">
+            {title}
+          </p>
+
+          {content && (
+            <p className="text-[12px] text-muted-foreground leading-relaxed line-clamp-2">
+              {content}
+            </p>
+          )}
+
+          {launchingOn && (
+            <p className="text-[11px] text-primary font-medium">
+              {launchingOn}
+            </p>
+          )}
+
+          {/* Footer */}
+          <div className="flex items-center justify-between mt-auto pt-3 border-t border-border/40">
+            <span className="text-[11px] font-medium text-muted-foreground flex items-center gap-1">
+              <FileText className="w-3.5 h-3.5 text-muted-foreground" />
+              {totalQuestions ?? 0} Questions
+            </span>
+
+            <span className="inline-flex items-center gap-1 text-[12px] font-semibold text-primary group-hover:translate-x-0.5 transition-transform">
+              {buttonText}
+              <ChevronRight className="w-3.5 h-3.5" />
+            </span>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export default SheetCard;

--- a/packages/components/src/containers/Cards/ShikshaCard.tsx
+++ b/packages/components/src/containers/Cards/ShikshaCard.tsx
@@ -1,0 +1,155 @@
+import type { PrimaryCardWithCTAProps } from "@tbe/interface";
+import { BookOpen, ChevronRight, Lock, Sparkles } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+
+interface ShikshaCardProps extends PrimaryCardWithCTAProps {
+  roadmap?: string;
+  difficultyLevel?: string;
+}
+
+const ShikshaCard = ({
+  image,
+  imageAltText,
+  title,
+  content,
+  href,
+  active,
+  ctaText,
+  isPremium,
+  isPurchased,
+  difficultyLevel,
+  launchingOn,
+}: ShikshaCardProps) => {
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [imageError, setImageError] = useState(false);
+
+  const isLocked = isPremium && !isPurchased;
+  const buttonText = isPurchased
+    ? "Continue Learning"
+    : active && ctaText
+      ? ctaText
+      : launchingOn
+        ? "Coming Soon"
+        : "View Course";
+
+  const isDisabled = !active && !isPurchased;
+  const hasImage = Boolean(image && !imageError);
+
+  return (
+    <Link href={isDisabled ? "#" : href} className="group block h-full">
+      <div className="relative h-full rounded-xl border border-border bg-card hover:bg-accent/40 hover:border-foreground/20 overflow-hidden transition-all duration-300 hover:-translate-y-0.5 shadow-xs hover:shadow-md flex flex-col">
+        {/* Cover image from DB */}
+        {hasImage ? (
+          <div className="relative w-full aspect-[16/9] overflow-hidden bg-gray-200/70 shrink-0">
+            {!imageLoaded && (
+              <div className="absolute inset-0 bg-gray-200/80 animate-pulse z-0" />
+            )}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={image}
+              alt={imageAltText || title}
+              loading="lazy"
+              decoding="async"
+              onLoad={() => setImageLoaded(true)}
+              onError={() => setImageError(true)}
+              className={`w-full h-full object-cover group-hover:scale-[1.03] transition-all duration-500 relative z-10 ${
+                imageLoaded ? "opacity-100" : "opacity-0"
+              }`}
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent z-10" />
+
+            {/* Badges */}
+            {difficultyLevel && (
+              <div className="absolute top-2.5 left-2.5 px-2.5 py-0.5 rounded-full bg-black/60 border border-white/20 backdrop-blur-xs z-20">
+                <span className="text-[10px] font-bold text-white/90 uppercase tracking-wider">
+                  {difficultyLevel}
+                </span>
+              </div>
+            )}
+            {isLocked && (
+              <div className="absolute top-2.5 right-2.5 flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-black/60 border border-white/20 backdrop-blur-xs z-20">
+                <Lock className="w-2.5 h-2.5 text-amber-400" />
+                <span className="text-[10px] font-bold text-amber-300 uppercase tracking-wider">
+                  Premium
+                </span>
+              </div>
+            )}
+            {isPurchased && (
+              <div className="absolute top-2.5 right-2.5 flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-black/60 border border-white/20 backdrop-blur-xs z-20">
+                <Sparkles className="w-2.5 h-2.5 text-emerald-400" />
+                <span className="text-[10px] font-bold text-emerald-300 uppercase tracking-wider">
+                  Enrolled
+                </span>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="relative w-full aspect-[16/9] bg-gradient-to-br from-primary/10 via-accent to-background flex items-center justify-center border-b border-border shrink-0">
+            <BookOpen className="w-8 h-8 text-primary/40" />
+            {isLocked && (
+              <div className="absolute top-2.5 right-2.5 flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-black/60 border border-white/20">
+                <Lock className="w-2.5 h-2.5 text-amber-400" />
+                <span className="text-[10px] font-bold text-amber-300 uppercase tracking-wider">
+                  Premium
+                </span>
+              </div>
+            )}
+            {isPurchased && (
+              <div className="absolute top-2.5 right-2.5 flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-black/60 border border-white/20">
+                <Sparkles className="w-2.5 h-2.5 text-emerald-400" />
+                <span className="text-[10px] font-bold text-emerald-300 uppercase tracking-wider">
+                  Enrolled
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Body content */}
+        <div className="p-4 flex flex-col flex-1 gap-2">
+          <p className="text-[14px] font-bold text-foreground leading-snug group-hover:text-primary transition-colors line-clamp-1">
+            {title}
+          </p>
+
+          {content && (
+            <p className="text-[12px] text-muted-foreground leading-relaxed line-clamp-2">
+              {content}
+            </p>
+          )}
+
+          {launchingOn && (
+            <p className="text-[11px] text-primary font-medium">
+              {launchingOn}
+            </p>
+          )}
+
+          {/* Additional Info Badges */}
+          <div className="flex items-center gap-2 mt-1 flex-wrap">
+            <span className="text-[10px] font-medium px-2 py-0.5 rounded bg-accent text-muted-foreground">
+              Self-Paced
+            </span>
+            <span className="text-[10px] font-medium px-2 py-0.5 rounded bg-accent text-muted-foreground">
+              Projects Included
+            </span>
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center justify-between mt-auto pt-3 border-t border-border/40">
+            <span className="text-[11px] font-medium text-muted-foreground flex items-center gap-1">
+              <BookOpen className="w-3.5 h-3.5 text-muted-foreground" />
+              Course
+            </span>
+
+            <span className="inline-flex items-center gap-1 text-[12px] font-semibold text-primary group-hover:translate-x-0.5 transition-transform">
+              {buttonText}
+              <ChevronRight className="w-3.5 h-3.5" />
+            </span>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export default ShikshaCard;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -151,6 +151,8 @@ export { default as PaymentCard } from "./containers/Cards/PaymentCard";
 export { default as PlaylistSkillCard } from "./containers/Cards/PlaylistSkillCard";
 export { default as QuestionDetailPanel } from "./containers/Cards/QuestionDetailPanel";
 export { default as QuizSection } from "./containers/Cards/QuizSection";
+export { default as SheetCard } from "./containers/Cards/SheetCard";
+export { default as ShikshaCard } from "./containers/Cards/ShikshaCard";
 export { default as Testimonials } from "./containers/Cards/Testimonials";
 export { default as UserLevelProgressContainer } from "./containers/Cards/UserLevelProgressContainer";
 export { default as WeAlreadyTaughtAt } from "./containers/Cards/WeAlreadyTaughtAt";


### PR DESCRIPTION
## Description

Redesigned the UI and card layouts for **Shiksha Explore** and **Interview Sheet Explore** pages.

### Changes Included
- **Interview Sheet Explore Page**: Updated layout with a clean 3-column card grid, modern hero header, and Lucide icons.
- **Shiksha Explore Page**: Redesigned course cards with Oncampus-inspired layout, DB cover image integration, and added metadata badges (`Self-Paced`, `Projects Included`).
- **Cards Styling**: Updated `SheetCard` and `ShikshaCard` components with 16:9 cover image banners, sleek typography, and status badges 

## Before 
<img width="1471" height="874" alt="{711C08E0-6DB5-49D5-9FBA-19DE8D9913F2}" src="https://github.com/user-attachments/assets/4dd3e032-c53b-4883-a54c-69180adb4e63" />
<img width="1845" height="888" alt="image" src="https://github.com/user-attachments/assets/f761543e-a5d3-4839-964f-ea86d905eb83" />

## After
<img width="1220" height="858" alt="image" src="https://github.com/user-attachments/assets/20479b3d-88d8-4f61-8c78-c15c637877aa" />

<img width="1351" height="903" alt="{5BFD24AA-91FB-4A35-B725-184773E54EE8}" src="https://github.com/user-attachments/assets/f7b7c0f6-fa13-455a-b8a2-ec747bd79d5f" />
