### PR TITLE
fix: remove unused userId prop from GamificationCard

### DIFF
--- a/packages/components/src/quizes/GamificationCard.tsx
+++ b/packages/components/src/quizes/GamificationCard.tsx
@@ -3,7 +3,6 @@
 import { useGamificationContext } from "./context/GamificationContext";
 
 interface GamificationCardProps {
-  userId?: string;
   isOpen: boolean;
   onClose: () => void;
   variant?: "popup" | "dashboard";

--- a/packages/components/src/quizes/PointsDisplay.tsx
+++ b/packages/components/src/quizes/PointsDisplay.tsx
@@ -6,14 +6,10 @@ import { useGamificationContext } from "./context/GamificationContext";
 import { GamificationCard } from "./GamificationCard";
 
 interface PointsDisplayProps {
-  userId?: string;
   variant?: "navbar" | "dashboard";
 }
 
-export function PointsDisplay({
-  userId,
-  variant = "navbar",
-}: PointsDisplayProps) {
+export function PointsDisplay({ variant = "navbar" }: PointsDisplayProps) {
   const { points, loading, currentLevel, pointsToNextLevel } =
     useGamificationContext();
   const [showCard, setShowCard] = useState(false);

--- a/packages/components/src/quizes/PointsDisplay.tsx
+++ b/packages/components/src/quizes/PointsDisplay.tsx
@@ -62,7 +62,6 @@ export function PointsDisplay({
 
         {showCard && (
           <GamificationCard
-            userId={userId}
             isOpen={showCard}
             onClose={handleCloseCard}
             variant="popup"
@@ -86,11 +85,7 @@ export function PointsDisplay({
         </button>
 
         {showCard && (
-          <GamificationCard
-            userId={userId}
-            isOpen={showCard}
-            onClose={handleCloseCard}
-          />
+          <GamificationCard isOpen={showCard} onClose={handleCloseCard} />
         )}
       </div>
     </>

--- a/packages/components/src/quizes/layout/DashboardNav.tsx
+++ b/packages/components/src/quizes/layout/DashboardNav.tsx
@@ -61,7 +61,7 @@ export function DashboardNav() {
           </div>
 
           {/* Points Display */}
-          <PointsDisplay userId={user?.id} variant="dashboard" />
+          <PointsDisplay variant="dashboard" />
 
           {/* User Menu */}
           <div className="flex items-center space-x-4">


### PR DESCRIPTION
Closes #1109

## Changes
- Removed the unused `userId` prop from `GamificationCardProps` interface in `GamificationCard.tsx`
- Cleaned up the two call sites in `PointsDisplay.tsx` that were passing `userId`

## Reason
The component already gets user state from `useGamificationContext()`, making the `userId` prop a no-op. Any consumer passing `userId` was being silently ignored.

## Testing
- Build passes (`pnpm run build` — 18/18 tasks successful)
- Type check passes (lint-staged + `turbo run check-types`)