### PR TITLE
fix: enable content feedback in resources app and add unit tests

### DIFF
--- a/apps/resources/src/app/api/proxy/[...path]/route.ts
+++ b/apps/resources/src/app/api/proxy/[...path]/route.ts
@@ -1,0 +1,95 @@
+import { envConfig } from "@tbe/constants";
+import { type NextRequest, NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Proxy API route to forward requests to the actual API server in Next.js App Router.
+ * This eliminates CORS issues by making all API calls from the same origin.
+ *
+ * Usage: /api/proxy/content-feedback -> {API_URL}/content-feedback
+ */
+async function proxyRequest(
+  request: NextRequest,
+  { params }: { params: { path: string[] } },
+) {
+  const apiUrl = envConfig.API_URL || process.env.NEXT_PUBLIC_API_URL;
+
+  if (!apiUrl) {
+    return NextResponse.json(
+      {
+        error: "API URL not configured",
+        message: "Please set NEXT_PUBLIC_API_URL environment variable",
+      },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const apiPath = Array.isArray(params.path)
+      ? params.path.join("/")
+      : params.path || "";
+
+    const searchParams = request.nextUrl.searchParams;
+    const queryString = searchParams.toString();
+    const url = queryString
+      ? `${apiUrl}/${apiPath}?${queryString}`
+      : `${apiUrl}/${apiPath}`;
+
+    const headers = new Headers();
+    request.headers.forEach((value, key) => {
+      const lower = key.toLowerCase();
+      // Avoid forwarding host and connection headers
+      if (
+        lower !== "host" &&
+        lower !== "connection" &&
+        lower !== "content-length"
+      ) {
+        headers.set(key, value);
+      }
+    });
+
+    const init: RequestInit = {
+      method: request.method,
+      headers,
+    };
+
+    if (["POST", "PUT", "PATCH", "DELETE"].includes(request.method)) {
+      const body = await request.arrayBuffer();
+      if (body.byteLength > 0) {
+        init.body = body;
+      }
+    }
+
+    const response = await fetch(url, init);
+    const data = await response.arrayBuffer();
+
+    const responseHeaders = new Headers();
+    const contentType = response.headers.get("content-type");
+    if (contentType) {
+      responseHeaders.set("content-type", contentType);
+    }
+
+    return new NextResponse(data, {
+      status: response.status,
+      headers: responseHeaders,
+    });
+  } catch (error: any) {
+    console.error("Proxy error:", error);
+    return NextResponse.json(
+      {
+        error: "Proxy error",
+        message: error?.message || "Internal Proxy Error",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export const GET = proxyRequest;
+export const POST = proxyRequest;
+export const PUT = proxyRequest;
+export const PATCH = proxyRequest;
+export const DELETE = proxyRequest;
+export const HEAD = proxyRequest;
+export const OPTIONS = proxyRequest;

--- a/apps/resources/src/app/api/proxy/[...path]/route.ts
+++ b/apps/resources/src/app/api/proxy/[...path]/route.ts
@@ -74,12 +74,14 @@ async function proxyRequest(
       status: response.status,
       headers: responseHeaders,
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error("Proxy error:", error);
+    const message =
+      error instanceof Error ? error.message : "Internal Proxy Error";
     return NextResponse.json(
       {
         error: "Proxy error",
-        message: error?.message || "Internal Proxy Error",
+        message,
       },
       { status: 500 },
     );

--- a/apps/testing/src/unit/hooks/useContentFeedback.test.ts
+++ b/apps/testing/src/unit/hooks/useContentFeedback.test.ts
@@ -1,0 +1,172 @@
+import { renderHookWithQuery } from "@test-utils/query-wrapper";
+import { act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tbe/utils", () => ({
+  sendRequest: vi.fn(),
+}));
+
+const mockUseUser = vi.fn();
+vi.mock("@tbe/hooks/useUser", () => ({
+  default: () => mockUseUser(),
+}));
+
+const mockGetAccessToken = vi.fn();
+vi.mock("@tbe/auth", () => ({
+  getAccessToken: () => mockGetAccessToken(),
+}));
+
+import { useContentFeedback } from "@tbe/hooks";
+import { sendRequest } from "@tbe/utils";
+
+const mockSendRequest = vi.mocked(sendRequest);
+
+describe("useContentFeedback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAccessToken.mockReturnValue("mock-access-token");
+    mockUseUser.mockReturnValue({
+      user: { id: "user-123" },
+      isAuth: true,
+      loading: false,
+    });
+  });
+
+  it("fetches existing feedback on mount when enabled and authenticated", async () => {
+    mockSendRequest.mockResolvedValueOnce({
+      status: true,
+      data: {
+        hasReviewed: true,
+        rating: 5,
+        reviewText: "Great resource!",
+        meta: { resourceSlug: "react-basics" },
+      },
+    });
+
+    const { result } = renderHookWithQuery(() =>
+      useContentFeedback({
+        contentType: "RESOURCE_GUIDE",
+        contentId: "react-basics",
+        enabled: true,
+      }),
+    );
+
+    // Wait for the fetch to resolve
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        headers: {
+          Authorization: "Bearer mock-access-token",
+        },
+        url: expect.stringContaining(
+          "/content-feedback?userId=user-123&contentType=RESOURCE_GUIDE&contentId=react-basics",
+        ),
+      }),
+    );
+
+    expect(result.current.hasReviewed).toBe(true);
+    expect(result.current.existingRating).toBe(5);
+    expect(result.current.existingReviewText).toBe("Great resource!");
+  });
+
+  it("submits new feedback via POST successfully", async () => {
+    mockSendRequest.mockResolvedValueOnce({
+      status: true,
+      data: {
+        id: "cf-1",
+        rating: 4,
+        reviewText: "Very helpful guide",
+      },
+    });
+
+    const { result } = renderHookWithQuery(() =>
+      useContentFeedback({
+        contentType: "RESOURCE_GUIDE",
+        contentId: "docker-guide",
+        enabled: false,
+      }),
+    );
+
+    let success = false;
+    await act(async () => {
+      success = await result.current.submitFeedback(4, "Very helpful guide", {
+        resourceSlug: "docker-guide",
+      });
+    });
+
+    expect(success).toBe(true);
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        url: "/content-feedback",
+        headers: {
+          Authorization: "Bearer mock-access-token",
+        },
+        body: {
+          userId: "user-123",
+          contentType: "RESOURCE_GUIDE",
+          contentId: "docker-guide",
+          rating: 4,
+          reviewText: "Very helpful guide",
+          meta: { resourceSlug: "docker-guide" },
+        },
+      }),
+    );
+
+    expect(result.current.hasReviewed).toBe(true);
+    expect(result.current.existingRating).toBe(4);
+    expect(result.current.existingReviewText).toBe("Very helpful guide");
+  });
+
+  it("handles submit failure gracefully", async () => {
+    mockSendRequest.mockResolvedValueOnce({
+      status: false,
+      error: "Internal server error",
+    });
+
+    const { result } = renderHookWithQuery(() =>
+      useContentFeedback({
+        contentType: "RESOURCE_GUIDE",
+        contentId: "system-design",
+        enabled: false,
+      }),
+    );
+
+    let success = true;
+    await act(async () => {
+      success = await result.current.submitFeedback(5, "Top notch!");
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.hasReviewed).toBe(false);
+  });
+
+  it("does not submit if user is unauthenticated", async () => {
+    mockUseUser.mockReturnValue({
+      user: null,
+      isAuth: false,
+      loading: false,
+    });
+
+    const { result } = renderHookWithQuery(() =>
+      useContentFeedback({
+        contentType: "RESOURCE_GUIDE",
+        contentId: "system-design",
+        enabled: false,
+      }),
+    );
+
+    let success = true;
+    await act(async () => {
+      success = await result.current.submitFeedback(5, "Top notch!");
+    });
+
+    expect(success).toBe(false);
+    expect(mockSendRequest).not.toHaveBeenCalled();
+  });
+});

