### PR TITLE
fix: handle multi-space names in getInitials to prevent undefined segments

### DIFF
--- a/apps/dsayatra/src/pages/dashboard.tsx
+++ b/apps/dsayatra/src/pages/dashboard.tsx
@@ -132,7 +132,9 @@ const DsaClient = () => {
                     ) : (
                       <div className="flex size-full items-center justify-center bg-gradient-to-br from-[#ff5757] to-[#cc4444] text-2xl font-black text-white sm:text-3xl">
                         {user?.name
-                          ?.split(" ")
+                          ?.trim()
+                          .split(/\s+/)
+                          .filter(Boolean)
                           .map((n) => n[0])
                           .join("") || "SJ"}
                       </div>

--- a/apps/quizes/src/pages/dashboard/leaderboard/index.tsx
+++ b/apps/quizes/src/pages/dashboard/leaderboard/index.tsx
@@ -85,7 +85,9 @@ function LeaderboardEntry({
 }: LeaderboardEntryProps) {
   const getInitials = (name: string) => {
     return name
-      .split(" ")
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
       .map((n) => n[0])
       .join("")
       .toUpperCase()
@@ -180,7 +182,9 @@ function UserProfileModal({ profile, isOpen, onClose }: UserProfileModalProps) {
 
   const getInitials = (name: string) => {
     return name
-      .split(" ")
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
       .map((n) => n[0])
       .join("")
       .toUpperCase()

--- a/apps/quizes/src/pages/dashboard/leaderboard/index.tsx
+++ b/apps/quizes/src/pages/dashboard/leaderboard/index.tsx
@@ -84,14 +84,16 @@ function LeaderboardEntry({
   onViewProfile,
 }: LeaderboardEntryProps) {
   const getInitials = (name: string) => {
-    return name
-      .trim()
-      .split(/\s+/)
-      .filter(Boolean)
-      .map((n) => n[0])
-      .join("")
-      .toUpperCase()
-      .slice(0, 2);
+    return (
+      name
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean)
+        .map((n) => n[0])
+        .join("")
+        .toUpperCase()
+        .slice(0, 2) || "U"
+    );
   };
 
   const formatTime = (seconds: number) => {
@@ -181,14 +183,16 @@ function UserProfileModal({ profile, isOpen, onClose }: UserProfileModalProps) {
   if (!isOpen || !profile) return null;
 
   const getInitials = (name: string) => {
-    return name
-      .trim()
-      .split(/\s+/)
-      .filter(Boolean)
-      .map((n) => n[0])
-      .join("")
-      .toUpperCase()
-      .slice(0, 2);
+    return (
+      name
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean)
+        .map((n) => n[0])
+        .join("")
+        .toUpperCase()
+        .slice(0, 2) || "U"
+    );
   };
 
   return (

--- a/packages/components/src/prepyatra/dashboard/ProfileSection.tsx
+++ b/packages/components/src/prepyatra/dashboard/ProfileSection.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { toast } from "sonner";
 
 const getInitials = (name?: string): string => {
-  if (!name) return "PY";
+  if (!name?.trim()) return "PY";
   return name
     .trim()
     .split(/\s+/)

--- a/packages/components/src/prepyatra/dashboard/ProfileSection.tsx
+++ b/packages/components/src/prepyatra/dashboard/ProfileSection.tsx
@@ -5,7 +5,9 @@ import { toast } from "sonner";
 const getInitials = (name?: string): string => {
   if (!name) return "PY";
   return name
-    .split(" ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
     .map((p) => p[0])
     .join("")
     .toUpperCase()

--- a/packages/components/src/quizes/layout/DashboardNav.tsx
+++ b/packages/components/src/quizes/layout/DashboardNav.tsx
@@ -35,14 +35,16 @@ export function DashboardNav() {
   };
 
   const getInitials = (name: string) => {
-    return name
-      .trim()
-      .split(/\s+/)
-      .filter(Boolean)
-      .map((n) => n[0])
-      .join("")
-      .toUpperCase()
-      .slice(0, 2);
+    return (
+      name
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean)
+        .map((n) => n[0])
+        .join("")
+        .toUpperCase()
+        .slice(0, 2) || "U"
+    );
   };
 
   return (

--- a/packages/components/src/quizes/layout/DashboardNav.tsx
+++ b/packages/components/src/quizes/layout/DashboardNav.tsx
@@ -36,7 +36,9 @@ export function DashboardNav() {
 
   const getInitials = (name: string) => {
     return name
-      .split(" ")
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
       .map((n) => n[0])
       .join("")
       .toUpperCase()


### PR DESCRIPTION
Closes #1083

## Problem
`name.split(" ")` produces empty string segments when names contain multiple consecutive spaces (e.g. `"A  B"`), causing `.map(n => n[0])` to return `undefined` — resulting in initials like `"AundefinedB"`.

## Fix
Replaced `.split(" ")` with `.trim().split(/\s+/).filter(Boolean)` across all 4 occurrences:
- `packages/components/src/quizes/layout/DashboardNav.tsx`
- `packages/components/src/prepyatra/dashboard/ProfileSection.tsx`
- `apps/quizes/src/pages/dashboard/leaderboard/index.tsx` (2 instances)
- `apps/dsayatra/src/pages/dashboard.tsx`

## What this does
- `.trim()` — removes leading/trailing whitespace
- `.split(/\s+/)` — splits on any whitespace (handles multiple spaces, tabs)
- `.filter(Boolean)` — removes any remaining empty strings

## Testing
Verified the fix handles: `"Moni  Kumari"`, `" Moni "`, `"A   B   C"` — all produce correct initials without undefined.