### PR TITLE
fix(api): extend subscription renewals

### DIFF
--- a/apps/api/src/lib/services/payment/enrollmentHandlers.ts
+++ b/apps/api/src/lib/services/payment/enrollmentHandlers.ts
@@ -84,12 +84,16 @@ const enrollInCourse: EnrollmentHandler = async (payment) => {
 
 const createSubscription: EnrollmentHandler = async (payment) => {
   try {
-    const plan = planTypeMap[
-      String(payment.productId) as keyof typeof planTypeMap
-    ] || {
-      type: "3Months" as const,
-      duration: 1,
-    };
+    const plan =
+      planTypeMap[
+        String(payment.productId).toLowerCase() as keyof typeof planTypeMap
+      ];
+    if (!plan) {
+      return {
+        success: false,
+        error: `Unknown subscription plan: ${payment.productId}`,
+      };
+    }
 
     const expiryDate =
       plan.type === "Lifetime"
@@ -103,9 +107,23 @@ const createSubscription: EnrollmentHandler = async (payment) => {
       );
 
     if (existingSubscription) {
+      if (plan.type !== "Lifetime") {
+        const currentExpiry = existingSubscription.expiryDate.getTime();
+        const extensionStart = Math.max(currentExpiry, Date.now());
+        existingSubscription.expiryDate = new Date(
+          extensionStart + plan.duration * 30 * 24 * 60 * 60 * 1000,
+        );
+        existingSubscription.duration += plan.duration;
+        await existingSubscription.save();
+        await updateUserSubscriptionStatusInDB({
+          userId: payment.user.toString(),
+          subscriptionStatus: "Active",
+          subscriptionExpiry: existingSubscription.expiryDate,
+        });
+      }
       return {
         success: true,
-        data: { alreadyEnrolled: true, existingSubscription },
+        data: { renewed: true, existingSubscription },
       };
     }
 

--- a/apps/testing/src/unit/services/payment-enrollment-handlers.test.ts
+++ b/apps/testing/src/unit/services/payment-enrollment-handlers.test.ts
@@ -244,7 +244,12 @@ describe("Payment Enrollment Handlers", () => {
 
     it("should return alreadyEnrolled when user has active subscription", async () => {
       mockGetActiveSubscriptionByUserFromDB.mockResolvedValue({
-        data: { _id: "existing_sub" },
+        data: {
+          _id: "existing_sub",
+          expiryDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+          duration: 1,
+          save: vi.fn().mockResolvedValue(undefined),
+        },
       });
 
       const payment = createMockPayment({
@@ -256,7 +261,7 @@ describe("Payment Enrollment Handlers", () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toMatchObject({
-        alreadyEnrolled: true,
+        renewed: true,
         existingSubscription: { _id: "existing_sub" },
       });
       expect(mockCreateSubscriptionInDB).not.toHaveBeenCalled();
@@ -299,7 +304,7 @@ describe("Payment Enrollment Handlers", () => {
       expect(result.error).toBe("Update failed");
     });
 
-    it("should use default plan type when productId not in planTypeMap", async () => {
+    it("should reject unknown subscription plans", async () => {
       mockGetActiveSubscriptionByUserFromDB.mockResolvedValue({ data: null });
       mockCreateSubscriptionInDB.mockResolvedValue({
         data: { _id: "sub_default" },
@@ -313,10 +318,8 @@ describe("Payment Enrollment Handlers", () => {
 
       const result = await ENROLLMENT_HANDLERS.createSubscription(payment);
 
-      expect(result.success).toBe(true);
-      expect(result.data).toMatchObject({
-        plan: "3Months", // Default
-      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Unknown subscription plan");
     });
 
     it("should set lifetime expiry date to 2099 for lifetime plans", async () => {


### PR DESCRIPTION
Fixes #1174. Rejects unknown subscription SKUs and extends an existing active subscription on paid renewals instead of silently treating the purchase as already enrolled.