--- a/packages/hooks/src/useContentFeedback.ts
+++ b/packages/hooks/src/useContentFeedback.ts
@@ -1,3 +1,4 @@
+import { getAccessToken } from "@tbe/auth";
 import type { FeedbackType } from "@tbe/constants";
 import { routes } from "@tbe/constants";
 import { sendRequest } from "@tbe/utils";
@@ -46,8 +47,14 @@ const useContentFeedback = ({
     setState((prev) => ({ ...prev, isFetching: true }));
 
     try {
+      const token = typeof window !== "undefined" ? getAccessToken() : null;
+      const headers: Record<string, string> = {};
+      if (token) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+
       const url = `${routes.api.contentFeedback}?userId=${user.id}&contentType=${contentType}&contentId=${encodeURIComponent(contentId)}`;
-      const response = await sendRequest({ url, method: "GET" });
+      const response = await sendRequest({ url, method: "GET", headers });
 
       if (response?.status && response.data) {
         setState((prev) => ({
@@ -88,9 +95,16 @@ const useContentFeedback = ({
     const metaToSubmit = overrideMeta || meta;
 
     try {
+      const token = typeof window !== "undefined" ? getAccessToken() : null;
+      const headers: Record<string, string> = {};
+      if (token) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+
       const response = await sendRequest({
         url: routes.api.contentFeedback,
         method: "POST",
+        headers,
         body: {
           userId: user.id,
           contentType,


### PR DESCRIPTION
## Summary
Fixes the content feedback widget failing in the Resources application by introducing the missing API proxy handler, attaching required authorization headers to requests, and adding unit tests.

## Changes
- **`apps/resources`**: Added App Router proxy route handler (`/api/proxy/[...path]/route.ts`) to forward API requests without CORS issues.
- **`packages/hooks`**: Updated `useContentFeedback` to attach `Authorization: Bearer <token>` for both fetching and submitting feedback.
- **`apps/testing`**: Added comprehensive unit test suite for `useContentFeedback`.

## Verification
- Ran unit tests: `pnpm --filter @tbe/testing test:unit src/unit/hooks/useContentFeedback.test.ts` (4/4 tests passed).
