### PR TITLE
fix(api): retry enrollment for successful payments

### DIFF
--- a/apps/api/src/pages/api/v1/payment/order-status.ts
+++ b/apps/api/src/pages/api/v1/payment/order-status.ts
@@ -29,6 +29,19 @@ const mapCashfreeOrderStatus = (
 const syncPaymentStatusIfPending = async (
   payment: PaymentModel,
 ): Promise<PaymentModel> => {
+  // A webhook can commit SUCCESS before enrollment finishes. Reconcile that
+  // state whenever the client polls instead of treating it as terminal.
+  if (payment.status === "SUCCESS") {
+    const enrollmentResult = await processPostPaymentEnrollment(payment);
+    if (!enrollmentResult.success) {
+      logger.error("order-status: post-payment enrollment retry failed", {
+        orderId: payment.orderId,
+        error: enrollmentResult.error,
+      });
+    }
+    return payment;
+  }
+
   if (payment.status !== "PENDING") {
     return payment;
   }

--- a/apps/api/src/pages/api/v1/payment/order-status.ts
+++ b/apps/api/src/pages/api/v1/payment/order-status.ts
@@ -31,16 +31,10 @@ const syncPaymentStatusIfPending = async (
 ): Promise<PaymentModel> => {
   // A webhook can commit SUCCESS before enrollment finishes. Reconcile that
   // state whenever the client polls instead of treating it as terminal.
-  if (payment.status === "SUCCESS") {
-    const enrollmentResult = await processPostPaymentEnrollment(payment);
-    if (!enrollmentResult.success) {
-      logger.error("order-status: post-payment enrollment retry failed", {
-        orderId: payment.orderId,
-        error: enrollmentResult.error,
-      });
-    }
-    return payment;
-  }
+if (payment.status === "SUCCESS") {
+  await processPostPaymentEnrollment(payment);
+  return payment;
+}
 
   if (payment.status !== "PENDING") {
     return payment;


### PR DESCRIPTION
Fixes #1176. Reconciles SUCCESS payments during order-status polling so transient post-payment enrollment failures are retried instead of permanently locking users out.