### PR TITLE
fix(ui): fix interview sheet sidebar layout, text cutoff, and enable …

### DIFF
--- a/apps/platform/src/pages/interview-prep/[sheetSlug]/index.tsx
+++ b/apps/platform/src/pages/interview-prep/[sheetSlug]/index.tsx
@@ -298,8 +298,10 @@ const SheetPage = ({ sheet, meta, slug, seoMeta }: SheetPageProps) => {
           <FlexContainer className='w-full gap-4' itemCenter={false}>
             {/* Left Sidebar (Questions) */}
             <FlexContainer
-              className='border md:w-3/12 w-full px-2 gap-1 rounded self-baseline max-h-[80vh] overflow-y-auto bg-white'
+              className='border md:w-3/12 w-full px-3 rounded self-baseline max-h-[80vh] overflow-y-auto overflow-x-hidden bg-white flex-col'
               itemCenter={false}
+              direction='col'
+              wrap={false}
             >
               <div className='w-full sticky top-0 z-10 bg-white py-2'>
                 <Text className='heading-5' level='h5'>
@@ -316,7 +318,7 @@ const SheetPage = ({ sheet, meta, slug, seoMeta }: SheetPageProps) => {
               </div>
 
               {/* Sidebar: use button for question navigation, not <Link> */}
-              <FlexContainer className='gap-px flex-grow' justifyCenter={false}>
+              <div className='flex flex-col gap-px w-full pb-2'>
                 {questions?.map(
                   ({
                     _id,
@@ -355,7 +357,7 @@ const SheetPage = ({ sheet, meta, slug, seoMeta }: SheetPageProps) => {
                     );
                   },
                 )}
-              </FlexContainer>
+              </div>
             </FlexContainer>
 
             {/* Main Content Area */}

--- a/packages/components/src/common/Learning/QuestionLink.tsx
+++ b/packages/components/src/common/Learning/QuestionLink.tsx
@@ -53,7 +53,7 @@ const QuestionLink = ({
       analyticsId={`learning_question_${questionId}`}
       analyticsLabel={`question:${title}`}
       key={questionId}
-      className={`flex items-center gap-1 w-full p-2 mb-1 rounded border text-left pre-title overflow-hidden ${
+      className={`flex flex-nowrap items-center gap-2 w-full px-3 py-2 mb-1 rounded border text-left pre-title overflow-hidden ${
         isLocked
           ? isDark
             ? "text-gray-500 cursor-not-allowed border-transparent"
@@ -99,12 +99,12 @@ const QuestionLink = ({
         {isLocked ? (
           <FaLock
             className={isDark ? "text-gray-500" : "text-gray-400"}
-            size={20}
+            size={14}
           />
         ) : isCompleted ? (
-          <IoIosCheckmarkCircle className={iconColor} size={24} />
+          <IoIosCheckmarkCircle className={iconColor} size={16} />
         ) : (
-          <FaRegCircle className={iconColor} size={24} />
+          <FaRegCircle className={iconColor} size={14} />
         )}
         {isStarred && (
           <FaStar
@@ -114,7 +114,7 @@ const QuestionLink = ({
           />
         )}
       </div>
-      <span className="truncate min-w-0">{title}</span>
+      <span className="min-w-0 flex-1 break-words leading-snug">{title}</span>
     </LinkText>
   );
 };


### PR DESCRIPTION
# fix(ui): fix interview sheet sidebar layout, text cutoff, and enable wrapping

## What does this PR do?

This PR fixes the left sidebar layout on the interview preparation sheet pages (such as `/interview-prep/[sheetSlug]`). It resolves a bug where the question items were being offset to the left and clipped, making the completion icons invisible and cutting off the start of the question titles. It also replaces text truncation with natural text wrapping so that the full question titles are readable in the list.

## Why?

1. **Text Cutoff**: The outer `FlexContainer` defaults to `direction="row"` and `wrap={true}`. This layout logic forced the inner question item wrappers to wrap incorrectly and push the list items 32px off-screen to the left, which was then cut off by the container's `overflow-x-hidden`. Replacing the list container with a column flex structure fixes this positioning offset.
2. **Readability**: Long question titles were previously truncated with an ellipsis (`...`), hiding crucial context. Allowing the text to wrap naturally (`break-words` and `leading-snug`) ensures the user can see the entire question.
3. **Better Proportions**: Sidebar icons were scaled down slightly (24px to 14/16px) to align cleanly with the newly wrapped, multi-line question text.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 Refactor / cleanup (no functional change)
- [x] 🎨 UI / styling change
- [ ] 🔌 API change (new or modified endpoints, request/response shape changes)
- [ ] 📦 Dependency update
- [ ] 📝 Documentation only

---

## Screenshots / Recordings

<img width="1920" height="912" alt="sidebar_before" src="https://github.com/user-attachments/assets/852d305c-691c-43c1-8502-d5c77611004e" />
---

## Testing

### Does this PR include tests?

- [ ] Yes — unit tests
- [ ] Yes — integration / e2e tests
- [x] No — here's why: Pure UI alignment and text wrapping adjustment that does not change functional page logic.

### How to test manually

1. Navigate to `/interview-prep/java-interview-questions` (or any interview prep sheet).
2. Look at the left questions sidebar.
3. Verify that the icons (checkbox/circles) and the beginning of the text are fully visible and not cut off on the left.
4. Verify that long question titles wrap to multiple lines and show the full title instead of showing an ellipsis (`...`).
5. Verify that the sidebar scrolls vertically when the question list extends past the viewport height.

---

## Checklist

- [x] I've tested this locally and it works as expected
- [x] I've checked for console errors / warnings
- [x] No unrelated changes snuck in
- [x] If UI change — tested on mobile viewport too
