### PR TITLE
fix: remove unused userId prop from GamificationCard

### DIFF
--- a/packages/components/src/quizes/GamificationCard.tsx
+++ b/packages/components/src/quizes/GamificationCard.tsx
@@ -3,7 +3,6 @@
 import { useGamificationContext } from "./context/GamificationContext";
 
 interface GamificationCardProps {
-  userId?: string;
   isOpen: boolean;
   onClose: () => void;
   variant?: "popup" | "dashboard";


### PR DESCRIPTION
Removes \userId\ from \GamificationCardProps\ — it was declared but never destructured or used. The component relies entirely on \useGamificationContext()\ for user state.

Closes #1109