### PR TITLE
feat(gamification): add dark and light themes to points badge & fix p…

### DIFF
--- a/apps/testing/src/unit/components/common/UserPointButton.test.tsx
+++ b/apps/testing/src/unit/components/common/UserPointButton.test.tsx
@@ -23,8 +23,6 @@ vi.mock("@tbe/gamification", () => ({
     theme: "light",
     showToast: vi.fn(),
     triggerCelebration: vi.fn(),
-    clearCelebration: vi.fn(),
-    celebrationState: null,
   }),
 }));
 
@@ -62,7 +60,7 @@ describe("UserPointButton", () => {
     await user.click(screen.getByRole("button", { name: /42/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/Your Points/i)).toBeVisible();
+      expect(screen.getByText(/YOU'RE AT/i)).toBeVisible();
       expect(screen.getByText(/Builder/i)).toBeInTheDocument();
     });
   });

--- a/packages/components/src/common/Buttons/UserPointButton.tsx
+++ b/packages/components/src/common/Buttons/UserPointButton.tsx
@@ -7,13 +7,19 @@ import {
 import { UserLevelProgressContainer } from "@tbe/components";
 import { useGamification, useGamificationContext } from "@tbe/gamification";
 import { useUser } from "@tbe/hooks";
-import { Flame } from "lucide-react";
 import { Fragment, useEffect, useState } from "react";
 
-const UserPointButton = () => {
+interface UserPointButtonProps {
+  theme?: "light" | "dark";
+}
+
+const UserPointButton = ({ theme: propTheme }: UserPointButtonProps) => {
   const [isClient, setIsClient] = useState(false);
   const { isAuth, loading } = useUser();
-  const { theme } = useGamificationContext();
+  const gamificationContext = useGamificationContext();
+  const theme = propTheme ?? gamificationContext?.theme ?? "light";
+  const isDark = theme === "dark";
+
   const {
     points,
     currentLevel,
@@ -29,44 +35,30 @@ const UserPointButton = () => {
 
   if (!isClient || !isAuth || loading) return null;
 
-  const isDark = theme === "dark";
-
   return (
     <Popover className="relative">
-      {/* ── Trigger pill: 🔥 + points ── */}
       <PopoverButton
-        className={`
-          flex items-center gap-1.5 px-3 py-1.5 rounded-full
-          font-semibold text-sm outline-none
-          transition-all duration-200 select-none
-          ${
-            isDark
-              ? "bg-primary/20 border border-primary/30 text-white hover:bg-primary/30 hover:border-primary/50"
-              : "bg-primary/10 border border-primary/25 text-primary hover:bg-primary/20 hover:border-primary/40"
-          }
-        `}
+        className={`flex p-1 w-10 h-10 justify-center items-center rounded-full border-2 border-primary text-primary outline-none font-bold transition-colors ${
+          isDark
+            ? "hover:bg-primary hover:text-white bg-black/40"
+            : "hover:text-white hover:bg-primary bg-white"
+        }`}
         aria-label={`${points} points`}
       >
-        <Flame
-          size={15}
-          className={isDark ? "text-primary" : "text-primary"}
-          aria-hidden="true"
-        />
-        <span className={isDark ? "text-white" : "text-primary"}>
-          {loading ? "…" : points}
+        <span className="w-full h-full flex text-xs items-center justify-center">
+          {points}
         </span>
       </PopoverButton>
-
       <Transition
         as={Fragment}
         enter="transition ease-out duration-200"
-        enterFrom="opacity-0 translate-y-1 scale-95"
-        enterTo="opacity-100 translate-y-0 scale-100"
+        enterFrom="opacity-0 translate-y-1"
+        enterTo="opacity-100 translate-y-0"
         leave="transition ease-in duration-150"
-        leaveFrom="opacity-100 translate-y-0 scale-100"
-        leaveTo="opacity-0 translate-y-1 scale-95"
+        leaveFrom="opacity-100 translate-y-0"
+        leaveTo="opacity-0 translate-y-1"
       >
-        <PopoverPanel className="absolute z-50 mt-2 flex w-screen max-w-max right-0">
+        <PopoverPanel className="absolute z-50 mt-2 flex w-screen max-w-max md:-translate-x-2/3 -translate-x-2/4">
           <UserLevelProgressContainer
             currentLevel={currentLevel}
             currentLevelName={currentLevelName}

--- a/packages/components/src/containers/Cards/Items/ProgressRing.tsx
+++ b/packages/components/src/containers/Cards/Items/ProgressRing.tsx
@@ -2,11 +2,6 @@ import { Text } from "@tbe/components";
 import type { ProgressRingProps } from "@tbe/interface";
 import React from "react";
 
-/**
- * Circular progress ring used as a compact points/level indicator.
- *
- * Supports dark and light themes — the track circle colour adapts accordingly.
- */
 const ProgressRing = ({
   progress = 0,
   point,
@@ -14,6 +9,7 @@ const ProgressRing = ({
 }: ProgressRingProps) => {
   const radius = 42;
   const circumference = 2 * Math.PI * radius;
+  const isDark = theme === "dark";
 
   // Ensure progress is between 0-100%
   const clampedProgress = Math.min(100, Math.max(0, progress));
@@ -22,11 +18,14 @@ const ProgressRing = ({
   const strokeDashoffset =
     circumference - (clampedProgress / 100) * circumference;
 
-  const trackColor = theme === "dark" ? "#2A2A2A" : "#E0E0E0";
+  const trackColor = isDark ? "#2A2A2A" : "#E0E0E0";
 
   return (
-    <div className="relative w-20 h-20 flex items-center justify-center">
-      <svg className="absolute w-full h-full" viewBox="0 0 100 100">
+    <div className="relative w-20 h-20 flex items-center justify-center flex-shrink-0">
+      <svg
+        className="absolute w-full h-full transform -rotate-90"
+        viewBox="0 0 100 100"
+      >
         {/* Background Circle */}
         <circle
           cx="50"
@@ -53,7 +52,7 @@ const ProgressRing = ({
       {/* Display Progress Percentage */}
       <Text
         className={`p-3 text-base md:text-lg font-bold ${
-          theme === "dark" ? "text-white" : "text-gray-900"
+          isDark ? "text-white" : "text-gray-900"
         }`}
         level="span"
       >

--- a/packages/components/src/containers/Cards/UserLevelProgressContainer.tsx
+++ b/packages/components/src/containers/Cards/UserLevelProgressContainer.tsx
@@ -1,5 +1,5 @@
+import { FlexContainer, ProgressRing, Text } from "@tbe/components";
 import type { LevelProgressCardProps } from "@tbe/interface";
-import { Flame, Gift, TrendingUp } from "lucide-react";
 import React from "react";
 
 const UserLevelProgressContainer = ({
@@ -13,199 +13,51 @@ const UserLevelProgressContainer = ({
 }: LevelProgressCardProps) => {
   const isDark = theme === "dark";
 
-  const nextLevelMinPts =
-    pointsLeftToNextLevel > 0 ? points + pointsLeftToNextLevel : null;
-
-  const cardStyle = isDark
-    ? {
-        background: "rgba(12, 12, 18, 0.92)",
-        backdropFilter: "blur(24px)",
-        WebkitBackdropFilter: "blur(24px)",
-        boxShadow:
-          "0 16px 40px rgba(0,0,0,0.7), inset 0 1px 0 rgba(255,255,255,0.06)",
-      }
-    : {};
-
-  const divider = (
-    <div
-      className={`border-t ${isDark ? "border-white/[0.06]" : "border-gray-100"}`}
-    />
-  );
-
-  const motivationalText =
-    points === 0
-      ? "Keep solving, keep growing! 🚀"
-      : points < 100
-        ? "Great start! Keep it up! ⚡"
-        : points < 500
-          ? "You're on fire! 🔥"
-          : "Legend in the making! 🏆";
-
   return (
     <div
-      className={`rounded-xl overflow-hidden w-[272px] ${
+      className={`px-3 py-3 rounded-2xl shadow-xl border relative w-full min-w-[220px] max-w-[320px] ${
         isDark
-          ? "border border-white/10"
-          : "border border-gray-100 bg-white shadow-lg"
+          ? "bg-[#121216] border-white/10 text-white"
+          : "bg-white border-gray-200 text-gray-900"
       }`}
-      style={cardStyle}
     >
-      {/* ── Header ── */}
-      <div className="px-4 pt-4 pb-3">
-        <div className="flex items-center gap-2.5">
-          <div
-            className={`flex-shrink-0 w-9 h-9 rounded-full flex items-center justify-center ${
-              isDark ? "bg-primary/20" : "bg-primary/10"
-            }`}
-          >
-            <Flame size={16} className="text-primary" aria-hidden="true" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <p
-              className={`text-[9px] uppercase tracking-widest font-semibold ${
-                isDark ? "text-white/40" : "text-gray-400"
-              }`}
-            >
-              Your Points
-            </p>
-            <p
-              className={`text-2xl font-black leading-none ${
-                isDark ? "text-white" : "text-gray-900"
-              }`}
-            >
-              {points}{" "}
-              <span
-                className={`text-base font-bold ${
-                  isDark ? "text-white/40" : "text-gray-400"
-                }`}
-              >
-                pts
-              </span>
-            </p>
-            <p
-              className={`text-[10px] mt-0.5 ${
-                isDark ? "text-white/45" : "text-gray-400"
-              }`}
-            >
-              {motivationalText}
-            </p>
-          </div>
-        </div>
-      </div>
-
-      {divider}
-
-      {/* ── Current Level ── */}
-      <div className="px-4 py-1.5 flex items-center gap-3">
-        <TrendingUp
-          size={18}
-          className={
-            isDark
-              ? "text-violet-400 flex-shrink-0"
-              : "text-violet-600 flex-shrink-0"
-          }
-          aria-hidden="true"
+      <FlexContainer className="flex-col flex-nowrap sm:flex-row gap-2.5 items-center">
+        <ProgressRing
+          point={points}
+          progress={percentageProgress}
+          theme={theme}
         />
-        <div className="flex-1 min-w-0">
-          <p
-            className={`text-[9px] uppercase tracking-widest font-semibold ${
-              isDark ? "text-white/40" : "text-gray-400"
-            }`}
-          >
-            Current Level
-          </p>
-          <p
-            className={`text-xs font-bold mt-0.5 ${
-              isDark ? "text-white" : "text-gray-900"
-            }`}
-          >
-            Lv {currentLevel} {currentLevelName}
-          </p>
-        </div>
-      </div>
-
-      {/* ── Next Milestone ── */}
-      {nextLevelName && pointsLeftToNextLevel > 0 ? (
-        <>
-          {divider}
-          <div className="px-4 py-1.5 flex items-center gap-3">
-            <Gift
-              size={18}
-              className={
-                isDark
-                  ? "text-emerald-400 flex-shrink-0"
-                  : "text-emerald-600 flex-shrink-0"
-              }
-              aria-hidden="true"
-            />
-            <div className="flex-1 min-w-0">
-              <p
-                className={`text-[9px] uppercase tracking-widest font-semibold ${
-                  isDark ? "text-white/40" : "text-gray-400"
-                }`}
-              >
-                Next Milestone
-              </p>
-              <p
-                className={`text-xs font-bold mt-0.5 ${
-                  isDark ? "text-white" : "text-gray-900"
-                }`}
-              >
-                {pointsLeftToNextLevel} pts → {nextLevelName}
-              </p>
-            </div>
-          </div>
-        </>
-      ) : (
-        !nextLevelName && (
-          <>
-            {divider}
-            <div className="px-4 py-1.5">
-              <div
-                className={`rounded-lg px-3 py-1.5 text-center text-xs font-bold ${
-                  isDark
-                    ? "bg-amber-500/15 text-amber-300 border border-amber-500/20"
-                    : "bg-amber-50 text-amber-700 border border-amber-200"
-                }`}
-              >
-                🏆 Max Level Achieved!
-              </div>
-            </div>
-          </>
-        )
-      )}
-
-      {/* ── Progress bar ── */}
-      <div className="px-4 pb-3 pt-2">
-        <div
-          className={`h-1 rounded-full overflow-hidden ${
-            isDark ? "bg-white/8" : "bg-gray-100"
-          }`}
+        <FlexContainer
+          className="gap-1.5 w-full"
+          direction="col"
+          itemCenter={false}
         >
-          <div
-            className="h-full rounded-full bg-gradient-to-r from-primary to-orange-400 transition-all duration-500 ease-out"
-            style={{ width: `${Math.max(2, percentageProgress)}%` }}
-            role="progressbar"
-            aria-valuenow={percentageProgress}
-            aria-valuemin={0}
-            aria-valuemax={100}
-          />
-        </div>
-        <div className="flex justify-between mt-1">
-          <span
-            className={`text-[9px] ${isDark ? "text-white/25" : "text-gray-300"}`}
-          >
-            Lv {currentLevel}
-          </span>
-          {nextLevelName && (
-            <span
-              className={`text-[9px] ${isDark ? "text-white/25" : "text-gray-300"}`}
+          <FlexContainer direction="col" itemCenter={false}>
+            <Text
+              className={`pre-title ${isDark ? "text-gray-400" : "text-greyDark"}`}
+              level="span"
             >
-              Lv {currentLevel + 1}
-            </span>
+              YOU&apos;RE AT
+            </Text>
+            <Text className="strong-text text-primary font-bold" level="span">
+              Level {currentLevel} : {currentLevelName}
+            </Text>
+          </FlexContainer>
+          {nextLevelName ? (
+            <FlexContainer className="py-1.5 px-2.5 w-full bg-primary font-semibold rounded-md text-center text-xs md:text-sm">
+              <Text className="button-text text-white font-bold" level="p">
+                {pointsLeftToNextLevel} Points to {nextLevelName}
+              </Text>
+            </FlexContainer>
+          ) : (
+            <FlexContainer className="py-1.5 px-2.5 w-full bg-primary font-semibold rounded-md text-center text-xs md:text-sm">
+              <Text className="button-text text-white font-bold" level="p">
+                Max Level Achieved!
+              </Text>
+            </FlexContainer>
           )}
-        </div>
-      </div>
+        </FlexContainer>
+      </FlexContainer>
     </div>
   );
 };

--- a/packages/gamification/src/PointsBadge.tsx
+++ b/packages/gamification/src/PointsBadge.tsx
@@ -1,6 +1,6 @@
 import { USER_LEVELS } from "@tbe/constants";
 import { AnimatePresence, motion } from "framer-motion";
-import { Flame, Gift, TrendingUp } from "lucide-react";
+import { Flame } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { useGamificationContext } from "./GamificationProvider";
@@ -10,18 +10,19 @@ import useGamification from "./useGamification";
 /**
  * Compact points display for navbars and headers.
  *
- * Shows a pill badge with current points. On click, expands to reveal
- * a compact card with level progress, next-level target, and a progress bar.
+ * Shows a circular badge with current points. On click, expands to reveal
+ * a card with level progress, next-level target, and a circular progress ring.
  *
- * Respects the theme from GamificationProvider context.
+ * Supports light and dark themes.
  *
  * Variants:
- * - "navbar" (default): pill-shaped, designed for top navbars
+ * - "navbar" (default): fixed-size circle designed for top navbars
  * - "inline": smaller badge that fits inside text rows
  */
 const PointsBadge = ({
   variant = "navbar",
   className = "",
+  theme: propTheme,
 }: PointsBadgeProps) => {
   const {
     points,
@@ -33,7 +34,8 @@ const PointsBadge = ({
     percentageProgress,
   } = useGamification();
 
-  const { theme } = useGamificationContext();
+  const context = useGamificationContext();
+  const theme = propTheme ?? context?.theme ?? "light";
   const isDark = theme === "dark";
 
   const [isOpen, setIsOpen] = useState(false);
@@ -53,242 +55,125 @@ const PointsBadge = ({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isOpen]);
 
+  const radius = variant === "navbar" ? 40 : 30;
+  const circumference = 2 * Math.PI * radius;
+  const strokeOffset = circumference * (1 - percentageProgress / 100);
   const nextLevel = USER_LEVELS.find((l) => l.level === currentLevel + 1);
-  const nextLevelMinPts = nextLevel?.minPoints ?? null;
 
-  const motivationalText =
-    points === 0
-      ? "Keep solving, keep growing! 🚀"
-      : points < 100
-        ? "Great start! Keep it up! ⚡"
-        : "You're on fire! 🔥";
-
-  /* ── Inline variant ── */
   if (variant === "inline") {
     return (
       <button
-        className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full border text-sm font-semibold transition-colors ${
+        className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-semibold transition-colors ${
           isDark
-            ? "bg-primary/20 border-primary/30 text-white hover:bg-primary/30"
-            : "bg-primary/10 border-primary/20 text-primary hover:bg-primary/20"
+            ? "bg-primary/20 text-white border border-primary/30 hover:bg-primary/30"
+            : "bg-primary/10 text-primary border border-primary/20 hover:bg-primary/20"
         } ${className}`}
         onClick={() => setIsOpen((v) => !v)}
       >
-        <Flame size={14} className="text-primary" />
+        <Flame size={14} />
         {loading ? "..." : points}
-        <span className={`text-xs ${isDark ? "opacity-50" : "opacity-60"}`}>
+        <span
+          className={`text-xs ${isDark ? "opacity-60 text-white" : "opacity-60 text-primary"}`}
+        >
           L{currentLevel}
         </span>
       </button>
     );
   }
 
-  const divider = (
-    <div
-      className={`border-t ${isDark ? "border-white/[0.06]" : "border-gray-100"}`}
-    />
-  );
-
-  /* ── Navbar pill variant ── */
   return (
     <div className="relative" ref={containerRef}>
       <motion.button
-        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full font-semibold text-sm outline-none transition-all duration-200 ${
-          isDark
-            ? "bg-primary/20 border border-primary/30 text-white hover:bg-primary/30 hover:border-primary/50"
-            : "bg-primary/10 border border-primary/25 text-primary hover:bg-primary/20 hover:border-primary/40"
-        } ${className}`}
+        className={`w-12 h-12 bg-[#ef4444] rounded-full flex items-center justify-center hover:bg-[#dc2626] transition-colors shadow-md ${className}`}
         onClick={() => setIsOpen((v) => !v)}
-        whileTap={{ scale: 0.96 }}
-        aria-label={`${points} points`}
+        whileTap={{ scale: 0.9 }}
       >
-        <Flame size={15} className="text-primary" aria-hidden="true" />
-        <span>{loading ? "..." : points}</span>
+        <span className="text-white font-bold text-sm">
+          {loading ? "..." : points}
+        </span>
       </motion.button>
 
       <AnimatePresence>
         {isOpen && (
           <motion.div
             animate={{ opacity: 1, y: 0, scale: 1 }}
-            className="absolute top-full right-0 mt-2 z-50"
+            className="absolute top-full right-0 mt-3 z-50"
             exit={{ opacity: 0, y: -8, scale: 0.95 }}
             initial={{ opacity: 0, y: -8, scale: 0.95 }}
             transition={{ type: "spring", stiffness: 400, damping: 30 }}
           >
-            {/* ── Card ── */}
             <div
-              className={`rounded-xl overflow-hidden w-[272px] ${
+              className={`rounded-2xl shadow-xl p-5 w-80 border ${
                 isDark
-                  ? "border border-white/10"
-                  : "border border-gray-100 bg-white shadow-lg"
+                  ? "bg-[#121216] border-white/10 text-white"
+                  : "bg-white border-gray-200 text-gray-900"
               }`}
-              style={
-                isDark
-                  ? {
-                      background: "rgba(12, 12, 18, 0.92)",
-                      backdropFilter: "blur(24px)",
-                      WebkitBackdropFilter: "blur(24px)",
-                      boxShadow:
-                        "0 16px 40px rgba(0,0,0,0.7), inset 0 1px 0 rgba(255,255,255,0.06)",
-                    }
-                  : {}
-              }
             >
-              {/* Header */}
-              <div className="px-4 pt-4 pb-3">
-                <div className="flex items-center gap-2.5">
-                  <div
-                    className={`flex-shrink-0 w-9 h-9 rounded-full flex items-center justify-center ${
-                      isDark ? "bg-primary/20" : "bg-primary/10"
-                    }`}
+              <div className="flex items-center gap-4">
+                {/* Progress ring */}
+                <div className="flex-shrink-0 relative">
+                  <svg
+                    className="transform -rotate-90"
+                    height={radius * 2 + 16}
+                    width={radius * 2 + 16}
                   >
-                    <Flame
-                      size={16}
-                      className="text-primary"
-                      aria-hidden="true"
+                    <circle
+                      cx={radius + 8}
+                      cy={radius + 8}
+                      fill={isDark ? "transparent" : "white"}
+                      r={radius}
+                      stroke={isDark ? "#2A2A2A" : "#f3f4f6"}
+                      strokeWidth="7"
                     />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p
-                      className={`text-[9px] uppercase tracking-widest font-semibold ${
-                        isDark ? "text-white/40" : "text-gray-400"
-                      }`}
-                    >
-                      Your Points
-                    </p>
-                    <p
-                      className={`text-2xl font-black leading-none ${
+                    <circle
+                      cx={radius + 8}
+                      cy={radius + 8}
+                      fill="none"
+                      r={radius}
+                      stroke="#ef4444"
+                      strokeDasharray={circumference}
+                      strokeDashoffset={strokeOffset}
+                      strokeLinecap="round"
+                      strokeWidth="7"
+                      style={{ transition: "stroke-dashoffset 0.5s ease" }}
+                    />
+                  </svg>
+                  <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                    <span
+                      className={`text-xl font-bold ${
                         isDark ? "text-white" : "text-gray-900"
                       }`}
                     >
-                      {points}{" "}
-                      <span
-                        className={`text-base font-bold ${
-                          isDark ? "text-white/40" : "text-gray-400"
-                        }`}
-                      >
-                        pts
-                      </span>
-                    </p>
-                    <p
-                      className={`text-[10px] mt-0.5 ${
-                        isDark ? "text-white/45" : "text-gray-400"
-                      }`}
-                    >
-                      {motivationalText}
-                    </p>
+                      {points}
+                    </span>
                   </div>
                 </div>
-              </div>
 
-              {divider}
-
-              {/* Current Level */}
-              <div className="px-4 py-1.5 flex items-center gap-3">
-                <TrendingUp
-                  size={18}
-                  className={
-                    isDark
-                      ? "text-violet-400 flex-shrink-0"
-                      : "text-violet-600 flex-shrink-0"
-                  }
-                  aria-hidden="true"
-                />
+                {/* Level info */}
                 <div className="flex-1 min-w-0">
                   <p
-                    className={`text-[9px] uppercase tracking-widest font-semibold ${
-                      isDark ? "text-white/40" : "text-gray-400"
+                    className={`text-[10px] uppercase font-semibold tracking-widest ${
+                      isDark ? "text-gray-400" : "text-gray-400"
                     }`}
                   >
-                    Current Level
+                    YOU&apos;RE AT
                   </p>
-                  <p
-                    className={`text-xs font-bold mt-0.5 ${
-                      isDark ? "text-white" : "text-gray-900"
-                    }`}
-                  >
-                    Lv {currentLevel} {currentLevelName}
+                  <p className="text-lg font-bold text-[#ef4444] leading-tight mt-0.5">
+                    Level {currentLevel}: {currentLevelName}
                   </p>
-                </div>
-              </div>
 
-              {/* Next Milestone */}
-              {nextLevel && pointsLeftToNextLevel > 0 && (
-                <>
-                  {divider}
-                  <div className="px-4 py-1.5 flex items-center gap-3">
-                    <Gift
-                      size={18}
-                      className={
-                        isDark
-                          ? "text-emerald-400 flex-shrink-0"
-                          : "text-emerald-600 flex-shrink-0"
-                      }
-                      aria-hidden="true"
-                    />
-                    <div className="flex-1 min-w-0">
-                      <p
-                        className={`text-[9px] uppercase tracking-widest font-semibold ${
-                          isDark ? "text-white/40" : "text-gray-400"
-                        }`}
-                      >
-                        Next Milestone
-                      </p>
-                      <p
-                        className={`text-xs font-bold mt-0.5 ${
-                          isDark ? "text-white" : "text-gray-900"
-                        }`}
-                      >
-                        {pointsLeftToNextLevel} pts → {nextLevelName}
+                  {nextLevel && pointsLeftToNextLevel > 0 ? (
+                    <div className="mt-2 bg-primary rounded-lg px-3 py-1.5">
+                      <p className="text-xs font-bold text-white text-center">
+                        {pointsLeftToNextLevel} pts to {nextLevelName}
                       </p>
                     </div>
-                  </div>
-                </>
-              )}
-
-              {/* Max level */}
-              {!nextLevel && (
-                <div className="px-4 py-2.5">
-                  <div
-                    className={`rounded-lg px-3 py-1.5 text-center text-xs font-bold ${
-                      isDark
-                        ? "bg-amber-500/15 text-amber-300 border border-amber-500/20"
-                        : "bg-amber-50 text-amber-700 border border-amber-200"
-                    }`}
-                  >
-                    🏆 Max Level Achieved!
-                  </div>
-                </div>
-              )}
-
-              {/* Progress bar */}
-              <div className="px-4 pb-3 pt-2">
-                <div
-                  className={`h-1 rounded-full overflow-hidden ${
-                    isDark ? "bg-white/8" : "bg-gray-100"
-                  }`}
-                >
-                  <div
-                    className="h-full rounded-full bg-gradient-to-r from-primary to-orange-400 transition-all duration-500 ease-out"
-                    style={{ width: `${Math.max(2, percentageProgress)}%` }}
-                    role="progressbar"
-                    aria-valuenow={percentageProgress}
-                    aria-valuemin={0}
-                    aria-valuemax={100}
-                  />
-                </div>
-                <div className="flex justify-between mt-1">
-                  <span
-                    className={`text-[9px] ${isDark ? "text-white/25" : "text-gray-300"}`}
-                  >
-                    Lv {currentLevel}
-                  </span>
-                  {nextLevel && (
-                    <span
-                      className={`text-[9px] ${isDark ? "text-white/25" : "text-gray-300"}`}
-                    >
-                      Lv {currentLevel + 1}
-                    </span>
+                  ) : (
+                    <div className="mt-2 bg-primary rounded-lg px-3 py-1.5">
+                      <p className="text-xs font-bold text-white text-center">
+                        Max Level Achieved!
+                      </p>
+                    </div>
                   )}
                 </div>
               </div>

--- a/packages/gamification/src/types.ts
+++ b/packages/gamification/src/types.ts
@@ -76,6 +76,7 @@ export interface LeaderboardEntry {
 export interface PointsBadgeProps {
   variant?: "navbar" | "inline";
   className?: string;
+  theme?: ThemeType;
 }
 
 export interface CelebrationAnimationProps {

--- a/packages/gamification/src/useGamification.ts
+++ b/packages/gamification/src/useGamification.ts
@@ -1,14 +1,15 @@
 import { useUser } from "@tbe/hooks";
 import { CACHE_TIMES, queryKeys, useQuery } from "@tbe/query";
 import { gamificationApi } from "@tbe/services";
+import { sendRequest } from "@tbe/utils";
 
 import { getUserGamificationLevel } from "./utils";
 
 /**
  * Unified hook for reading a user's gamification state.
  *
- * Uses React Query for caching + deduplication, and gamificationApi
- * from @tbe/services for the network call.
+ * Uses React Query for caching + deduplication, and sends the request
+ * via sendRequest / gamificationApi to ensure compatibility across all apps.
  *
  * Returns points, level info, and progress — everything a UI needs
  * to render gamification state without managing its own fetch logic.
@@ -24,12 +25,26 @@ const useGamification = (overrideUserId?: string) => {
     refetch,
   } = useQuery({
     queryKey: queryKeys.gamification.points(userId ?? ""),
-    queryFn: () => gamificationApi.getuserGamificationPoints(userId!),
+    queryFn: async () => {
+      try {
+        const res = await sendRequest({
+          method: "GET",
+          url: `/gamification?userId=${userId}`,
+        });
+        if (res && (res.data !== undefined || res.success !== false)) {
+          return res;
+        }
+      } catch {
+        // Fallback to services api client
+      }
+      return await gamificationApi.getuserGamificationPoints(userId!);
+    },
     ...CACHE_TIMES.STANDARD,
     enabled: !!userId,
   });
 
-  const points = (response as any)?.data?.points ?? 0;
+  const points =
+    (response as any)?.data?.points ?? (response as any)?.points ?? 0;
 
   const {
     currentLevel,


### PR DESCRIPTION
### What Changed
- Restored original navbar points button with circular progress ring card.
- Added **dark theme** for DSA Yatra & Oncampus, and **light theme** for Platform & Prep Yatra.
- Set milestone badge background to `bg-primary`.
- Fixed points fetch on Platform app.


### PREV
<img width="406" height="249" alt="image" src="https://github.com/user-attachments/assets/4cec4e76-b1bc-44d2-832f-0832d9be6a0d" />

### NOW

<table>
  <tr>
    <th align="center">Dark Mode</th>
    <th align="center">Light Mode</th>
  </tr>
  <tr>
    <td align="center">
      <img width="586" height="455"
        src="https://github.com/user-attachments/assets/87e17a42-12f3-4911-8bb8-c5bfa9d6d867"
        alt="Dark Mode" />
    </td>
    <td align="center">
      <img width="480" height="340"
        src="https://github.com/user-attachments/assets/b9c0fc2a-a43d-4ad1-953d-c181ceff3340"
        alt="Light Mode" />
    </td>
  </tr>
</table>