### PR TITLE
fix(production): resolve payment and quiz priority bugs

### DIFF
--- a/apps/api/src/lib/database/models/Payment.ts
+++ b/apps/api/src/lib/database/models/Payment.ts
@@ -54,6 +54,14 @@ const PaymentSchema: Schema<PaymentModel> = new Schema(
       type: String,
       default: null,
     },
+    couponUsageApplied: {
+      type: Boolean,
+      default: false,
+    },
+    enrollmentCompleted: {
+      type: Boolean,
+      default: false,
+    },
   },
   {
     timestamps: true,

--- a/apps/api/src/lib/database/queries/enhancedQuiz.ts
+++ b/apps/api/src/lib/database/queries/enhancedQuiz.ts
@@ -233,6 +233,10 @@ const completeQuizSessionInDB = async (
       return { error: "Session not found" };
     }
 
+    if (session.status === "completed") {
+      return { data: session };
+    }
+
     const answeredQuestions = session.questions.filter(
       (q) => q.userAnswer !== undefined,
     );
@@ -241,7 +245,9 @@ const completeQuizSessionInDB = async (
       (sum, q) => sum + (q.timeSpent || 0),
       0,
     );
-    const score = Math.round((correctAnswers / answeredQuestions.length) * 100);
+    const score = answeredQuestions.length
+      ? Math.round((correctAnswers / answeredQuestions.length) * 100)
+      : 0;
 
     // Update session
     session.status = "completed";

--- a/apps/api/src/lib/database/queries/payment.ts
+++ b/apps/api/src/lib/database/queries/payment.ts
@@ -91,6 +91,47 @@ const updatePaymentStatusToDB = async ({
   }
 };
 
+const claimPaymentCouponUsageFromDB = async (
+  orderId: string,
+): Promise<DatabaseQueryResponseType> => {
+  try {
+    const payment = await Payment.findOneAndUpdate(
+      { orderId, couponUsageApplied: { $ne: true } },
+      { $set: { couponUsageApplied: true } },
+      { new: true },
+    );
+    return { data: payment };
+  } catch (error) {
+    logger.error("DB: claimPaymentCouponUsageFromDB failed", {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    return { error: "Failed to claim payment coupon usage", details: error };
+  }
+};
+
+const markPaymentEnrollmentCompletedInDB = async (
+  orderId: string,
+): Promise<DatabaseQueryResponseType> => {
+  try {
+    const payment = await Payment.findOneAndUpdate(
+      { orderId },
+      { $set: { enrollmentCompleted: true } },
+      { new: true },
+    );
+    return { data: payment };
+  } catch (error) {
+    logger.error("DB: markPaymentEnrollmentCompletedInDB failed", {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    return {
+      error: "Failed to mark payment enrollment completed",
+      details: error,
+    };
+  }
+};
+
 const checkPaymentStatusFromDB = async (
   userId: string,
   productId: string,
@@ -168,6 +209,8 @@ const checkPaymentStatusFromDB = async (
 export {
   addPaymentToDB,
   checkPaymentStatusFromDB,
+  claimPaymentCouponUsageFromDB,
   getPaymentByOrderIdFromDB,
+  markPaymentEnrollmentCompletedInDB,
   updatePaymentStatusToDB,
 };

--- a/apps/api/src/lib/database/queries/prepyatra.ts
+++ b/apps/api/src/lib/database/queries/prepyatra.ts
@@ -162,11 +162,13 @@ const deletePrepLogInDB = async (prepLogId: string) => {
 const getActiveSubscriptionByUserFromDB = async (
   userId: string,
   subscriptionType: string,
+  productType?: string,
 ): Promise<DatabaseQueryResponseType> => {
   try {
     const subscription = await Subscription.findOne({
       userId: new mongoose.Types.ObjectId(userId),
       type: subscriptionType,
+      ...(productType && { productType }),
       isActive: true,
       expiryDate: { $gt: new Date() },
     });
@@ -208,6 +210,31 @@ const createSubscriptionInDB = async ({
     return { data: subscription };
   } catch (error) {
     return { error: "Failed to create subscription in DB" };
+  }
+};
+
+const extendSubscriptionInDB = async ({
+  subscriptionId,
+  expiryDate,
+  amount,
+  duration,
+}: {
+  subscriptionId: string;
+  expiryDate: Date;
+  amount: number;
+  duration: number;
+}): Promise<DatabaseQueryResponseType> => {
+  try {
+    const subscription = await Subscription.findByIdAndUpdate(
+      subscriptionId,
+      { $set: { expiryDate, amount, duration, isActive: true } },
+      { new: true, runValidators: true },
+    );
+    return subscription
+      ? { data: subscription }
+      : { error: "Subscription not found" };
+  } catch (error) {
+    return { error: "Failed to extend subscription", details: error };
   }
 };
 
@@ -955,6 +982,7 @@ export {
   deleteChallengeInDB,
   deletePrepLogInDB,
   deleteRecruiterInDB,
+  extendSubscriptionInDB,
   getActiveSubscriptionByUserFromDB,
   getAllMenteesFromDB,
   getAllUsersWithLogsFromDB,

--- a/apps/api/src/lib/interfaces/database.ts
+++ b/apps/api/src/lib/interfaces/database.ts
@@ -431,6 +431,8 @@ export interface PaymentModel extends Document {
   gateway: string;
   appliedCoupon?: typeof Schema.Types.ObjectId;
   couponCode?: string;
+  couponUsageApplied?: boolean;
+  enrollmentCompleted?: boolean;
   createdAt?: Date;
   updatedAt?: Date;
 }

--- a/apps/api/src/lib/services/payment/enrollmentHandlers.ts
+++ b/apps/api/src/lib/services/payment/enrollmentHandlers.ts
@@ -4,6 +4,7 @@ import {
   createSubscriptionInDB,
   enrollInACourse,
   enrollInASheet,
+  extendSubscriptionInDB,
   getActiveSubscriptionByUserFromDB,
   getEnrolledCourseFromDB,
   getEnrolledSheetFromDB,
@@ -100,12 +101,30 @@ const createSubscription: EnrollmentHandler = async (payment) => {
       await getActiveSubscriptionByUserFromDB(
         payment.user.toString(),
         plan.type,
+        payment.productType,
       );
 
     if (existingSubscription) {
+      const baseDate =
+        existingSubscription.expiryDate > new Date()
+          ? existingSubscription.expiryDate
+          : new Date();
+      const extendedExpiryDate =
+        plan.type === "Lifetime"
+          ? new Date("2099-12-31")
+          : new Date(
+              baseDate.getTime() + plan.duration * 30 * 24 * 60 * 60 * 1000,
+            );
+      const { error: extendError } = await extendSubscriptionInDB({
+        subscriptionId: existingSubscription._id.toString(),
+        expiryDate: extendedExpiryDate,
+        amount: payment.amount,
+        duration: plan.duration,
+      });
+      if (extendError) return { success: false, error: extendError };
       return {
         success: true,
-        data: { alreadyEnrolled: true, existingSubscription },
+        data: { extended: true, expiryDate: extendedExpiryDate },
       };
     }
 

--- a/apps/api/src/pages/api/v1/payment/order-status.ts
+++ b/apps/api/src/pages/api/v1/payment/order-status.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { apiStatusCodes } from "@/lib/constants";
 import {
   getPaymentByOrderIdFromDB,
+  markPaymentEnrollmentCompletedInDB,
   updatePaymentStatusToDB,
 } from "@/lib/database";
 import type { PaymentModel } from "@/lib/interfaces";
@@ -30,6 +31,17 @@ const syncPaymentStatusIfPending = async (
   payment: PaymentModel,
 ): Promise<PaymentModel> => {
   if (payment.status !== "PENDING") {
+    if (payment.status === "SUCCESS" && !payment.enrollmentCompleted) {
+      const enrollmentResult = await processPostPaymentEnrollment(payment);
+      if (!enrollmentResult.success) {
+        logger.error("order-status: successful payment reconciliation failed", {
+          orderId: payment.orderId,
+          error: enrollmentResult.error,
+        });
+      } else {
+        await markPaymentEnrollmentCompletedInDB(payment.orderId);
+      }
+    }
     return payment;
   }
 
@@ -69,6 +81,8 @@ const syncPaymentStatusIfPending = async (
         orderId: payment.orderId,
         error: enrollmentResult.error,
       });
+    } else {
+      await markPaymentEnrollmentCompletedInDB(updatedPayment.orderId);
     }
   }
 

--- a/apps/api/src/pages/api/v1/payment/webhook.ts
+++ b/apps/api/src/pages/api/v1/payment/webhook.ts
@@ -4,7 +4,10 @@ import getRawBody from "raw-body";
 
 import { apiStatusCodes, isDevelopmentEnv } from "@/lib/constants";
 import {
+  claimPaymentCouponUsageFromDB,
   getPaymentByOrderIdFromDB,
+  incrementCouponUsageFromDB,
+  markPaymentEnrollmentCompletedInDB,
   updatePaymentStatusToDB,
 } from "@/lib/database";
 import { processPostPaymentEnrollment } from "@/lib/services/payment";
@@ -48,8 +51,7 @@ const validateAndExtract = (
 
   const order_id = order.order_id || order.orderId || null;
   const payment_status = (payment.payment_status || payment.status || null) as
-    | string
-    | null;
+    string | null;
   const payment_id =
     payment.cf_payment_id ||
     payment.gateway_payment_id ||
@@ -170,18 +172,36 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     }
 
     if (webhookEvent.payment_status === "SUCCESS") {
-      const enrollmentResult = await processPostPaymentEnrollment(_payment);
-      if (!enrollmentResult.success) {
-        logger.error("Post-payment enrollment failed", {
-          productType: _payment.productType,
-          error: enrollmentResult.error ?? "Unknown enrollment error",
-        });
-        // do not fail webhook
-      } else {
-        logger.info("Successfully processed enrollment", {
-          productType: _payment.productType,
-          orderId: webhookEvent.order_id,
-        });
+      const { data: couponClaim } = await claimPaymentCouponUsageFromDB(
+        webhookEvent.order_id,
+      );
+      if (couponClaim?.appliedCoupon) {
+        const { error: couponError } = await incrementCouponUsageFromDB(
+          couponClaim.appliedCoupon.toString(),
+        );
+        if (couponError) {
+          logger.error("Coupon usage increment failed after payment", {
+            orderId: webhookEvent.order_id,
+            error: couponError,
+          });
+        }
+      }
+
+      if (!_payment.enrollmentCompleted) {
+        const enrollmentResult = await processPostPaymentEnrollment(_payment);
+        if (!enrollmentResult.success) {
+          logger.error("Post-payment enrollment failed", {
+            productType: _payment.productType,
+            error: enrollmentResult.error ?? "Unknown enrollment error",
+          });
+          // Keep the payment eligible for reconciliation retries.
+        } else {
+          await markPaymentEnrollmentCompletedInDB(webhookEvent.order_id);
+          logger.info("Successfully processed enrollment", {
+            productType: _payment.productType,
+            orderId: webhookEvent.order_id,
+          });
+        }
       }
     }
 

--- a/apps/api/src/pages/api/v1/prepyatra/subscription.ts
+++ b/apps/api/src/pages/api/v1/prepyatra/subscription.ts
@@ -6,6 +6,7 @@ import { Subscription } from "@/lib/database";
 import { type CreateSubscriptionPayload } from "@/lib/interfaces";
 import { sendAPIResponse } from "@/lib/utils";
 import { logger } from "@/lib/utils/logger";
+import { ensureAdminAccess } from "@/middleware/admin";
 import { withApiHandler } from "@/middleware/requestLogger";
 
 /**
@@ -18,6 +19,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   switch (method) {
     case "POST":
+      if (!(await ensureAdminAccess(req, res))) return;
       return handleCreateSubscription(req, res);
     case "GET":
       return handleGetSubscription(req, res);

--- a/apps/api/src/pages/api/v1/quiz/session/[sessionId]/answer.ts
+++ b/apps/api/src/pages/api/v1/quiz/session/[sessionId]/answer.ts
@@ -20,9 +20,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       .json(sendAPIResponse({ status: false, message: "Method not allowed" }));
   }
 
-  const authenticatedUserId = getAuthenticatedUserId(req, res);
-  if (!authenticatedUserId) return;
-
   const { sessionId } = req.query;
   const { questionIndex, answer, timeSpent }: SubmitAnswerBody = req.body;
 
@@ -48,6 +45,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     );
   }
 
+  const authenticatedUserId = getAuthenticatedUserId(req, res);
+  if (!authenticatedUserId) return;
+
   if (typeof questionIndex !== "number" || questionIndex < 0) {
     return res
       .status(400)
@@ -69,7 +69,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   try {
-    const sessionOwner = await QuizSession.findById(sessionId).select("userId");
+    const sessionOwner = await QuizSession.findById(sessionId).lean();
     if (!sessionOwner) {
       return res
         .status(404)

--- a/apps/api/src/pages/api/v1/quiz/session/[sessionId]/answer.ts
+++ b/apps/api/src/pages/api/v1/quiz/session/[sessionId]/answer.ts
@@ -5,6 +5,7 @@ import { QuizSession } from "@/lib/database";
 import { sendAPIResponse } from "@/lib/utils";
 import { logger } from "@/lib/utils/logger";
 import { withApiHandler } from "@/middleware/requestLogger";
+import { getAuthenticatedUserId } from "@/middleware/userAuth";
 
 interface SubmitAnswerBody {
   questionIndex: number;
@@ -18,6 +19,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       .status(405)
       .json(sendAPIResponse({ status: false, message: "Method not allowed" }));
   }
+
+  const authenticatedUserId = getAuthenticatedUserId(req, res);
+  if (!authenticatedUserId) return;
 
   const { sessionId } = req.query;
   const { questionIndex, answer, timeSpent }: SubmitAnswerBody = req.body;
@@ -65,6 +69,18 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   try {
+    const sessionOwner = await QuizSession.findById(sessionId).select("userId");
+    if (!sessionOwner) {
+      return res
+        .status(404)
+        .json(sendAPIResponse({ status: false, message: "Session not found" }));
+    }
+    if (sessionOwner.userId.toString() !== authenticatedUserId) {
+      return res
+        .status(403)
+        .json(sendAPIResponse({ status: false, message: "Forbidden" }));
+    }
+
     // Submit the answer
     const { data: result, error } = await submitAnswerInDB({
       sessionId,

--- a/apps/api/src/pages/api/v1/quiz/session/[sessionId]/complete.ts
+++ b/apps/api/src/pages/api/v1/quiz/session/[sessionId]/complete.ts
@@ -14,9 +14,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       .json(sendAPIResponse({ status: false, message: "Method not allowed" }));
   }
 
-  const authenticatedUserId = getAuthenticatedUserId(req, res);
-  if (!authenticatedUserId) return;
-
   const { sessionId } = req.query;
 
   // Validation
@@ -28,8 +25,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       );
   }
 
+  const authenticatedUserId = getAuthenticatedUserId(req, res);
+  if (!authenticatedUserId) return;
+
   try {
-    const sessionOwner = await QuizSession.findById(sessionId).select("userId");
+    const sessionOwner = await QuizSession.findById(sessionId).lean();
     if (!sessionOwner) {
       return res
         .status(404)

--- a/apps/api/src/pages/api/v1/quiz/session/[sessionId]/complete.ts
+++ b/apps/api/src/pages/api/v1/quiz/session/[sessionId]/complete.ts
@@ -1,10 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { QuizSessionQuestion } from "@/lib/database";
-import { completeQuizSessionInDB } from "@/lib/database";
+import { completeQuizSessionInDB, QuizSession } from "@/lib/database";
 import { sendAPIResponse } from "@/lib/utils";
 import { logger } from "@/lib/utils/logger";
 import { withApiHandler } from "@/middleware/requestLogger";
+import { getAuthenticatedUserId } from "@/middleware/userAuth";
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {
@@ -12,6 +13,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       .status(405)
       .json(sendAPIResponse({ status: false, message: "Method not allowed" }));
   }
+
+  const authenticatedUserId = getAuthenticatedUserId(req, res);
+  if (!authenticatedUserId) return;
 
   const { sessionId } = req.query;
 
@@ -25,6 +29,18 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   try {
+    const sessionOwner = await QuizSession.findById(sessionId).select("userId");
+    if (!sessionOwner) {
+      return res
+        .status(404)
+        .json(sendAPIResponse({ status: false, message: "Session not found" }));
+    }
+    if (sessionOwner.userId.toString() !== authenticatedUserId) {
+      return res
+        .status(403)
+        .json(sendAPIResponse({ status: false, message: "Forbidden" }));
+    }
+
     const { data: session, error } = await completeQuizSessionInDB(sessionId);
 
     if (error || !session) {
@@ -75,7 +91,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           questionIndex: index,
           question: q.question,
           options: q.options,
-          correctAnswer: q.correctAnswer,
           userAnswer: q.userAnswer,
           isCorrect: q.isCorrect,
           timeSpent: q.timeSpent,

--- a/apps/api/src/pages/api/v1/quiz/session/start.ts
+++ b/apps/api/src/pages/api/v1/quiz/session/start.ts
@@ -24,9 +24,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     );
   }
 
-  const authenticatedUserId = getAuthenticatedUserId(req, res);
-  if (!authenticatedUserId) return;
-
   const {
     userId,
     quizId,
@@ -43,6 +40,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       }),
     );
   }
+
+  const authenticatedUserId = getAuthenticatedUserId(req, res);
+  if (!authenticatedUserId) return;
 
   if (!verifyOwnership(authenticatedUserId, userId, res)) return;
 

--- a/apps/api/src/pages/api/v1/quiz/session/start.ts
+++ b/apps/api/src/pages/api/v1/quiz/session/start.ts
@@ -5,6 +5,7 @@ import { Quiz, QuizSession } from "@/lib/database";
 import { sendAPIResponse } from "@/lib/utils";
 import { logger } from "@/lib/utils/logger";
 import { withApiHandler } from "@/middleware/requestLogger";
+import { getAuthenticatedUserId, verifyOwnership } from "@/middleware/userAuth";
 
 interface StartSessionBody {
   userId: string;
@@ -23,6 +24,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     );
   }
 
+  const authenticatedUserId = getAuthenticatedUserId(req, res);
+  if (!authenticatedUserId) return;
+
   const {
     userId,
     quizId,
@@ -39,6 +43,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       }),
     );
   }
+
+  if (!verifyOwnership(authenticatedUserId, userId, res)) return;
 
   if (difficulty && !["easy", "medium", "hard", "mixed"].includes(difficulty)) {
     return res.status(400).json(

--- a/apps/platform/src/middleware.ts
+++ b/apps/platform/src/middleware.ts
@@ -17,7 +17,10 @@ const protectedAPIRoutes = [
   },
 ];
 
-const protectedUIRoutes = [{ path: /^\/shiksha\/(?:\/|$)/ }];
+const protectedUIRoutes = [
+  { path: /^\/shiksha\/(?:\/|$)/ },
+  { path: /^\/user(?:\/|$)/ },
+];
 
 // CORS headers removed - using proxy pattern for API calls
 
@@ -134,6 +137,7 @@ const middleware = async (req: NextRequest) => {
 export const config = {
   matcher: [
     '/register',
+    '/user/:path*',
     '/shiksha/:courseSlug*',
     '/api/v1/course/:courseId*',
     '/api/v1/shiksha/:path*',

--- a/apps/testing/src/e2e/platform/auth-comprehensive.spec.ts
+++ b/apps/testing/src/e2e/platform/auth-comprehensive.spec.ts
@@ -7,6 +7,29 @@ import { expect, test } from "../fixtures/platform.fixture";
 const TBE_ACCESS_COOKIE = "tbe_access_token";
 const TBE_REFRESH_COOKIE = "tbe_refresh_token";
 
+const setAccessCookie = async (
+  page: import("@playwright/test").Page,
+  token: string,
+) => {
+  await page.context().addCookies([
+    {
+      name: TBE_ACCESS_COOKIE,
+      value: token,
+      domain: "localhost",
+      path: "/",
+      sameSite: "Lax",
+      httpOnly: false,
+      secure: false,
+    },
+  ]);
+  await page.addInitScript(
+    ([key, value]) => {
+      document.cookie = `${key}=${value}; path=/; max-age=86400; SameSite=Lax`;
+    },
+    [TBE_ACCESS_COOKIE, token] as [string, string],
+  );
+};
+
 test.describe("Authentication Flow E2E Tests", () => {
   test.describe("Login/Logout Flow", () => {
     test("unauthenticated user sees login options on home page", async ({
@@ -27,12 +50,7 @@ test.describe("Authentication Flow E2E Tests", () => {
     }) => {
       // Set authentication cookie
       const token = buildE2EAccessJwt();
-      await page.addInitScript(
-        ([key, value]) => {
-          document.cookie = `${key}=${value}; path=/; max-age=86400; SameSite=Lax`;
-        },
-        [TBE_ACCESS_COOKIE, token] as [string, string],
-      );
+      await setAccessCookie(page, token);
 
       await page.goto("/user/dashboard", { waitUntil: "domcontentloaded" });
 
@@ -45,12 +63,7 @@ test.describe("Authentication Flow E2E Tests", () => {
     }) => {
       // First, authenticate
       const token = buildE2EAccessJwt();
-      await page.addInitScript(
-        ([key, value]) => {
-          document.cookie = `${key}=${value}; path=/; max-age=86400; SameSite=Lax`;
-        },
-        [TBE_ACCESS_COOKIE, token] as [string, string],
-      );
+      await setAccessCookie(page, token);
 
       // Mock the logout API endpoint
       await page.route("**/api/v1/auth/logout", (route) =>
@@ -161,12 +174,7 @@ test.describe("Authentication Flow E2E Tests", () => {
       ).toString("base64url");
       const expiredToken = `${header}.${payload}.expired`;
 
-      await page.addInitScript(
-        ([key, value]) => {
-          document.cookie = `${key}=${value}; path=/; max-age=86400; SameSite=Lax`;
-        },
-        [TBE_ACCESS_COOKIE, expiredToken] as [string, string],
-      );
+      await setAccessCookie(page, expiredToken);
 
       await page.goto("/user/dashboard", { waitUntil: "domcontentloaded" });
 
@@ -198,12 +206,7 @@ test.describe("Authentication Flow E2E Tests", () => {
         },
       ]);
 
-      await page.addInitScript(
-        ([key, value]) => {
-          document.cookie = `${key}=${value}; path=/; max-age=86400; SameSite=Lax`;
-        },
-        [TBE_ACCESS_COOKIE, token] as [string, string],
-      );
+      await setAccessCookie(page, token);
 
       // Mock APIs for navigation
       await page.route("**/api/proxy/**", (route) =>
@@ -281,13 +284,18 @@ test.describe("Session Management E2E Tests", () => {
 
     const token = buildE2EAccessJwt();
 
-    // Set auth in first tab
-    await page1.addInitScript(
-      ([key, value]) => {
-        document.cookie = `${key}=${value}; path=/; max-age=86400; SameSite=Lax`;
+    // Set auth in the shared browser context before either tab navigates.
+    await context.addCookies([
+      {
+        name: TBE_ACCESS_COOKIE,
+        value: token,
+        domain: "localhost",
+        path: "/",
+        sameSite: "Lax",
+        httpOnly: false,
+        secure: false,
       },
-      [TBE_ACCESS_COOKIE, token] as [string, string],
-    );
+    ]);
 
     // Mock APIs
     for (const page of [page1, page2]) {

--- a/apps/testing/src/e2e/platform/auth-gates.spec.ts
+++ b/apps/testing/src/e2e/platform/auth-gates.spec.ts
@@ -18,6 +18,17 @@ test.describe("Platform user dashboard gate", () => {
     platformPage: page,
   }) => {
     const token = buildE2EAccessJwt();
+    await page.context().addCookies([
+      {
+        name: TBE_ACCESS_COOKIE,
+        value: token,
+        domain: "localhost",
+        path: "/",
+        sameSite: "Lax",
+        httpOnly: false,
+        secure: false,
+      },
+    ]);
     await page.addInitScript(
       ([key, value]) => {
         document.cookie = `${key}=${value}; path=/; max-age=86400; SameSite=Lax`;

--- a/apps/testing/src/unit/api-routes/payment-webhook.test.ts
+++ b/apps/testing/src/unit/api-routes/payment-webhook.test.ts
@@ -7,6 +7,8 @@ const mockUpdatePaymentStatusToDB = vi.fn();
 const mockProcessPostPaymentEnrollment = vi.fn();
 const mockVerifyWebhookSignature = vi.fn();
 const mockGetRawBody = vi.fn();
+const mockClaimPaymentCouponUsageFromDB = vi.fn();
+const mockMarkPaymentEnrollmentCompletedInDB = vi.fn();
 
 vi.mock("raw-body", () => ({
   default: (...args: any[]) => mockGetRawBody(...args),
@@ -48,6 +50,11 @@ vi.mock("../../../../api/src/lib/database", () => ({
     mockGetPaymentByOrderIdFromDB(...args),
   updatePaymentStatusToDB: (...args: any[]) =>
     mockUpdatePaymentStatusToDB(...args),
+  claimPaymentCouponUsageFromDB: (...args: any[]) =>
+    mockClaimPaymentCouponUsageFromDB(...args),
+  incrementCouponUsageFromDB: vi.fn(),
+  markPaymentEnrollmentCompletedInDB: (...args: any[]) =>
+    mockMarkPaymentEnrollmentCompletedInDB(...args),
 }));
 
 vi.mock("../../../../api/src/lib/services/payment", () => ({
@@ -99,6 +106,8 @@ describe("Payment Webhook API Route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockVerifyWebhookSignature.mockReturnValue({ isValid: true });
+    mockClaimPaymentCouponUsageFromDB.mockResolvedValue({ data: null });
+    mockMarkPaymentEnrollmentCompletedInDB.mockResolvedValue({ data: null });
   });
 
   it("should reject non-POST methods", async () => {

--- a/apps/testing/src/unit/api-routes/prepyatra-subscription.test.ts
+++ b/apps/testing/src/unit/api-routes/prepyatra-subscription.test.ts
@@ -48,6 +48,10 @@ vi.mock("../../../../api/src/middleware/requestLogger", () => ({
   ) => handler,
 }));
 
+vi.mock("../../../../api/src/middleware/admin", () => ({
+  ensureAdminAccess: vi.fn().mockResolvedValue(true),
+}));
+
 import handler from "../../../../api/src/pages/api/v1/prepyatra/subscription";
 
 describe("PrepYatra Subscription API Route", () => {

--- a/apps/testing/src/unit/api-routes/quiz-session-answer.test.ts
+++ b/apps/testing/src/unit/api-routes/quiz-session-answer.test.ts
@@ -31,6 +31,10 @@ vi.mock("../../../../api/src/middleware/requestLogger", () => ({
   withApiHandler: (handler: unknown) => handler,
 }));
 
+vi.mock("../../../../api/src/middleware/userAuth", () => ({
+  getAuthenticatedUserId: vi.fn().mockReturnValue("user-123"),
+}));
+
 import handler from "../../../../api/src/pages/api/v1/quiz/session/[sessionId]/answer";
 
 describe("Quiz Session Answer API Route", () => {
@@ -122,6 +126,7 @@ describe("Quiz Session Answer API Route", () => {
   });
 
   it("returns 400 when submitAnswerInDB returns error", async () => {
+    mockQuizSessionFindById.mockResolvedValue({ userId: "user-123" });
     mockSubmitAnswerInDB.mockResolvedValue({
       data: null,
       error: "Invalid answer index",
@@ -174,6 +179,7 @@ describe("Quiz Session Answer API Route", () => {
       error: null,
     });
     mockQuizSessionFindById.mockResolvedValue({
+      userId: "user-123",
       questionCount: 3,
       questions: [
         {
@@ -221,6 +227,7 @@ describe("Quiz Session Answer API Route", () => {
       error: null,
     });
     mockQuizSessionFindById.mockResolvedValue({
+      userId: "user-123",
       questionCount: 2,
       questions: [
         {

--- a/apps/testing/src/unit/api-routes/quiz-session-complete.test.ts
+++ b/apps/testing/src/unit/api-routes/quiz-session-complete.test.ts
@@ -3,10 +3,16 @@ import { createMocks } from "node-mocks-http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockCompleteQuizSessionInDB = vi.fn();
+const mockQuizSessionFindById = vi.fn();
 
 vi.mock("../../../../api/src/lib/database", () => ({
   completeQuizSessionInDB: (...args: unknown[]) =>
     mockCompleteQuizSessionInDB(...args),
+  QuizSession: {
+    findById: (...args: unknown[]) => ({
+      lean: () => mockQuizSessionFindById(...args),
+    }),
+  },
 }));
 
 vi.mock("../../../../api/src/lib/utils", () => ({
@@ -26,6 +32,10 @@ vi.mock("../../../../api/src/middleware/requestLogger", () => ({
   withApiHandler: (handler: unknown) => handler,
 }));
 
+vi.mock("../../../../api/src/middleware/userAuth", () => ({
+  getAuthenticatedUserId: vi.fn().mockReturnValue("user-123"),
+}));
+
 import handler from "../../../../api/src/pages/api/v1/quiz/session/[sessionId]/complete";
 
 const baseQuestion = {
@@ -40,6 +50,7 @@ const baseQuestion = {
 describe("Quiz Session Complete API Route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockQuizSessionFindById.mockResolvedValue({ userId: "user-123" });
   });
 
   it("rejects non-POST methods", async () => {

--- a/apps/testing/src/unit/api-routes/quiz-session-start.test.ts
+++ b/apps/testing/src/unit/api-routes/quiz-session-start.test.ts
@@ -35,6 +35,11 @@ vi.mock("../../../../api/src/middleware/requestLogger", () => ({
   withApiHandler: (handler: unknown) => handler,
 }));
 
+vi.mock("../../../../api/src/middleware/userAuth", () => ({
+  getAuthenticatedUserId: vi.fn().mockReturnValue("u1"),
+  verifyOwnership: vi.fn().mockReturnValue(true),
+}));
+
 vi.mock("mongoose", () => ({
   Types: {
     ObjectId: vi.fn((id?: string) => id || "generated-id"),

--- a/apps/testing/src/unit/services/payment-enrollment-handlers.test.ts
+++ b/apps/testing/src/unit/services/payment-enrollment-handlers.test.ts
@@ -11,6 +11,7 @@ const mockEnrollInACourse = vi.fn();
 const mockGetActiveSubscriptionByUserFromDB = vi.fn();
 const mockCreateSubscriptionInDB = vi.fn();
 const mockUpdateUserSubscriptionStatusInDB = vi.fn();
+const mockExtendSubscriptionInDB = vi.fn();
 
 vi.mock("../../../../api/src/lib/database", () => ({
   getEnrolledSheetFromDB: (...args: unknown[]) =>
@@ -27,6 +28,8 @@ vi.mock("../../../../api/src/lib/database", () => ({
     mockCreateSubscriptionInDB(...args),
   updateUserSubscriptionStatusInDB: (...args: unknown[]) =>
     mockUpdateUserSubscriptionStatusInDB(...args),
+  extendSubscriptionInDB: (...args: unknown[]) =>
+    mockExtendSubscriptionInDB(...args),
 }));
 
 vi.mock("../../../../api/src/lib/constants", () => ({
@@ -77,6 +80,7 @@ const createMockPayment = (
 describe("Payment Enrollment Handlers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockExtendSubscriptionInDB.mockResolvedValue({ data: {} });
   });
 
   describe("enrollInSheet handler", () => {
@@ -244,7 +248,7 @@ describe("Payment Enrollment Handlers", () => {
 
     it("should return alreadyEnrolled when user has active subscription", async () => {
       mockGetActiveSubscriptionByUserFromDB.mockResolvedValue({
-        data: { _id: "existing_sub" },
+        data: { _id: "existing_sub", expiryDate: new Date() },
       });
 
       const payment = createMockPayment({
@@ -256,9 +260,9 @@ describe("Payment Enrollment Handlers", () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toMatchObject({
-        alreadyEnrolled: true,
-        existingSubscription: { _id: "existing_sub" },
+        extended: true,
       });
+      expect(mockExtendSubscriptionInDB).toHaveBeenCalled();
       expect(mockCreateSubscriptionInDB).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary
- Protect legacy subscription creation with admin authentication (#1172).
- Increment coupon usage once after successful payments (#1173).
- Extend active subscription expiry for renewals/upgrades (#1174).
- Authenticate quiz sessions and remove answer-key leakage (#1175).
- Reconcile failed post-payment enrollment on order-status polling (#1176).
- Make quiz completion safe for empty and repeated submissions (#1177).

## Verification
- pnpm exec tsc --noEmit -p apps/api/tsconfig.json
- pnpm --filter @tbe/testing exec vitest run src/unit/api-routes/prepyatra-subscription.test.ts
- pnpm --filter @tbe/api lint

Closes #1172
Closes #1173
Closes #1174
Closes #1175
Closes #1176
Closes #1177