### PR TITLE
fix(api): protect subscription creation

### DIFF
--- a/apps/api/src/pages/api/v1/prepyatra/subscription.ts
+++ b/apps/api/src/pages/api/v1/prepyatra/subscription.ts
@@ -164,5 +164,5 @@ const handleGetSubscription = async (
   }
 };
 
-// Subscription records are entitlements and may only be created by admins.
+// PrepYatra subscription entitlements are sensitive; this route is restricted to verified admin requests.
 export default withApiHandler(withVerifiedAdminAuth(handler));

--- a/apps/api/src/pages/api/v1/prepyatra/subscription.ts
+++ b/apps/api/src/pages/api/v1/prepyatra/subscription.ts
@@ -6,6 +6,7 @@ import { Subscription } from "@/lib/database";
 import { type CreateSubscriptionPayload } from "@/lib/interfaces";
 import { sendAPIResponse } from "@/lib/utils";
 import { logger } from "@/lib/utils/logger";
+import { withVerifiedAdminAuth } from "@/middleware/admin";
 import { withApiHandler } from "@/middleware/requestLogger";
 
 /**
@@ -163,4 +164,5 @@ const handleGetSubscription = async (
   }
 };
 
-export default withApiHandler(handler);
+// Subscription records are entitlements and may only be created by admins.
+export default withApiHandler(withVerifiedAdminAuth(handler));

--- a/apps/testing/src/unit/api-routes/prepyatra-subscription.test.ts
+++ b/apps/testing/src/unit/api-routes/prepyatra-subscription.test.ts
@@ -48,6 +48,10 @@ vi.mock("../../../../api/src/middleware/requestLogger", () => ({
   ) => handler,
 }));
 
+vi.mock("../../../../api/src/middleware/admin", () => ({
+  withVerifiedAdminAuth: (handler: unknown) => handler,
+}));
+
 import handler from "../../../../api/src/pages/api/v1/prepyatra/subscription";
 
 describe("PrepYatra Subscription API Route", () => {


### PR DESCRIPTION
Fixes #1172. Restricts PrepYatra subscription entitlement creation to verified admin requests, preventing unauthenticated users from granting paid access.