### PR TITLE
fix(api): enforce coupon usage limits

### DIFF
--- a/apps/api/src/lib/database/queries/coupon.ts
+++ b/apps/api/src/lib/database/queries/coupon.ts
@@ -441,8 +441,15 @@ const incrementCouponUsageFromDB = async (
   couponId: string,
 ): Promise<DatabaseQueryResponseType> => {
   try {
-    const updatedCoupon = await Coupon.findByIdAndUpdate(
-      couponId,
+    const updatedCoupon = await Coupon.findOneAndUpdate(
+      {
+        _id: couponId,
+        $or: [
+          { maxUsage: { $exists: false } },
+          { maxUsage: null },
+          { $expr: { $lt: ["$currentUsage", "$maxUsage"] } },
+        ],
+      },
       { $inc: { currentUsage: 1 } },
       { new: true },
     );

--- a/apps/api/src/lib/services/payment/enrollmentService.ts
+++ b/apps/api/src/lib/services/payment/enrollmentService.ts
@@ -1,4 +1,5 @@
 import { getProductConfig } from "@/lib/constants/products";
+import { incrementCouponUsageFromDB } from "@/lib/database";
 import type { PaymentModel } from "@/lib/interfaces";
 import { logger } from "@/lib/utils/logger";
 
@@ -29,6 +30,17 @@ const processPostPaymentEnrollment = async (
         error: result.error,
       });
     } else {
+      if (payment.appliedCoupon && !result.data?.alreadyEnrolled) {
+        const { error: couponError } = await incrementCouponUsageFromDB(
+          payment.appliedCoupon.toString(),
+        );
+        if (couponError) {
+          logger.error("Coupon usage update failed", {
+            orderId: payment.orderId,
+            error: couponError,
+          });
+        }
+      }
       logger.info("Post-payment enrollment succeeded", {
         productType: payment.productType,
         orderId: payment.orderId,

--- a/apps/testing/src/integration/coupon-lifecycle.integration.test.ts
+++ b/apps/testing/src/integration/coupon-lifecycle.integration.test.ts
@@ -15,18 +15,21 @@ const {
   mockFindOne,
   mockFindById,
   mockFindByIdAndUpdate,
+  mockFindOneAndUpdate,
   mockFindByIdAndDelete,
   MockCoupon,
 } = vi.hoisted(() => {
   const mockFindOneInner = vi.fn();
   const mockFindByIdInner = vi.fn();
   const mockFindByIdAndUpdateInner = vi.fn();
+  const mockFindOneAndUpdateInner = vi.fn();
   const mockFindByIdAndDeleteInner = vi.fn();
   const mockSaveInner = vi.fn();
 
   (mockFindOneInner as any)._result = null;
   (mockFindByIdInner as any)._result = null;
   (mockFindByIdAndUpdateInner as any)._result = null;
+  (mockFindOneAndUpdateInner as any)._result = null;
   (mockFindByIdAndDeleteInner as any)._result = null;
 
   const MockCouponInner = vi.fn(function (this: any, doc: any) {
@@ -52,6 +55,10 @@ const {
       mockFindByIdAndUpdateInner(...args);
       return (mockFindByIdAndUpdateInner as any)._result;
     },
+    findOneAndUpdate: (...args: any[]) => {
+      mockFindOneAndUpdateInner(...args);
+      return (mockFindOneAndUpdateInner as any)._result;
+    },
     findByIdAndDelete: (...args: any[]) => {
       mockFindByIdAndDeleteInner(...args);
       return (mockFindByIdAndDeleteInner as any)._result;
@@ -67,6 +74,7 @@ const {
     mockFindOne: mockFindOneInner,
     mockFindById: mockFindByIdInner,
     mockFindByIdAndUpdate: mockFindByIdAndUpdateInner,
+    mockFindOneAndUpdate: mockFindOneAndUpdateInner,
     mockFindByIdAndDelete: mockFindByIdAndDeleteInner,
     MockCoupon: MockCouponInner,
   };
@@ -137,11 +145,11 @@ describe("Coupon Lifecycle Integration", () => {
 
     // STEP 2: Use coupon — increment usage
     const afterFirstUse = { ...couponDoc, currentUsage: 1 };
-    (mockFindByIdAndUpdate as any)._result = afterFirstUse;
+    (mockFindOneAndUpdate as any)._result = afterFirstUse;
 
     await incrementCouponUsageFromDB("coupon_lifecycle");
-    expect(mockFindByIdAndUpdate).toHaveBeenCalledWith(
-      "coupon_lifecycle",
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: "coupon_lifecycle" }),
       { $inc: { currentUsage: 1 } },
       { new: true },
     );
@@ -152,7 +160,7 @@ describe("Coupon Lifecycle Integration", () => {
       currentUsage: 2,
       isUsageLimitReached: true,
     };
-    (mockFindByIdAndUpdate as any)._result = afterSecondUse;
+    (mockFindOneAndUpdate as any)._result = afterSecondUse;
 
     await incrementCouponUsageFromDB("coupon_lifecycle");
 

--- a/apps/testing/src/unit/database/coupon-queries.test.ts
+++ b/apps/testing/src/unit/database/coupon-queries.test.ts
@@ -8,6 +8,7 @@ const {
   mockFindOne,
   mockFindById,
   mockFindByIdAndUpdate,
+  mockFindOneAndUpdate,
   mockFindByIdAndDelete,
   mockSave,
   mockSort,
@@ -17,6 +18,7 @@ const {
   const mockFindOneInner = vi.fn();
   const mockFindByIdInner = vi.fn();
   const mockFindByIdAndUpdateInner = vi.fn();
+  const mockFindOneAndUpdateInner = vi.fn();
   const mockFindByIdAndDeleteInner = vi.fn();
   const mockSaveInner = vi.fn();
   const mockPopulateInner = vi.fn();
@@ -67,6 +69,8 @@ const {
     },
     findByIdAndUpdate: (...args: unknown[]) =>
       mockFindByIdAndUpdateInner(...args),
+    findOneAndUpdate: (...args: unknown[]) =>
+      mockFindOneAndUpdateInner(...args),
     findByIdAndDelete: (...args: unknown[]) => {
       mockFindByIdAndDeleteInner(...args);
       return mockFindByIdAndDeleteInner._mockReturn;
@@ -83,6 +87,7 @@ const {
     mockFindOne: mockFindOneInner,
     mockFindById: mockFindByIdInner,
     mockFindByIdAndUpdate: mockFindByIdAndUpdateInner,
+    mockFindOneAndUpdate: mockFindOneAndUpdateInner,
     mockFindByIdAndDelete: mockFindByIdAndDeleteInner,
     mockSave: mockSaveInner,
     mockPopulate: mockPopulateInner,
@@ -387,25 +392,25 @@ describe("incrementCouponUsageFromDB", () => {
 
   it("atomically increments currentUsage", async () => {
     const updated = makeCouponDoc({ currentUsage: 6 });
-    mockFindByIdAndUpdate.mockReturnValue(updated);
+    mockFindOneAndUpdate.mockReturnValue(updated);
 
     // The actual function calls findByIdAndUpdate directly (no populate chain)
     await incrementCouponUsageFromDB("coupon_abc");
 
-    expect(mockFindByIdAndUpdate).toHaveBeenCalledWith(
-      "coupon_abc",
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: "coupon_abc" }),
       { $inc: { currentUsage: 1 } },
       { new: true },
     );
   });
 
   it("returns error when coupon not found", async () => {
-    mockFindByIdAndUpdate.mockReturnValue(null);
+    mockFindOneAndUpdate.mockReturnValue(null);
 
     const result = await incrementCouponUsageFromDB("nonexistent");
 
-    expect(mockFindByIdAndUpdate).toHaveBeenCalledWith(
-      "nonexistent",
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: "nonexistent" }),
       { $inc: { currentUsage: 1 } },
       { new: true },
     );


### PR DESCRIPTION
Fixes #1173. Atomically increments coupon usage after successful enrollment and prevents increments beyond maxUsage.