### PR TITLE
fix(resources): restore Save as PDF action

### DIFF
--- a/apps/resources/src/components/ResourceArticle.tsx
+++ b/apps/resources/src/components/ResourceArticle.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ResourceMeta } from "@/lib/types";
 
 type Props = {
@@ -34,6 +36,15 @@ export function ResourceArticle({
     },
   };
 
+  const handleArticleClick = (e: React.MouseEvent<HTMLElement>) => {
+    const target = e.target as HTMLElement | null;
+    const printBtn = target?.closest(".print-btn, [data-action='print']");
+    if (printBtn) {
+      e.preventDefault();
+      window.print();
+    }
+  };
+
   return (
     <>
       {includeJsonLd ? (
@@ -42,7 +53,7 @@ export function ResourceArticle({
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
       ) : null}
-      <article className={articleClassName}>
+      <article className={articleClassName} onClick={handleArticleClick}>
         {styleTags ? (
           <div
             className="resource-embed-styles"


### PR DESCRIPTION
## Summary
- restore client-side handling for embedded resource print buttons
- prevent sanitized inline handlers from leaving Save as PDF unresponsive
- call the browser native print flow for all resource pages

## Verification
- pnpm --filter @tbe/resources check-types passed
- pnpm --filter @tbe/resources lint passed with existing warnings
- pnpm --filter @tbe/resources build compiled successfully; command exceeded the session timeout during finalization
- pnpm test produced passing test output but exceeded the session timeout before completion

Closes #1202