### PR TITLE
feat(platform): Add dark/light mode toggle to the platform

### DIFF
--- a/apps/platform/src/pages/_app.tsx
+++ b/apps/platform/src/pages/_app.tsx
@@ -3,7 +3,7 @@ import '@/styles/globals.css';
 import '@/styles/colors.css';
 
 import { AuthProvider, getAccessToken } from '@tbe/auth';
-import { Layout } from '@tbe/components';
+import { Layout, ThemeProvider } from '@tbe/components';
 // import { envConfig, googleAnalyticsScript, gtag, routes } from '@tbe/constants';
 import { envConfig, routes } from '@tbe/constants';
 import { GamificationProvider } from '@tbe/gamification';
@@ -233,9 +233,11 @@ const AppContent = ({
 const TheBoringEducation = ({ Component, pageProps }: AppProps) => {
   return (
     <Fragment>
-      <AuthProvider>
-        <AppContent Component={Component} pageProps={pageProps} />
-      </AuthProvider>
+      <ThemeProvider defaultTheme='light' enableSystem={false}>
+        <AuthProvider>
+          <AppContent Component={Component} pageProps={pageProps} />
+        </AuthProvider>
+      </ThemeProvider>
     </Fragment>
   );
 };

--- a/apps/platform/src/pages/_document.tsx
+++ b/apps/platform/src/pages/_document.tsx
@@ -2,9 +2,9 @@ import { Head, Html, Main, NextScript } from 'next/document';
 
 const TheBoringEducation = () => {
   return (
-    <Html lang='en'>
+    <Html lang='en' suppressHydrationWarning>
       <Head />
-      <body>
+      <body className='bg-background text-foreground antialiased'>
         <Main />
         <NextScript />
       </body>

--- a/apps/platform/src/pages/index.tsx
+++ b/apps/platform/src/pages/index.tsx
@@ -5,27 +5,27 @@ import {
   PlatformLandingHero,
   SEO,
   Testimonials,
+  useColorTheme,
   WeAlreadyTaughtAt,
 } from '@tbe/components';
 import { PAGE_REFRESH_TIMEOUT, routes, STATIC_FILE_PATH } from '@tbe/constants';
 import type { PageProps } from '@tbe/interface';
 import { getPreFetchProps } from '@tbe/utils';
-import { useRouter } from 'next/router';
 import { Fragment } from 'react';
 
 const Home = ({ seoMeta }: PageProps) => {
-  const router = useRouter();
+  const pageTheme = useColorTheme();
 
   return (
     <Fragment>
       <SEO seoMeta={seoMeta} />
-      <main className='relative min-h-screen w-full bg-[#FAFAFC] overflow-hidden'>
+      <main className='relative min-h-screen w-full bg-background overflow-hidden'>
         <PlatformLandingHero
           ctaText='Start Learning Now →'
           ctaHref={routes.learn}
         />
 
-        <AppShowcaseSections theme='light' />
+        <AppShowcaseSections theme={pageTheme} />
 
         <Banner
           buttonLink={routes.devRels}

--- a/apps/platform/src/pages/interview-prep/[sheetSlug]/index.tsx
+++ b/apps/platform/src/pages/interview-prep/[sheetSlug]/index.tsx
@@ -10,6 +10,7 @@ import {
   SEO,
   SheetHeroContainer,
   Text,
+  useColorTheme,
 } from '@tbe/components';
 import { routes } from '@tbe/constants';
 import {
@@ -40,6 +41,7 @@ const SheetPage = ({
   slug,
   seoMeta,
 }: SheetPageProps) => {
+  const pageTheme = useColorTheme();
   const router = useRouter();
   const [sheet, setSheet] = useState(initialSheet);
   const [isEnrolled, setIsEnrolled] = useState(
@@ -339,7 +341,7 @@ const SheetPage = ({
   return (
     <Fragment>
       <SEO seoMeta={seoMeta} />
-      <div className='bg-[#FAFAFA] min-h-screen font-body text-foreground'>
+      <div className='bg-background min-h-screen font-body text-foreground'>
         <SheetHeroContainer
           id={sheet._id ?? ''}
           isEnrolled={isEnrolled}
@@ -393,10 +395,11 @@ const SheetPage = ({
 
             {/* Mobile Drawer Panel (Solid White Background) */}
             <div
-              className={`fixed inset-y-0 left-0 z-50 w-[85%] max-w-[340px] bg-white text-gray-900 border-r border-gray-200 p-4 shadow-2xl flex flex-col gap-3 lg:hidden transform transition-transform duration-300 ease-in-out ${isMobileSidebarOpen ? 'translate-x-0' : '-translate-x-full'
-                }`}
+              className={`fixed inset-y-0 left-0 z-50 w-[85%] max-w-[340px] bg-card text-foreground border-r border-border p-4 shadow-2xl flex flex-col gap-3 lg:hidden transform transition-transform duration-300 ease-in-out ${
+                isMobileSidebarOpen ? 'translate-x-0' : '-translate-x-full'
+              }`}
             >
-              <div className='flex items-center justify-between pb-3 border-b border-gray-100 bg-white'>
+              <div className='flex items-center justify-between pb-3 border-b border-border bg-card'>
                 <div className='flex items-center gap-2'>
                   <h2 className='font-semibold text-base text-gray-900'>
                     Questions
@@ -414,7 +417,7 @@ const SheetPage = ({
               </div>
 
               {!isLocked && (
-                <div className='pb-2 bg-white'>
+                <div className='pb-2 bg-card'>
                   <LinerProgressBar
                     completedChapters={completedQuestions}
                     totalChapters={totalQuestions}
@@ -422,7 +425,7 @@ const SheetPage = ({
                 </div>
               )}
 
-              <div className='flex flex-col gap-1.5 flex-1 overflow-y-auto pt-1 pr-1 custom-scrollbar scroll-smooth bg-white'>
+              <div className='flex flex-col gap-1.5 flex-1 overflow-y-auto pt-1 pr-1 custom-scrollbar scroll-smooth bg-card'>
                 {questions?.map(
                   ({
                     _id,
@@ -531,7 +534,7 @@ const SheetPage = ({
                       <div className='prose prose-slate max-w-none'>
                         <InterviewSheetMDXRenderer
                           mdxSource={sheet.meta || ''}
-                          theme='light'
+                          theme={pageTheme}
                         />
                       </div>
                     </div>
@@ -577,19 +580,20 @@ const SheetPage = ({
                     frequency={currentQuestion?.frequency}
                     priority={currentQuestion?.priority}
                     companyTypes={currentQuestion?.companyTypes}
-                    theme='light'
+                    theme={pageTheme}
                     isStarred={isStarred}
                     onToggleStar={handleStarToggle}
                     actions={[
                       currentQuestionId && (
                         <Button
                           key='complete'
-                          className={`w-auto self-start py-2.5 px-6 rounded-xl font-semibold text-xs sm:text-sm text-white shadow-xs transition-all duration-150 cursor-pointer ${!isEnrolled
-                            ? 'bg-primary hover:bg-primary/90 border-none text-white'
-                            : isQuestionCompleted
-                              ? 'bg-emerald-600 hover:bg-emerald-700 border-none text-white'
-                              : 'bg-primary hover:bg-primary/90 border-none text-white'
-                            }`}
+                          className={`w-auto self-start py-2.5 px-6 rounded-xl font-semibold text-xs sm:text-sm text-white shadow-xs transition-all duration-150 cursor-pointer ${
+                            !isEnrolled
+                              ? 'bg-primary hover:bg-primary/90 border-none text-white'
+                              : isQuestionCompleted
+                                ? 'bg-emerald-600 hover:bg-emerald-700 border-none text-white'
+                                : 'bg-primary hover:bg-primary/90 border-none text-white'
+                          }`}
                           isLoading={isLoading}
                           text={
                             isLoading
@@ -616,7 +620,7 @@ const SheetPage = ({
                         <ResourceTooltip
                           key='resources'
                           resources={questionResources}
-                          theme='light'
+                          theme={pageTheme}
                           className='mt-2'
                         />
                       ),
@@ -646,18 +650,18 @@ const SheetPage = ({
           meta={
             currentQuestionId
               ? {
-                sheetId: sheet._id.toString(),
-                sheetName: sheet.name || '',
-                questionId: currentQuestionId,
-                questionName:
-                  currentQuestion?.title || currentQuestion?.question || '',
-              }
+                  sheetId: sheet._id.toString(),
+                  sheetName: sheet.name || '',
+                  questionId: currentQuestionId,
+                  questionName:
+                    currentQuestion?.title || currentQuestion?.question || '',
+                }
               : {
-                sheetId: sheet._id.toString(),
-                sheetName: sheet.name || '',
-              }
+                  sheetId: sheet._id.toString(),
+                  sheetName: sheet.name || '',
+                }
           }
-          theme='light'
+          theme={pageTheme}
         />
       )}
     </Fragment>

--- a/apps/platform/src/pages/learn.tsx
+++ b/apps/platform/src/pages/learn.tsx
@@ -18,7 +18,7 @@ const LearnPage = ({ seoMeta }: PageProps) => {
 
   if (loadingUser) {
     return (
-      <div className='min-h-screen flex items-center justify-center bg-[#FAFAFC]'>
+      <div className='min-h-screen flex items-center justify-center bg-background'>
         <LoadingSpinner />
       </div>
     );

--- a/apps/platform/src/pages/projects/[projectSlug]/index.tsx
+++ b/apps/platform/src/pages/projects/[projectSlug]/index.tsx
@@ -350,7 +350,7 @@ const ProjectPage = ({
           <FlexContainer className='w-full gap-4' itemCenter={false}>
             {/* Sidebar with Progress Bar and Chapters */}
             <FlexContainer
-              className='border md:w-3/12 w-full px-2 gap-1 rounded self-baseline max-h-[80vh] overflow-y-auto bg-white'
+              className='border md:w-3/12 w-full px-2 gap-1 rounded self-baseline max-h-[80vh] overflow-y-auto bg-card border-border'
               itemCenter={false}
             >
               <div className='w-full sticky top-0 bg-inherit py-2'>

--- a/apps/platform/src/pages/shiksha/[courseSlug]/learn.tsx
+++ b/apps/platform/src/pages/shiksha/[courseSlug]/learn.tsx
@@ -10,6 +10,7 @@ import {
   SEO,
   SheetHeroContainer,
   Text,
+  useColorTheme,
 } from '@tbe/components';
 import { routes } from '@tbe/constants';
 import {
@@ -38,6 +39,7 @@ const CourseLearnPage = ({
   seoMeta,
   currentChapterId,
 }: CoursePageProps) => {
+  const pageTheme = useColorTheme();
   const router = useRouter();
   const [course, setCourse] = useState(initialCourse);
   const [isEnrolled, setIsEnrolled] = useState(
@@ -356,11 +358,11 @@ const CourseLearnPage = ({
 
             {/* Mobile Drawer Panel (Solid White Background) */}
             <div
-              className={`fixed inset-y-0 left-0 z-50 w-[85%] max-w-[340px] bg-white text-gray-900 border-r border-gray-200 p-4 shadow-2xl flex flex-col gap-3 lg:hidden transform transition-transform duration-300 ease-in-out ${
+              className={`fixed inset-y-0 left-0 z-50 w-[85%] max-w-[340px] bg-card text-foreground border-r border-border p-4 shadow-2xl flex flex-col gap-3 lg:hidden transform transition-transform duration-300 ease-in-out ${
                 isMobileSidebarOpen ? 'translate-x-0' : '-translate-x-full'
               }`}
             >
-              <div className='flex items-center justify-between pb-3 border-b border-gray-100 bg-white'>
+              <div className='flex items-center justify-between pb-3 border-b border-border bg-card'>
                 <div className='flex items-center gap-2'>
                   <h2 className='font-semibold text-base text-gray-900'>
                     Chapters
@@ -378,7 +380,7 @@ const CourseLearnPage = ({
               </div>
 
               {!isLocked && (
-                <div className='pb-2 bg-white'>
+                <div className='pb-2 bg-card'>
                   <LinerProgressBar
                     completedChapters={completedChapters}
                     totalChapters={totalChapters}
@@ -386,7 +388,7 @@ const CourseLearnPage = ({
                 </div>
               )}
 
-              <div className='flex flex-col gap-1.5 flex-1 overflow-y-auto pt-1 pr-1 custom-scrollbar scroll-smooth bg-white'>
+              <div className='flex flex-col gap-1.5 flex-1 overflow-y-auto pt-1 pr-1 custom-scrollbar scroll-smooth bg-card'>
                 {chapters?.map(({ _id, name, content, isCompleted }, index) => {
                   const chapterId = _id?.toString();
 
@@ -516,7 +518,7 @@ const CourseLearnPage = ({
                       <div className='prose prose-slate max-w-none text-muted-foreground'>
                         <InterviewSheetMDXRenderer
                           mdxSource={course.meta || ''}
-                          theme='light'
+                          theme={pageTheme}
                         />
                       </div>
                     </div>
@@ -557,7 +559,7 @@ const CourseLearnPage = ({
                     <div className='w-full'>
                       <InterviewSheetMDXRenderer
                         mdxSource={displayContent}
-                        theme='light'
+                        theme={pageTheme}
                       />
                     </div>
 
@@ -620,7 +622,7 @@ const CourseLearnPage = ({
                 chapters.find((c) => c._id.toString() === currentChapterIdState)
                   ?.name || '',
             }}
-            theme='light'
+            theme={pageTheme}
           />
         )}
       </div>

--- a/apps/platform/src/pages/topmate-sessions.tsx
+++ b/apps/platform/src/pages/topmate-sessions.tsx
@@ -19,7 +19,7 @@ import { Fragment } from 'react';
 
 // Custom card component specifically for topmate-sessions
 const TopmateServiceCard = ({ card }: { card: any }) => (
-  <div className='w-full bg-white rounded-2 shadow-sm border-2 border-accent hover:shadow-lg transition-all duration-300 p-6 h-full flex flex-col'>
+  <div className='w-full bg-card text-card-foreground rounded-2 shadow-sm border-2 border-border hover:shadow-lg transition-all duration-300 p-6 h-full flex flex-col'>
     {card.image && (
       <div className='flex justify-center mb-4'>
         <Image

--- a/apps/platform/src/pages/unskilled/index.tsx
+++ b/apps/platform/src/pages/unskilled/index.tsx
@@ -340,7 +340,7 @@ const UnskilledLandingPage = ({
               {evaluationData && (
                 <motion.div
                   animate={{ opacity: 1, y: 0 }}
-                  className='mt-12 bg-white shadow-md rounded-xl border border-gray-100 p-8 flex flex-col gap-8'
+                  className='mt-12 bg-card text-card-foreground shadow-md rounded-xl border border-border p-8 flex flex-col gap-8'
                   initial={{ opacity: 0, y: 20 }}
                   transition={{ duration: 0.5 }}
                 >

--- a/apps/platform/src/styles/globals.css
+++ b/apps/platform/src/styles/globals.css
@@ -7,6 +7,34 @@
   html {
     @apply scroll-smooth;
   }
+
+  :root {
+    --background: 0 0% 97%;
+    --foreground: 240 4% 10%;
+    --card: 0 0% 100%;
+    --card-foreground: 240 4% 10%;
+    --muted: 210 20% 96%;
+    --muted-foreground: 215 16% 40%;
+    --border: 214 20% 90%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 240 4% 10%;
+  }
+
+  .dark {
+    --background: 180 11% 2%;
+    --foreground: 0 0% 99%;
+    --card: 240 4% 8%;
+    --card-foreground: 0 0% 99%;
+    --muted: 240 4% 12%;
+    --muted-foreground: 240 5% 65%;
+    --border: 240 4% 16%;
+    --popover: 240 4% 8%;
+    --popover-foreground: 0 0% 99%;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+  }
 }
 
 /* Custom Classes */
@@ -54,57 +82,57 @@
 
   /* 2. Fonts */
   .heading-1 {
-    @apply text-4xl sm:text-5xl md:text-6xl lg:text-[64px] font-extrabold tracking-tight text-slate-900 leading-[1.1];
+    @apply text-4xl sm:text-5xl md:text-6xl lg:text-[64px] font-extrabold tracking-tight text-slate-900 dark:text-contentDark leading-[1.1];
   }
 
   .heading-2 {
-    @apply text-3xl sm:text-4xl md:text-5xl font-extrabold tracking-tight text-slate-900 leading-[1.15];
+    @apply text-3xl sm:text-4xl md:text-5xl font-extrabold tracking-tight text-slate-900 dark:text-contentDark leading-[1.15];
   }
 
   .heading-3 {
-    @apply text-2xl sm:text-3xl md:text-4xl lg:text-[40px] font-extrabold tracking-tight text-slate-900 leading-tight;
+    @apply text-2xl sm:text-3xl md:text-4xl lg:text-[40px] font-extrabold tracking-tight text-slate-900 dark:text-contentDark leading-tight;
   }
 
   .heading-4,
   .md-1 {
-    @apply text-xl sm:text-2xl md:text-3xl font-bold tracking-tight text-slate-900;
+    @apply text-xl sm:text-2xl md:text-3xl font-bold tracking-tight text-slate-900 dark:text-contentDark;
   }
 
   .heading-5 {
-    @apply text-lg sm:text-xl md:text-2xl font-bold tracking-tight text-slate-900;
+    @apply text-lg sm:text-xl md:text-2xl font-bold tracking-tight text-slate-900 dark:text-contentDark;
   }
 
   .subtitle {
-    @apply text-base sm:text-lg md:text-xl font-medium text-slate-600 leading-relaxed;
+    @apply text-base sm:text-lg md:text-xl font-medium text-slate-600 dark:text-zinc-300 leading-relaxed;
   }
 
   .paragraph {
-    @apply text-sm sm:text-base md:text-lg font-normal text-slate-600 leading-relaxed;
+    @apply text-sm sm:text-base md:text-lg font-normal text-slate-600 dark:text-zinc-300 leading-relaxed;
   }
 
   .strong-text {
-    @apply text-strong-text font-semibold text-contentLight;
+    @apply text-strong-text font-semibold text-contentLight dark:text-contentDark;
   }
 
   .pre-title {
-    @apply text-pre-title font-normal text-contentLight;
+    @apply text-pre-title font-normal text-contentLight dark:text-grey;
   }
 
   .button-text {
-    @apply text-button-text font-bold text-contentLight;
+    @apply text-button-text font-bold text-contentLight dark:text-contentDark;
   }
 
   .label {
-    @apply text-label font-semibold text-greyDark;
+    @apply text-label font-semibold text-greyDark dark:text-muted-foreground;
   }
 
   /* Link */
   .link {
-    @apply text-button-text text-contentLight;
+    @apply text-button-text text-contentLight dark:text-contentDark;
   }
 
   .button {
-    @apply rounded-1 text-button-text font-bold text-contentLight;
+    @apply rounded-1 text-button-text font-bold text-contentLight dark:text-contentDark;
   }
 
   .disabled {

--- a/apps/platform/tailwind.config.js
+++ b/apps/platform/tailwind.config.js
@@ -2,6 +2,7 @@ const { fontFamily } = require('tailwindcss/defaultTheme');
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx}',
     './src/components/**/*.{js,ts,jsx,tsx}',
@@ -63,6 +64,21 @@ module.exports = {
         greyDark: '#848484',
         accent: '#ECF1F4',
         lightBG: '#F8F8F8',
+        background: 'hsl(var(--background) / <alpha-value>)',
+        foreground: 'hsl(var(--foreground) / <alpha-value>)',
+        card: {
+          DEFAULT: 'hsl(var(--card) / <alpha-value>)',
+          foreground: 'hsl(var(--card-foreground) / <alpha-value>)',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted) / <alpha-value>)',
+          foreground: 'hsl(var(--muted-foreground) / <alpha-value>)',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover) / <alpha-value>)',
+          foreground: 'hsl(var(--popover-foreground) / <alpha-value>)',
+        },
+        border: 'hsl(var(--border) / <alpha-value>)',
       },
       spacing: {
         1: '8px',

--- a/packages/components/src/common/Theme/ThemeContext.tsx
+++ b/packages/components/src/common/Theme/ThemeContext.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+const HasThemeProviderContext = createContext(false);
+
+export const HasThemeProvider = HasThemeProviderContext.Provider;
+
+/** Returns true when the tree is wrapped in `@tbe/components` ThemeProvider. */
+export const useHasThemeProvider = () => useContext(HasThemeProviderContext);

--- a/packages/components/src/common/Theme/ThemeProvider.tsx
+++ b/packages/components/src/common/Theme/ThemeProvider.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import type { ThemeProviderProps } from "@tbe/interface";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+import { HasThemeProvider } from "./ThemeContext";
+
+const ThemeProvider = ({
+  children,
+  defaultTheme = "light",
+  attribute = "class",
+  enableSystem = false,
+  disableTransitionOnChange = true,
+}: ThemeProviderProps) => (
+  <HasThemeProvider value>
+    <NextThemesProvider
+      attribute={attribute}
+      defaultTheme={defaultTheme}
+      disableTransitionOnChange={disableTransitionOnChange}
+      enableSystem={enableSystem}
+    >
+      {children}
+    </NextThemesProvider>
+  </HasThemeProvider>
+);
+
+export default ThemeProvider;

--- a/packages/components/src/common/Theme/ThemeToggle.tsx
+++ b/packages/components/src/common/Theme/ThemeToggle.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import type { ThemeToggleProps } from "@tbe/interface";
+import { cn } from "@tbe/utils";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+import { useHasThemeProvider } from "./ThemeContext";
+
+const ThemeToggle = ({ className, theme: shellTheme }: ThemeToggleProps) => {
+  const hasThemeProvider = useHasThemeProvider();
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!hasThemeProvider) {
+    return null;
+  }
+
+  const isDark = mounted && resolvedTheme === "dark";
+  const isShellDark = shellTheme === "dark" || isDark;
+  const label = isDark ? "Switch to light mode" : "Switch to dark mode";
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      data-analytics-id="theme-toggle"
+      data-analytics-label={label}
+      className={cn(
+        "inline-flex h-6 w-6 shrink-0 items-center justify-center transition-opacity outline-none hover:opacity-70",
+        isShellDark ? "text-white" : "text-black",
+        className,
+      )}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+    >
+      {isDark ? (
+        <Sun aria-hidden="true" className="h-3 w-3" strokeWidth={2} />
+      ) : (
+        <Moon aria-hidden="true" className="h-3 w-3" strokeWidth={2} />
+      )}
+      <span className="sr-only">{label}</span>
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/packages/components/src/common/Theme/index.ts
+++ b/packages/components/src/common/Theme/index.ts
@@ -1,0 +1,4 @@
+export { useHasThemeProvider } from "./ThemeContext";
+export { default as ThemeProvider } from "./ThemeProvider";
+export { default as ThemeToggle } from "./ThemeToggle";
+export { useColorTheme } from "./useColorTheme";

--- a/packages/components/src/common/Theme/useColorTheme.ts
+++ b/packages/components/src/common/Theme/useColorTheme.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+import { useHasThemeProvider } from "./ThemeContext";
+
+/** Resolves the active color theme for page sections. Defaults to light. */
+export const useColorTheme = (): "light" | "dark" => {
+  const hasThemeProvider = useHasThemeProvider();
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!hasThemeProvider || !mounted) {
+    return "light";
+  }
+
+  return resolvedTheme === "dark" ? "dark" : "light";
+};

--- a/packages/components/src/containers/Cards/CardContainerA.tsx
+++ b/packages/components/src/containers/Cards/CardContainerA.tsx
@@ -16,7 +16,9 @@ const CardContainerA = ({
   theme = "light",
 }: CardContainerAProps) => (
   <Section
-    className={`md:px-8 md:py-8 px-2 py-4${theme === "dark" ? " bg-[#0A0A0A]" : ""}`}
+    className={`md:px-8 md:py-8 px-2 py-4${
+      theme === "dark" ? " bg-[#0A0A0A]" : " bg-transparent"
+    }`}
   >
     <FlexContainer className="gap-4" direction="col">
       <SectionHeaderContainer

--- a/packages/components/src/containers/Cards/Items/TestimonialCard.tsx
+++ b/packages/components/src/containers/Cards/Items/TestimonialCard.tsx
@@ -8,7 +8,7 @@ const TestimonialCard = ({
   content,
   work,
 }: TestimonialCardProps) => (
-  <div className="flex h-full flex-col justify-between rounded-2xl border border-zinc-200/80 bg-white/90 p-5 shadow-sm backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:border-[#FF5757]/40 hover:shadow-md select-none">
+  <div className="flex h-full flex-col justify-between rounded-2xl border border-zinc-200/80 bg-white/90 p-5 shadow-sm backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:border-[#FF5757]/40 hover:shadow-md select-none dark:border-zinc-700 dark:bg-zinc-900/90">
     <div>
       {/* Star Rating & Quote Accent */}
       <div className="flex items-center justify-between pb-3">
@@ -24,20 +24,20 @@ const TestimonialCard = ({
       </div>
 
       {/* Testimonial Content */}
-      <p className="text-xs sm:text-sm font-medium leading-relaxed text-zinc-600">
+      <p className="text-xs sm:text-sm font-medium leading-relaxed text-zinc-600 dark:text-zinc-300">
         "{content}"
       </p>
     </div>
 
     {/* Learner Info Footer */}
-    <div className="mt-4 flex items-center gap-3 border-t border-zinc-100 pt-3">
+    <div className="mt-4 flex items-center gap-3 border-t border-zinc-100 pt-3 dark:border-zinc-800">
       <img
         alt={imageAltText}
         className="h-10 w-10 rounded-full border-2 border-[#FF5757]/20 object-cover"
         src={`${image}`}
       />
       <div className="min-w-0 flex-1">
-        <h4 className="text-xs font-extrabold text-zinc-900 truncate">
+        <h4 className="text-xs font-extrabold text-zinc-900 truncate dark:text-zinc-100">
           {title}
         </h4>
         <p className="text-[10px] font-bold text-[#FF5757] truncate">{work}</p>

--- a/packages/components/src/containers/Page/Landing/AppShowcaseSections.tsx
+++ b/packages/components/src/containers/Page/Landing/AppShowcaseSections.tsx
@@ -34,8 +34,8 @@ const WidgetCard = ({
 }) => (
   <div className={`relative w-full ${className}`}>
     {/* Gradient border overlay */}
-    <div className="absolute -inset-px rounded-2xl bg-gradient-to-b from-zinc-200/80 via-zinc-200/30 to-transparent pointer-events-none" />
-    <div className="relative rounded-2xl border border-zinc-200/80 bg-white/95 p-4 sm:p-5 backdrop-blur-xl shadow-[0_8px_30px_rgb(0,0,0,0.04)]">
+    <div className="absolute -inset-px rounded-2xl bg-gradient-to-b from-zinc-200/80 via-zinc-200/30 to-transparent dark:from-zinc-700/80 dark:via-zinc-800/30 pointer-events-none" />
+    <div className="relative rounded-2xl border border-zinc-200/80 bg-white/95 p-4 sm:p-5 backdrop-blur-xl shadow-[0_8px_30px_rgb(0,0,0,0.04)] dark:border-zinc-700 dark:bg-zinc-900/95 dark:shadow-[0_8px_30px_rgb(0,0,0,0.35)]">
       {children}
     </div>
   </div>
@@ -50,7 +50,7 @@ const RowItem = ({
   className?: string;
 }) => (
   <div
-    className={`flex items-center justify-between gap-2 rounded-xl border border-zinc-100/80 bg-zinc-50/60 px-2.5 py-2 sm:px-3 sm:py-2.5 ring-1 ring-zinc-100/60 transition-colors hover:bg-white/80 ${className}`}
+    className={`flex items-center justify-between gap-2 rounded-xl border border-zinc-100 dark:border-zinc-800/80 bg-zinc-50/60 px-2.5 py-2 sm:px-3 sm:py-2.5 ring-1 ring-zinc-100/60 transition-colors hover:bg-white/80 dark:border-zinc-700/80 dark:bg-zinc-800/60 dark:ring-zinc-700/60 dark:hover:bg-zinc-800 ${className}`}
   >
     {children}
   </div>
@@ -256,8 +256,9 @@ export function AppShowcaseSections({
               focusText="Learn Tech with Mini Courses."
               headingLevel={3}
               textCenter={false}
+              theme={theme}
             />
-            <Text className="paragraph text-grey" level="p">
+            <Text className="paragraph" level="p">
               Master complex tech topics through bite-sized, free courses
               designed for busy professionals and students.
             </Text>
@@ -271,7 +272,7 @@ export function AppShowcaseSections({
               ].map(({ label, icon: Icon }) => (
                 <div
                   key={label}
-                  className="flex items-center gap-2.5 rounded-xl border border-zinc-200/80 bg-white/70 px-3 py-2 text-xs font-semibold text-zinc-800 shadow-sm backdrop-blur-sm transition-all hover:border-zinc-300 hover:bg-white"
+                  className="flex items-center gap-2.5 rounded-xl border border-zinc-200/80 bg-white/70 px-3 py-2 text-xs font-semibold text-zinc-800 dark:text-zinc-200 shadow-sm backdrop-blur-sm transition-all hover:border-zinc-300 hover:bg-white dark:border-zinc-700 dark:bg-zinc-800/90 dark:text-zinc-100 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
                 >
                   <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-[rgba(255,87,87,0.12)] text-[#FF5757] ring-1 ring-[rgba(255,87,87,0.20)]">
                     <Icon className="h-3.5 w-3.5" />
@@ -303,16 +304,16 @@ export function AppShowcaseSections({
           >
             <WidgetCard>
               {/* Header */}
-              <div className="flex items-center justify-between border-b border-zinc-100 pb-3 mb-3">
+              <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800 pb-3 mb-3">
                 <div className="flex items-center gap-2">
                   <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[rgba(255,87,87,0.15)] ring-1 ring-[rgba(255,87,87,0.30)]">
                     <BookOpen className="h-3.5 w-3.5 text-[#FF5757]" />
                   </div>
                   <div className="min-w-0">
-                    <h4 className="text-xs font-bold text-zinc-900 truncate">
+                    <h4 className="text-xs font-bold text-zinc-900 dark:text-zinc-100 truncate">
                       Free Mini Courses
                     </h4>
-                    <p className="text-[10px] text-zinc-500 font-medium">
+                    <p className="text-[10px] text-zinc-500 dark:text-zinc-400 font-medium">
                       Bite-sized learning paths
                     </p>
                   </div>
@@ -355,7 +356,7 @@ export function AppShowcaseSections({
                       <mod.icon
                         className={`h-3.5 w-3.5 shrink-0 ${mod.color}`}
                       />
-                      <span className="text-xs font-semibold text-zinc-800 truncate">
+                      <span className="text-xs font-semibold text-zinc-800 dark:text-zinc-200 truncate">
                         {mod.name}
                       </span>
                     </div>
@@ -387,16 +388,16 @@ export function AppShowcaseSections({
             className="w-full order-2 lg:order-1"
           >
             <WidgetCard>
-              <div className="flex items-center justify-between border-b border-zinc-100 pb-3 mb-3">
+              <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800 pb-3 mb-3">
                 <div className="flex items-center gap-2 min-w-0">
                   <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[rgba(255,87,87,0.15)] ring-1 ring-[rgba(255,87,87,0.30)]">
                     <MessageSquare className="h-3.5 w-3.5 text-[#FF5757]" />
                   </div>
                   <div className="min-w-0">
-                    <h4 className="text-xs font-bold text-zinc-900 truncate">
+                    <h4 className="text-xs font-bold text-zinc-900 dark:text-zinc-100 truncate">
                       Interview Question Bank
                     </h4>
-                    <p className="text-[10px] text-zinc-500 font-medium">
+                    <p className="text-[10px] text-zinc-500 dark:text-zinc-400 font-medium">
                       JavaScript · React · Node · System Design
                     </p>
                   </div>
@@ -433,7 +434,7 @@ export function AppShowcaseSections({
                     <div className="flex items-center gap-2 min-w-0">
                       <MessageSquare className="h-3.5 w-3.5 shrink-0 text-[#FF5757]/70" />
                       <div className="min-w-0">
-                        <h5 className="text-xs font-semibold text-zinc-800 truncate">
+                        <h5 className="text-xs font-semibold text-zinc-800 dark:text-zinc-200 truncate">
                           {q.question}
                         </h5>
                         <p className="text-[10px] text-zinc-400 font-medium">
@@ -463,8 +464,9 @@ export function AppShowcaseSections({
               focusText="Crack Tech Interviews with Curated Question Banks."
               headingLevel={3}
               textCenter={false}
+              theme={theme}
             />
-            <Text className="paragraph text-grey" level="p">
+            <Text className="paragraph" level="p">
               Access structured interview question sheets for JavaScript, React,
               Node.js, Python, Java, and System Design — organised by role level
               so you always practise what matters most.
@@ -478,7 +480,7 @@ export function AppShowcaseSections({
               ].map((bullet) => (
                 <li key={bullet} className="flex items-start gap-2.5">
                   <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                  <span className="text-xs sm:text-sm font-semibold text-zinc-800 leading-snug">
+                  <span className="text-xs sm:text-sm font-semibold text-zinc-800 dark:text-zinc-200 leading-snug">
                     {bullet}
                   </span>
                 </li>
@@ -520,8 +522,9 @@ export function AppShowcaseSections({
               focusText="Master Data Structures Without the Random Grind."
               headingLevel={3}
               textCenter={false}
+              theme={theme}
             />
-            <Text className="paragraph text-grey" level="p">
+            <Text className="paragraph" level="p">
               Stop solving random LeetCode questions. Follow a structured,
               topic-wise roadmap that builds pattern intuition step-by-step for
               FAANG & startup interviews.
@@ -535,7 +538,7 @@ export function AppShowcaseSections({
               ].map((bullet) => (
                 <li key={bullet} className="flex items-start gap-2.5">
                   <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                  <span className="text-xs sm:text-sm font-semibold text-zinc-800 leading-snug">
+                  <span className="text-xs sm:text-sm font-semibold text-zinc-800 dark:text-zinc-200 leading-snug">
                     {bullet}
                   </span>
                 </li>
@@ -564,16 +567,16 @@ export function AppShowcaseSections({
           >
             <WidgetCard>
               {/* Header */}
-              <div className="flex items-center justify-between border-b border-zinc-100 pb-3 mb-3">
+              <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800 pb-3 mb-3">
                 <div className="flex items-center gap-2">
                   <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[rgba(255,87,87,0.15)] ring-1 ring-[rgba(255,87,87,0.30)]">
                     <Layers className="h-3.5 w-3.5 text-[#FF5757]" />
                   </div>
                   <div className="min-w-0">
-                    <h4 className="text-xs font-bold text-zinc-900 truncate">
+                    <h4 className="text-xs font-bold text-zinc-900 dark:text-zinc-100 truncate">
                       DSA Roadmap & Streak
                     </h4>
-                    <p className="text-[10px] text-zinc-500 font-medium">
+                    <p className="text-[10px] text-zinc-500 dark:text-zinc-400 font-medium">
                       14 Days Streak • 42 Solved
                     </p>
                   </div>
@@ -592,7 +595,7 @@ export function AppShowcaseSections({
                     className={`shrink-0 rounded-lg px-2.5 py-1 text-[11px] font-bold transition-all ${
                       dsaActiveTopic === topic
                         ? "bg-[#FF5757] text-white"
-                        : "bg-zinc-100/80 text-zinc-600 hover:text-zinc-900 ring-1 ring-zinc-200/60"
+                        : "bg-zinc-100/80 text-zinc-600 hover:text-zinc-900 ring-1 ring-zinc-200/60 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:text-zinc-100 dark:ring-zinc-700"
                     }`}
                   >
                     {topic}
@@ -608,7 +611,7 @@ export function AppShowcaseSections({
                       <prob.icon
                         className={`h-3.5 w-3.5 shrink-0 ${prob.color}`}
                       />
-                      <span className="text-xs font-semibold text-zinc-800 truncate">
+                      <span className="text-xs font-semibold text-zinc-800 dark:text-zinc-200 truncate">
                         {prob.name}
                       </span>
                     </div>
@@ -617,7 +620,7 @@ export function AppShowcaseSections({
                         className={`rounded-md px-1.5 py-0.5 text-[9px] font-extrabold ring-1 ${
                           prob.diff === "Easy"
                             ? "bg-[rgba(255,87,87,0.10)] text-[#FF5757] ring-[rgba(255,87,87,0.20)]"
-                            : "bg-zinc-100 text-zinc-500 ring-zinc-200/60"
+                            : "bg-zinc-100 text-zinc-500 ring-zinc-200/60 dark:bg-zinc-800 dark:text-zinc-400 dark:ring-zinc-700"
                         }`}
                       >
                         {prob.diff}
@@ -651,16 +654,16 @@ export function AppShowcaseSections({
             className="w-full order-2 lg:order-1"
           >
             <WidgetCard>
-              <div className="flex items-center justify-between border-b border-zinc-100 pb-3 mb-3">
+              <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800 pb-3 mb-3">
                 <div className="flex items-center gap-2 min-w-0">
                   <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[rgba(255,87,87,0.15)] ring-1 ring-[rgba(255,87,87,0.30)]">
                     <GraduationCap className="h-3.5 w-3.5 text-[#FF5757]" />
                   </div>
                   <div className="min-w-0">
-                    <h4 className="text-xs font-bold text-zinc-900 truncate">
+                    <h4 className="text-xs font-bold text-zinc-900 dark:text-zinc-100 truncate">
                       Campus Placement Readiness
                     </h4>
-                    <p className="text-[10px] text-zinc-500 font-medium">
+                    <p className="text-[10px] text-zinc-500 dark:text-zinc-400 font-medium">
                       Aptitude, CS Core & Interview Sheets
                     </p>
                   </div>
@@ -696,10 +699,10 @@ export function AppShowcaseSections({
                 ].map((mod) => (
                   <div
                     key={mod.title}
-                    className="rounded-xl border border-zinc-100/80 bg-zinc-50/60 p-2.5 ring-1 ring-zinc-100/60 space-y-1.5"
+                    className="rounded-xl border border-zinc-100 dark:border-zinc-800/80 bg-zinc-50/60 p-2.5 ring-1 ring-zinc-100/60 space-y-1.5"
                   >
                     <div className="flex items-start justify-between gap-1">
-                      <span className="text-[11px] font-bold text-zinc-800 leading-tight">
+                      <span className="text-[11px] font-bold text-zinc-800 dark:text-zinc-200 leading-tight">
                         {mod.title}
                       </span>
                       <span className="text-[10px] font-extrabold text-[#FF5757] shrink-0">
@@ -734,8 +737,9 @@ export function AppShowcaseSections({
               focusText="Ace Campus Placements from Day One."
               headingLevel={3}
               textCenter={false}
+              theme={theme}
             />
-            <Text className="paragraph text-grey" level="p">
+            <Text className="paragraph" level="p">
               Built specifically for college students to conquer aptitude tests,
               core CS fundamentals (OS, DBMS, CN, OOPS), and campus interview
               rounds.
@@ -749,7 +753,7 @@ export function AppShowcaseSections({
               ].map((bullet) => (
                 <li key={bullet} className="flex items-start gap-2.5">
                   <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                  <span className="text-xs sm:text-sm font-semibold text-zinc-800 leading-snug">
+                  <span className="text-xs sm:text-sm font-semibold text-zinc-800 dark:text-zinc-200 leading-snug">
                     {bullet}
                   </span>
                 </li>
@@ -791,8 +795,9 @@ export function AppShowcaseSections({
               focusText="Build ATS-Friendly Resumes That Get Calls."
               headingLevel={3}
               textCenter={false}
+              theme={theme}
             />
-            <Text className="paragraph text-grey" level="p">
+            <Text className="paragraph" level="p">
               Score your resume against ATS screeners, optimize bullet points
               with action verbs, and export recruiter-approved tech resume
               templates instantly.
@@ -806,7 +811,7 @@ export function AppShowcaseSections({
               ].map((bullet) => (
                 <li key={bullet} className="flex items-start gap-2.5">
                   <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                  <span className="text-xs sm:text-sm font-semibold text-zinc-800 leading-snug">
+                  <span className="text-xs sm:text-sm font-semibold text-zinc-800 dark:text-zinc-200 leading-snug">
                     {bullet}
                   </span>
                 </li>
@@ -834,16 +839,16 @@ export function AppShowcaseSections({
             className="w-full"
           >
             <WidgetCard>
-              <div className="flex items-center justify-between border-b border-zinc-100 pb-3 mb-3">
+              <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800 pb-3 mb-3">
                 <div className="flex items-center gap-2 min-w-0">
                   <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[rgba(255,87,87,0.15)] ring-1 ring-[rgba(255,87,87,0.30)]">
                     <FileCheck className="h-3.5 w-3.5 text-[#FF5757]" />
                   </div>
                   <div className="min-w-0">
-                    <h4 className="text-xs font-bold text-zinc-900">
+                    <h4 className="text-xs font-bold text-zinc-900 dark:text-zinc-100">
                       Live ATS Score Inspector
                     </h4>
-                    <p className="text-[10px] text-zinc-500 font-medium">
+                    <p className="text-[10px] text-zinc-500 dark:text-zinc-400 font-medium">
                       Software Engineer Template
                     </p>
                   </div>
@@ -876,7 +881,7 @@ export function AppShowcaseSections({
                   <RowItem key={item.label}>
                     <div className="flex items-center gap-2 min-w-0">
                       <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-[#FF5757]/70" />
-                      <span className="text-xs font-semibold text-zinc-800 truncate">
+                      <span className="text-xs font-semibold text-zinc-800 dark:text-zinc-200 truncate">
                         {item.label}
                       </span>
                     </div>
@@ -908,16 +913,16 @@ export function AppShowcaseSections({
             className="w-full order-2 lg:order-1"
           >
             <WidgetCard>
-              <div className="flex items-center justify-between border-b border-zinc-100 pb-3 mb-3">
+              <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800 pb-3 mb-3">
                 <div className="flex items-center gap-2 min-w-0">
                   <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[rgba(255,87,87,0.15)] ring-1 ring-[rgba(255,87,87,0.30)]">
                     <UserCheck className="h-3.5 w-3.5 text-[#FF5757]" />
                   </div>
                   <div className="min-w-0">
-                    <h4 className="text-xs font-bold text-zinc-900 truncate">
+                    <h4 className="text-xs font-bold text-zinc-900 dark:text-zinc-100 truncate">
                       Job Search & Recruiter Pipeline
                     </h4>
-                    <p className="text-[10px] text-zinc-500 font-medium">
+                    <p className="text-[10px] text-zinc-500 dark:text-zinc-400 font-medium">
                       Applications & Recruiter Network
                     </p>
                   </div>
@@ -952,7 +957,7 @@ export function AppShowcaseSections({
                 ].map((job) => (
                   <RowItem key={job.company}>
                     <div className="min-w-0">
-                      <h5 className="text-xs font-semibold text-zinc-800 truncate">
+                      <h5 className="text-xs font-semibold text-zinc-800 dark:text-zinc-200 truncate">
                         {job.company}
                       </h5>
                       <p className="text-[10px] font-medium text-zinc-400 truncate">
@@ -981,8 +986,9 @@ export function AppShowcaseSections({
               focusText="Streamline Your Job Search & Recruiter Hub."
               headingLevel={3}
               textCenter={false}
+              theme={theme}
             />
-            <Text className="paragraph text-grey" level="p">
+            <Text className="paragraph" level="p">
               Store recruiter contacts, organize job applications, log daily
               interview practice hours, and share your verified readiness
               journey with employers.
@@ -996,7 +1002,7 @@ export function AppShowcaseSections({
               ].map((bullet) => (
                 <li key={bullet} className="flex items-start gap-2.5">
                   <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                  <span className="text-xs sm:text-sm font-semibold text-zinc-800 leading-snug">
+                  <span className="text-xs sm:text-sm font-semibold text-zinc-800 dark:text-zinc-200 leading-snug">
                     {bullet}
                   </span>
                 </li>
@@ -1038,8 +1044,9 @@ export function AppShowcaseSections({
               focusText="Free Open-Source Tech Vault for Developers."
               headingLevel={3}
               textCenter={false}
+              theme={theme}
             />
-            <Text className="paragraph text-grey" level="p">
+            <Text className="paragraph" level="p">
               Access curated developer roadmaps, tech interview cheatsheets,
               system design primers, and open-source project guides — 100% free
               forever.
@@ -1053,7 +1060,7 @@ export function AppShowcaseSections({
               ].map((bullet) => (
                 <li key={bullet} className="flex items-start gap-2.5">
                   <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                  <span className="text-xs sm:text-sm font-semibold text-zinc-800 leading-snug">
+                  <span className="text-xs sm:text-sm font-semibold text-zinc-800 dark:text-zinc-200 leading-snug">
                     {bullet}
                   </span>
                 </li>
@@ -1081,16 +1088,16 @@ export function AppShowcaseSections({
             className="w-full"
           >
             <WidgetCard>
-              <div className="flex items-center justify-between border-b border-zinc-100 pb-3 mb-3">
+              <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800 pb-3 mb-3">
                 <div className="flex items-center gap-2 min-w-0">
                   <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[rgba(255,87,87,0.15)] ring-1 ring-[rgba(255,87,87,0.30)]">
                     <FolderGit2 className="h-3.5 w-3.5 text-[#FF5757]" />
                   </div>
                   <div className="min-w-0">
-                    <h4 className="text-xs font-bold text-zinc-900">
+                    <h4 className="text-xs font-bold text-zinc-900 dark:text-zinc-100">
                       Developer Vault
                     </h4>
-                    <p className="text-[10px] text-zinc-500 font-medium">
+                    <p className="text-[10px] text-zinc-500 dark:text-zinc-400 font-medium">
                       Cheatsheets & Study Guides
                     </p>
                   </div>
@@ -1131,7 +1138,7 @@ export function AppShowcaseSections({
                     <div className="flex items-center gap-2 min-w-0">
                       <FileText className="h-3.5 w-3.5 shrink-0 text-[#FF5757]/70" />
                       <div className="min-w-0">
-                        <h5 className="text-xs font-semibold text-zinc-800 truncate">
+                        <h5 className="text-xs font-semibold text-zinc-800 dark:text-zinc-200 truncate">
                           {res.title}
                         </h5>
                         <p className="text-[10px] text-zinc-400 font-medium">

--- a/packages/components/src/containers/Page/Landing/CollegeEventsSection.tsx
+++ b/packages/components/src/containers/Page/Landing/CollegeEventsSection.tsx
@@ -12,7 +12,7 @@ const CollegeEventsSection = () => (
         textCenter
       />
 
-      <Text className="paragraph text-grey max-w-2xl mx-auto" level="p">
+      <Text className="paragraph max-w-2xl mx-auto" level="p">
         Bring cutting-edge tech education to your campus! Join our network of
         college partners and host exciting tech events, workshops, and learning
         sessions.
@@ -32,7 +32,7 @@ const CollegeEventsSection = () => (
           href={LINKS.viewSessionDetails}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 rounded-lg border border-zinc-300 bg-white px-5 py-2.5 text-xs font-bold sm:text-sm text-zinc-800 transition-colors duration-200 hover:bg-zinc-50"
+          className="inline-flex items-center gap-2 rounded-lg border border-zinc-300 bg-white px-5 py-2.5 text-xs font-bold sm:text-sm text-zinc-800 transition-colors duration-200 hover:bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700"
         >
           View Session Details
         </a>

--- a/packages/components/src/containers/Page/common/GradientContainer.tsx
+++ b/packages/components/src/containers/Page/common/GradientContainer.tsx
@@ -11,7 +11,10 @@ const GradientContainer = ({
 }: GradientContainerProps) => (
   <div
     className={`flex-auto rounded-2 border ${className} ${
-      backgroundColor ?? (theme === "dark" ? "bg-[#111]" : "bg-white")
+      backgroundColor ??
+      (theme === "dark"
+        ? "bg-[#111] border-zinc-800"
+        : "bg-white dark:bg-card border-transparent dark:border-border")
     } hover:shadow-2xl
       transition-all duration-300 ${suppressHoverScale ? "" : "hover:scale-105"}`}
   >

--- a/packages/components/src/containers/Page/common/ModernLandingHero.tsx
+++ b/packages/components/src/containers/Page/common/ModernLandingHero.tsx
@@ -35,7 +35,7 @@ const ModernLandingHero = ({
   stats,
   previewContent,
 }: ModernLandingHeroProps) => (
-  <Section className="bg-lightBG">
+  <Section className="bg-background">
     <div className="max-w-7xl mx-auto px-8 py-8">
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-center">
         {/* Left: Content */}
@@ -51,7 +51,7 @@ const ModernLandingHero = ({
                 className="text-4xl lg:text-5xl font-bold leading-tight"
                 level="h1"
               >
-                <span className="text-black">{heading}</span>{" "}
+                <span className="text-foreground">{heading}</span>{" "}
                 <span className="text-primary">{focusText}</span>
               </Text>
             </motion.div>
@@ -61,7 +61,10 @@ const ModernLandingHero = ({
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.2 }}
             >
-              <Text level="p" className="text-xl text-gray-600 leading-relaxed">
+              <Text
+                level="p"
+                className="text-xl text-muted-foreground leading-relaxed"
+              >
                 {heroText}
               </Text>
             </motion.div>
@@ -78,7 +81,7 @@ const ModernLandingHero = ({
               {stats.map((stat, index) => (
                 <div key={index} className="flex items-center gap-2">
                   <span className="text-primary">{stat.icon}</span>
-                  <span className="text-gray-600">{stat.text}</span>
+                  <span className="text-muted-foreground">{stat.text}</span>
                 </div>
               ))}
             </motion.div>
@@ -101,7 +104,7 @@ const ModernLandingHero = ({
             {React.isValidElement(secondaryButton)
               ? React.cloneElement(secondaryButton as any, {
                   className:
-                    `${(secondaryButton as any).props.className || ""} bg-white border-1 border-primary text-black rounded-lg hover:bg-primary/10 focus:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-primary transition-colors duration-200`.trim(),
+                    `${(secondaryButton as any).props.className || ""} bg-card border-1 border-primary text-foreground rounded-lg hover:bg-primary/10 focus:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-primary transition-colors duration-200`.trim(),
                 })
               : secondaryButton}
           </motion.div>
@@ -115,20 +118,20 @@ const ModernLandingHero = ({
             transition={{ duration: 0.6, delay: 0.8 }}
             className="lg:col-span-1"
           >
-            <div className="bg-white rounded-lg shadow-2xl p-6 text-gray-900 transform hover:scale-105 transition-transform duration-300">
-              <div className="aspect-video bg-gradient-to-br from-blue-100 to-purple-100 rounded-lg flex items-center justify-center mb-4">
+            <div className="bg-card text-card-foreground rounded-lg shadow-2xl p-6 transform hover:scale-105 transition-transform duration-300 border border-border">
+              <div className="aspect-video bg-gradient-to-br from-blue-100 to-purple-100 dark:from-zinc-800 dark:to-zinc-700 rounded-lg flex items-center justify-center mb-4">
                 <FaPlay className="text-4xl text-primary" />
               </div>
               <Text level="p" className="font-semibold mb-2">
                 {previewContent.title}
               </Text>
-              <Text level="p" className="text-sm text-gray-600 mb-4">
+              <Text level="p" className="text-sm text-muted-foreground mb-4">
                 {previewContent.description}
               </Text>
               <Button
                 text={previewContent.buttonText}
                 variant="PRIMARY"
-                className="w-full hover:bg-gray-100 hover:text-primary"
+                className="w-full hover:bg-muted hover:text-primary"
                 onClick={previewContent.onPreviewClick}
               />
             </div>

--- a/packages/components/src/containers/Page/common/PlatformLandingHero.tsx
+++ b/packages/components/src/containers/Page/common/PlatformLandingHero.tsx
@@ -210,7 +210,7 @@ const FeatureCard: React.FC<FeatureCardProps> = ({
       <motion.div
         whileHover={{ y: -4, scale: 1.03, rotate: 0 }}
         transition={{ duration: 0.25, ease: "easeOut" }}
-        className={`bg-white/95 backdrop-blur-md rounded-xl sm:rounded-2xl p-3 sm:p-4 shadow-[0_8px_25px_-8px_rgba(0,0,0,0.06)] hover:shadow-xl hover:shadow-red-500/10 border border-slate-100/90 transition-all duration-300 w-full lg:w-[235px] xl:w-[250px] transform ${rotateClass}`}
+        className={`bg-white/95 dark:bg-zinc-900/95 backdrop-blur-md rounded-xl sm:rounded-2xl p-3 sm:p-4 shadow-[0_8px_25px_-8px_rgba(0,0,0,0.06)] hover:shadow-xl hover:shadow-red-500/10 border border-slate-100/90 dark:border-zinc-700/90 transition-all duration-300 w-full lg:w-[235px] xl:w-[250px] transform ${rotateClass}`}
       >
         <div className="flex items-center gap-3">
           <div
@@ -219,10 +219,10 @@ const FeatureCard: React.FC<FeatureCardProps> = ({
             {icon}
           </div>
           <div className="flex-1 min-w-0">
-            <h4 className="text-xs sm:text-sm font-bold text-slate-900 leading-tight group-hover:text-[#FF4D4D] transition-colors duration-200 truncate">
+            <h4 className="text-xs sm:text-sm font-bold text-slate-900 dark:text-contentDark leading-tight group-hover:text-[#FF4D4D] transition-colors duration-200 truncate">
               {title}
             </h4>
-            <p className="text-[10px] sm:text-[11px] text-slate-500 mt-0.5 leading-tight line-clamp-2 font-normal">
+            <p className="text-[10px] sm:text-[11px] text-slate-500 dark:text-zinc-400 mt-0.5 leading-tight line-clamp-2 font-normal">
               {subtitle}
             </p>
           </div>
@@ -251,7 +251,7 @@ export const PlatformLandingHero: React.FC<PlatformLandingHeroProps> = ({
     });
 
   return (
-    <section className="relative w-full overflow-hidden bg-[#FAFAFC] py-6 sm:py-12 md:py-16 lg:py-24">
+    <section className="relative w-full overflow-hidden bg-[#FAFAFC] dark:bg-dark py-6 sm:py-12 md:py-16 lg:py-24">
       {/* --- Responsive Ambient Background Lights & Orbit Rings --- */}
       <div
         aria-hidden
@@ -597,7 +597,7 @@ export const PlatformLandingHero: React.FC<PlatformLandingHeroProps> = ({
               initial={{ y: 16, opacity: 0 }}
               animate={{ y: 0, opacity: 1 }}
               transition={{ duration: 0.6, delay: 0.1 }}
-              className="text-3xl sm:text-5xl lg:text-6xl font-extrabold text-slate-900 tracking-tight leading-[1.15] sm:leading-[1.12]"
+              className="text-3xl sm:text-5xl lg:text-6xl font-extrabold text-slate-900 dark:text-contentDark tracking-tight leading-[1.15] sm:leading-[1.12]"
             >
               Everything You Need <br className="hidden sm:inline" />
               to Learn. <span className="text-[#FF4D4D]">Practice.</span>{" "}
@@ -610,7 +610,7 @@ export const PlatformLandingHero: React.FC<PlatformLandingHeroProps> = ({
               initial={{ y: 16, opacity: 0 }}
               animate={{ y: 0, opacity: 1 }}
               transition={{ duration: 0.6, delay: 0.2 }}
-              className="text-slate-600 font-medium text-sm sm:text-base lg:text-lg mt-3 sm:mt-4 max-w-md sm:max-w-lg leading-relaxed"
+              className="text-slate-600 dark:text-zinc-200 font-medium text-sm sm:text-base lg:text-lg mt-3 sm:mt-4 max-w-md sm:max-w-lg leading-relaxed"
             >
               From core subjects to real world questions,{" "}
               <br className="hidden sm:inline" />

--- a/packages/components/src/containers/Page/common/SectionHeaderContainer.tsx
+++ b/packages/components/src/containers/Page/common/SectionHeaderContainer.tsx
@@ -36,7 +36,7 @@ const SectionHeaderContainer = ({
       </Text>
       {subtext && (
         <Text
-          className={`pre-text ${isDark ? "text-gray-400" : "text-greyDark"}`}
+          className={`pre-text ${isDark ? "text-gray-400" : "text-greyDark dark:text-zinc-400"}`}
           level="span"
           textCenter={textCenter}
         >

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -46,6 +46,12 @@ export { default as StarButton } from "./common/Buttons/StarButton";
 export { default as ToggleButton } from "./common/Buttons/ToggleButton";
 export { default as UserPointButton } from "./common/Buttons/UserPointButton";
 export { default as Carousel } from "./common/Carousel";
+export {
+  ThemeProvider,
+  ThemeToggle,
+  useColorTheme,
+  useHasThemeProvider,
+} from "./common/Theme";
 /** @deprecated Use `CelebrationAnimation` from `@tbe/gamification` instead */
 export { default as CelebrationAnimation } from "./common/CelebrationAnimation";
 export { default as CertificateBanner } from "./common/Certificate/CertificateBanner";

--- a/packages/components/src/layout/LearningEnvironmentLayout.tsx
+++ b/packages/components/src/layout/LearningEnvironmentLayout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { Fragment, useState } from "react";
 
 import { FlexContainer, LearningSidebarPanel, LoadingSpinner, Text } from "..";
+import { useColorTheme, useHasThemeProvider } from "../common/Theme";
 import LearningNavbar from "./LearningNavbar";
 
 export interface LearningEnvironmentLayoutProps {
@@ -29,10 +30,14 @@ const LearningEnvironmentLayout = ({
   completedItems = 0,
 }: LearningEnvironmentLayoutProps) => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const hasThemeProvider = useHasThemeProvider();
+  const colorTheme = useColorTheme();
+  // Preserve prior dark learning chrome when no ThemeProvider is present.
+  const sidebarTheme = hasThemeProvider ? colorTheme : "dark";
 
   return (
     <div
-      className={`flex flex-col bg-black text-white ${layoutMode === "workspace" ? "min-h-screen md:h-screen md:overflow-hidden" : "min-h-screen"}`}
+      className={`flex flex-col bg-background text-foreground ${layoutMode === "workspace" ? "min-h-screen md:h-screen md:overflow-hidden" : "min-h-screen"}`}
     >
       {/* Top Navbar */}
       <LearningNavbar
@@ -42,76 +47,66 @@ const LearningEnvironmentLayout = ({
         showGamification={showGamification}
       />
 
-      {/* Main Content Area */}
-      <main
-        className={`flex-1 min-h-0 w-full pt-[72px] flex flex-col items-center ${layoutMode === "workspace" ? "overflow-y-auto md:overflow-hidden" : ""}`}
+      <div
+        className={`flex-1 flex flex-col ${layoutMode === "workspace" ? "pt-[72px] min-h-0" : "pt-[72px]"}`}
       >
         {isLoading ? (
-          <div className="flex flex-col h-full min-h-[60vh] w-full items-center justify-center">
-            <LoadingSpinner height={8} width={8} />
-            <Text level="p" className="mt-4 text-gray-400">
+          <FlexContainer className="flex-1 items-center justify-center">
+            <LoadingSpinner />
+            <Text level="p" className="mt-4 text-muted-foreground">
               Loading environment...
             </Text>
-          </div>
-        ) : layoutMode === "centered" ? (
-          <FlexContainer
-            className="w-full max-w-[1000px] shrink-0 mx-auto px-4 py-6 gap-4"
-            itemCenter={false}
-            justifyCenter={false}
-          >
-            <div className="w-full h-full">{children}</div>
           </FlexContainer>
         ) : (
-          /* Workspace Mode (e.g. DSA Split Panes) - Full height minus navbar */
-          <div className="flex-1 w-full flex flex-col min-h-0">{children}</div>
+          children
         )}
-      </main>
+      </div>
 
-      {/* Slide-out Sidebar Drawer for Mobile & Desktop */}
+      {/* Mobile Sidebar */}
       {sidebarContent && (
-        <Transition show={sidebarOpen} as={Fragment}>
-          <Dialog as="div" className="relative z-50" onClose={setSidebarOpen}>
+        <Transition.Root as={Fragment} show={sidebarOpen}>
+          <Dialog
+            as="div"
+            className="relative z-50 lg:hidden"
+            onClose={setSidebarOpen}
+          >
             <Transition.Child
               as={Fragment}
-              enter="transition-opacity ease-out duration-200"
+              enter="transition-opacity ease-linear duration-300"
               enterFrom="opacity-0"
               enterTo="opacity-100"
-              leave="transition-opacity ease-in duration-150"
+              leave="transition-opacity ease-linear duration-300"
               leaveFrom="opacity-100"
               leaveTo="opacity-0"
             >
-              <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" />
+              <div className="fixed inset-0 bg-black/80" />
             </Transition.Child>
 
-            <div className="fixed inset-0 overflow-hidden">
-              <div className="absolute inset-0 overflow-hidden">
-                <div className="pointer-events-none fixed inset-y-0 left-0 flex max-w-full">
-                  <Transition.Child
-                    as={Fragment}
-                    enter="transform transition ease-in-out duration-200"
-                    enterFrom="-translate-x-full"
-                    enterTo="translate-x-0"
-                    leave="transform transition ease-in-out duration-150"
-                    leaveFrom="translate-x-0"
-                    leaveTo="-translate-x-full"
+            <div className="fixed inset-0 flex">
+              <Transition.Child
+                as={Fragment}
+                enter="transition ease-in-out duration-300 transform"
+                enterFrom="-translate-x-full"
+                enterTo="translate-x-0"
+                leave="transition ease-in-out duration-300 transform"
+                leaveFrom="translate-x-0"
+                leaveTo="-translate-x-full"
+              >
+                <Dialog.Panel className="pointer-events-auto w-[380px] max-w-md bg-card text-foreground border-r border-border">
+                  <LearningSidebarPanel
+                    title="Questions"
+                    totalItems={totalItems}
+                    completedItems={completedItems}
+                    theme={sidebarTheme}
+                    onClose={() => setSidebarOpen(false)}
                   >
-                    <Dialog.Panel className="pointer-events-auto w-[380px] max-w-md bg-[#111111] text-white">
-                      <LearningSidebarPanel
-                        title="Questions"
-                        totalItems={totalItems}
-                        completedItems={completedItems}
-                        theme="dark"
-                        onClose={() => setSidebarOpen(false)}
-                      >
-                        {sidebarContent}
-                      </LearningSidebarPanel>
-                    </Dialog.Panel>
-                  </Transition.Child>
-                </div>
-              </div>
+                    {sidebarContent}
+                  </LearningSidebarPanel>
+                </Dialog.Panel>
+              </Transition.Child>
             </div>
           </Dialog>
-        </Transition>
+        </Transition.Root>
       )}
     </div>
   );

--- a/packages/components/src/layout/LearningNavbar.tsx
+++ b/packages/components/src/layout/LearningNavbar.tsx
@@ -1,8 +1,11 @@
 import { Bars3Icon } from "@heroicons/react/24/outline";
 import { TOP_NAVIGATION } from "@tbe/constants";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
 
-import { FlexContainer, Link, LinkButton } from "..";
+import { FlexContainer, Link, LinkButton, ThemeToggle } from "..";
 import UserPointButton from "../common/Buttons/UserPointButton";
+import { useHasThemeProvider } from "../common/Theme";
 
 export interface LearningNavbarProps {
   backHref: string;
@@ -17,12 +20,28 @@ const LearningNavbar = ({
   headerCenterContent,
   showGamification = false,
 }: LearningNavbarProps) => {
-  const theme = "dark";
+  const hasThemeProvider = useHasThemeProvider();
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Without a provider, keep the previous dark learning chrome.
+  const shellIsDark = hasThemeProvider
+    ? mounted && resolvedTheme === "dark"
+    : true;
 
   return (
-    <header className="fixed top-0 left-0 right-0 h-[72px] z-40 bg-black shadow-md shadow-white/5 dark:shadow-[0_1px_15px_rgba(255,255,255,0.1)]">
+    <header
+      className={`fixed top-0 left-0 right-0 h-[72px] z-40 shadow-md shadow-white/5 ${
+        shellIsDark
+          ? "bg-black text-white"
+          : "bg-white text-black border-b border-border"
+      }`}
+    >
       <nav className="relative flex items-center justify-between h-full px-[12px] lg:px-[32px] border-0">
-        {/* Left Section */}
         <div className="flex items-center">
           <LinkButton
             href={backHref}
@@ -30,40 +49,46 @@ const LearningNavbar = ({
               variant: "OUTLINE",
               size: "SMALL",
               text: "← Back",
-              className:
-                "border-gray-700 bg-transparent hover:border-primary hover:bg-primary/10 py-[4px] px-[8px] h-auto whitespace-nowrap",
+              className: shellIsDark
+                ? "border-gray-700 bg-transparent hover:border-primary hover:bg-primary/10 py-[4px] px-[8px] h-auto whitespace-nowrap"
+                : "border-gray-300 bg-transparent hover:border-primary hover:bg-primary/10 py-[4px] px-[8px] h-auto whitespace-nowrap",
             }}
           />
 
           {onMenuToggle && (
             <button
-              className={`flex items-center justify-center rounded-md p-[6px] ${theme === "dark" ? "text-white hover:bg-gray-800" : "text-black hover:bg-gray-100"}`}
+              className={`flex items-center justify-center rounded-md p-[6px] ${
+                shellIsDark
+                  ? "text-white hover:bg-gray-800"
+                  : "text-black hover:bg-gray-100"
+              }`}
               type="button"
               aria-label="Open learning menu"
               onClick={onMenuToggle}
             >
               <Bars3Icon
                 aria-hidden="true"
-                className={`h-[16px] w-[16px] ${theme === "dark" ? "text-white" : "text-black"}`}
+                className={`h-[16px] w-[16px] ${shellIsDark ? "text-white" : "text-black"}`}
               />
             </button>
           )}
         </div>
 
-        {/* Center Section - Absolutely positioned for true centering */}
         {headerCenterContent && (
           <div className="absolute left-1/2 -translate-x-1/2 flex items-center justify-center h-full px-4 min-w-0">
             {headerCenterContent}
           </div>
         )}
 
-        {/* Right Section */}
         <div className="flex items-center gap-[16px] min-w-0">
+          {hasThemeProvider && (
+            <ThemeToggle theme={shellIsDark ? "dark" : "light"} />
+          )}
           {showGamification && <UserPointButton />}
           {TOP_NAVIGATION?.issues?.[0]?.href && (
             <FlexContainer direction="col" itemCenter={false}>
               <Link
-                className={`text-base ${theme === "dark" ? "text-white" : "text-black"} hover:text-primary whitespace-nowrap`}
+                className={`text-base ${shellIsDark ? "text-white" : "text-black"} hover:text-primary whitespace-nowrap`}
                 href={TOP_NAVIGATION.issues[0].href}
                 target={TOP_NAVIGATION.issues[0]?.target}
               >

--- a/packages/components/src/layout/Navbar.tsx
+++ b/packages/components/src/layout/Navbar.tsx
@@ -12,7 +12,18 @@ import type { TopNavbarLinkProps } from "@tbe/types";
 import { cn } from "@tbe/utils";
 import { AnimatePresence, motion } from "framer-motion";
 import NextLink from "next/link";
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { useTheme } from "next-themes";
+import {
+  cloneElement,
+  Fragment,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { FaInstagram, FaLinkedin, FaYoutube } from "react-icons/fa";
 
 import {
@@ -27,10 +38,12 @@ import {
   PopoverContainer,
   ProductLogo,
   Text,
+  ThemeToggle,
   UserAvatar,
   UserPointButton,
 } from "..";
 import NotificationPopover from "../common/Notification/index";
+import { useHasThemeProvider } from "../common/Theme";
 
 function resolveSection(
   visibility: NavbarSectionVisibility | undefined,
@@ -67,8 +80,25 @@ const Navbar = ({
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [openPopover, setOpenPopover] = useState<string | null>(null);
   const [learningSidebarOpen, setLearningSidebarOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
   const { isVisible } = useScrollDirection(100);
   const navRef = useRef<HTMLElement>(null);
+  const hasThemeProvider = useHasThemeProvider();
+  const { resolvedTheme } = useTheme();
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // When ThemeProvider is mounted (platform), follow the global theme so the
+  // toggle stays visible and the navbar chrome stays in sync site-wide.
+  // When no provider (other apps), honor the explicit `theme` prop.
+  const effectiveTheme: "light" | "dark" = hasThemeProvider
+    ? mounted && resolvedTheme === "dark"
+      ? "dark"
+      : "light"
+    : (theme ?? "light");
+  const showThemeToggle = hasThemeProvider;
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -122,15 +152,15 @@ const Navbar = ({
     if (variant === "transparent") {
       return "glass-dark backdrop-blur-md";
     }
-    if (theme === "dark") {
+    if (effectiveTheme === "dark") {
       return "bg-black";
     }
-    return "bg-white";
+    return "bg-white dark:bg-black";
   };
 
   const finalDashboardRoute = dashboardRoute || variantConfig.dashboardRoute;
 
-  const finalBranding =
+  const resolvedBranding =
     customBranding ||
     (variantConfig.productName ? (
       <NextLink
@@ -146,8 +176,19 @@ const Navbar = ({
       variantConfig.branding
     ));
 
+  const finalBranding =
+    !customBranding &&
+    !variantConfig.productName &&
+    isValidElement(resolvedBranding)
+      ? cloneElement(resolvedBranding as ReactElement<{ isDark?: boolean }>, {
+          isDark: effectiveTheme === "dark",
+        })
+      : resolvedBranding;
+
   const borderClass =
-    theme === "dark" ? "border-0" : variantConfig.borderClass || "border";
+    effectiveTheme === "dark"
+      ? "border-0"
+      : variantConfig.borderClass || "border";
   const shouldUseCustomActions = customActions && customActions.length > 0;
   const isLearningVariant = variant === "learning";
 
@@ -195,7 +236,7 @@ const Navbar = ({
           {isLearningVariant && (
             <button
               className={`flex items-center justify-center rounded-md p-[6px] ${
-                theme === "dark"
+                effectiveTheme === "dark"
                   ? "text-white hover:bg-gray-800"
                   : "text-black hover:bg-gray-100"
               }`}
@@ -205,7 +246,7 @@ const Navbar = ({
             >
               <Bars3Icon
                 aria-hidden="true"
-                className={`h-[16px] w-[16px] ${theme === "dark" ? "text-white" : "text-black"}`}
+                className={`h-[16px] w-[16px] ${effectiveTheme === "dark" ? "text-white" : "text-black"}`}
               />
             </button>
           )}
@@ -213,31 +254,33 @@ const Navbar = ({
         {shouldUseCustomActions ? (
           <>
             <div className="flex lg:hidden gap-[8px] items-center">
+              {showThemeToggle && <ThemeToggle theme={effectiveTheme} />}
               {requiresAuth && (
                 <UserAvatar
                   dashboardRoute={finalDashboardRoute}
                   profileRoute={profileRoute}
-                  theme={theme}
+                  theme={effectiveTheme}
                   variant={variant}
                 />
               )}
               <button
-                className={`-m-[10px] flex items-center justify-center rounded-md p-[10px] ${theme === "dark" ? "text-white" : "text-black"}`}
+                className={`-m-[10px] flex items-center justify-center rounded-md p-[10px] ${effectiveTheme === "dark" ? "text-white" : "text-black"}`}
                 type="button"
                 aria-label="Open menu"
                 onClick={() => setMobileMenuOpen(true)}
               >
                 <Bars3Icon
                   aria-hidden="true"
-                  className={`h-[24px] w-[24px] ${theme === "dark" ? "text-white" : "text-black"}`}
+                  className={`h-[24px] w-[24px] ${effectiveTheme === "dark" ? "text-white" : "text-black"}`}
                 />
               </button>
             </div>
             {/* Desktop Actions - explicit hidden for mobile, flex row for desktop */}
             <div className="hidden max-lg:hidden lg:flex lg:flex-row lg:items-center lg:gap-[16px] lg:visible">
-              {customActions.map((action: React.ReactNode, index: number) => (
+              {customActions.map((action: ReactNode, index: number) => (
                 <div key={index}>{action}</div>
               ))}
+              {showThemeToggle && <ThemeToggle theme={effectiveTheme} />}
               {requiresAuth && showNotifications && <NotificationPopover />}
               {/* {showGamification && <UserPointButton />} */}
               {requiresAuth && showLoginButton && (
@@ -247,7 +290,7 @@ const Navbar = ({
                 <UserAvatar
                   dashboardRoute={finalDashboardRoute}
                   profileRoute={profileRoute}
-                  theme={theme}
+                  theme={effectiveTheme}
                   variant={variant}
                 />
               )}
@@ -256,99 +299,103 @@ const Navbar = ({
         ) : (
           <>
             <div className="flex lg:hidden gap-[8px] items-center">
+              {showThemeToggle && <ThemeToggle theme={effectiveTheme} />}
               {requiresAuth && showNotifications && <NotificationPopover />}
               {showGamification && <UserPointButton />}
               {requiresAuth && (
                 <UserAvatar
                   dashboardRoute={finalDashboardRoute}
                   profileRoute={profileRoute}
-                  theme={theme}
+                  theme={effectiveTheme}
                   variant={variant}
                 />
               )}
               <button
-                className={`-m-[10px] flex items-center justify-center rounded-md p-[10px] ${theme === "dark" ? "text-white" : "text-black"}`}
+                className={`-m-[10px] flex items-center justify-center rounded-md p-[10px] ${effectiveTheme === "dark" ? "text-white" : "text-black"}`}
                 type="button"
                 aria-label="Open menu"
                 onClick={() => setMobileMenuOpen(true)}
               >
                 <Bars3Icon
                   aria-hidden="true"
-                  className={`h-[24px] w-[24px] ${theme === "dark" ? "text-white" : "text-black"}`}
+                  className={`h-[24px] w-[24px] ${effectiveTheme === "dark" ? "text-white" : "text-black"}`}
                 />
               </button>
             </div>
-            {showFullNavigation && (
-              <div className="hidden items-center lg:flex lg:gap-x-[24px]">
-                {issuesNav.visible && issuesNav.links[0]?.href && (
-                  <FlexContainer direction="col" itemCenter={false}>
-                    <Link
-                      className={`text-base ${theme === "dark" ? "text-white" : "text-black"} hover:text-${accentColorClass}`}
-                      href={issuesNav.links[0].href}
-                      target={issuesNav.links[0]?.target}
-                    >
-                      {issuesNav.links[0]?.name}
-                    </Link>
-                  </FlexContainer>
-                )}
+            <div className="hidden items-center lg:flex lg:gap-x-[24px]">
+              {showFullNavigation && (
+                <>
+                  {issuesNav.visible && issuesNav.links[0]?.href && (
+                    <FlexContainer direction="col" itemCenter={false}>
+                      <Link
+                        className={`text-base ${effectiveTheme === "dark" ? "text-white" : "text-black"} hover:text-${accentColorClass}`}
+                        href={issuesNav.links[0].href}
+                        target={issuesNav.links[0]?.target}
+                      >
+                        {issuesNav.links[0]?.name}
+                      </Link>
+                    </FlexContainer>
+                  )}
 
-                {learnNav.visible && (
-                  <PopoverContainer
-                    isOpen={openPopover === "products"}
-                    label="Learn"
-                    onToggle={() => handleSetOpen("products")}
-                    theme={theme}
-                  >
-                    <NavbarDropdownContainer links={learnNav.links} />
-                  </PopoverContainer>
-                )}
-                {variantConfig.pricingNavLink && !hidePricingLink && (
-                  <FlexContainer direction="col" itemCenter={false}>
-                    <Link
-                      className={`text-base ${theme === "dark" ? "text-white" : "text-black"} hover:text-${accentColorClass}`}
-                      href={variantConfig.pricingNavLink.href}
+                  {learnNav.visible && (
+                    <PopoverContainer
+                      isOpen={openPopover === "products"}
+                      label="Learn"
+                      onToggle={() => handleSetOpen("products")}
+                      theme={effectiveTheme}
                     >
-                      {variantConfig.pricingNavLink.label ?? "Pricing"}
-                    </Link>
-                  </FlexContainer>
-                )}
-                {toolsNav.visible && (
-                  <PopoverContainer
-                    isOpen={openPopover === "tools"}
-                    label="Tools"
-                    onToggle={() => handleSetOpen("tools")}
-                    theme={theme}
-                  >
-                    <NavbarDropdownContainer links={toolsNav.links} />
-                  </PopoverContainer>
-                )}
-                {linksNav.visible && (
-                  <PopoverContainer
-                    isOpen={openPopover === "links"}
-                    label="Links"
-                    panelClasses="-left-6"
-                    onToggle={() => handleSetOpen("links")}
-                    theme={theme}
-                  >
-                    <NavbarDropdownContainer links={linksNav.links} />
-                  </PopoverContainer>
-                )}
+                      <NavbarDropdownContainer links={learnNav.links} />
+                    </PopoverContainer>
+                  )}
+                  {variantConfig.pricingNavLink && !hidePricingLink && (
+                    <FlexContainer direction="col" itemCenter={false}>
+                      <Link
+                        className={`text-base ${effectiveTheme === "dark" ? "text-white" : "text-black"} hover:text-${accentColorClass}`}
+                        href={variantConfig.pricingNavLink.href}
+                      >
+                        {variantConfig.pricingNavLink.label ?? "Pricing"}
+                      </Link>
+                    </FlexContainer>
+                  )}
+                  {toolsNav.visible && (
+                    <PopoverContainer
+                      isOpen={openPopover === "tools"}
+                      label="Tools"
+                      onToggle={() => handleSetOpen("tools")}
+                      theme={effectiveTheme}
+                    >
+                      <NavbarDropdownContainer links={toolsNav.links} />
+                    </PopoverContainer>
+                  )}
+                  {linksNav.visible && (
+                    <PopoverContainer
+                      isOpen={openPopover === "links"}
+                      label="Links"
+                      panelClasses="-left-6"
+                      onToggle={() => handleSetOpen("links")}
+                      theme={effectiveTheme}
+                    >
+                      <NavbarDropdownContainer links={linksNav.links} />
+                    </PopoverContainer>
+                  )}
+                </>
+              )}
 
-                {requiresAuth && showNotifications && <NotificationPopover />}
-                {showGamification && <UserPointButton />}
-                {requiresAuth && showLoginButton && (
-                  <LoginRedirectButton text="Login" />
-                )}
-                {requiresAuth && (
-                  <UserAvatar
-                    dashboardRoute={finalDashboardRoute}
-                    profileRoute={profileRoute}
-                    theme={theme}
-                    variant={variant}
-                  />
-                )}
-              </div>
-            )}
+              {requiresAuth && showNotifications && <NotificationPopover />}
+              {showThemeToggle && <ThemeToggle theme={effectiveTheme} />}
+              {showGamification && <UserPointButton />}
+              {requiresAuth && showLoginButton && (
+                <LoginRedirectButton text="Login" />
+              )}
+              {requiresAuth && (
+                <UserAvatar
+                  dashboardRoute={finalDashboardRoute}
+                  profileRoute={profileRoute}
+                  theme={effectiveTheme}
+                  variant={variant}
+                />
+              )}
+            </div>
           </>
         )}
       </nav>
@@ -361,12 +408,12 @@ const Navbar = ({
       >
         <div className="fixed inset-0 z-50" />
         <Dialog.Panel
-          className={`fixed inset-y-0 right-0 z-50 w-full overflow-y-auto ${theme === "dark" ? "bg-[#0A0A0A]" : "bg-white"} p-2 sm:max-w-sm sm:ring-1 ${theme === "dark" ? "sm:ring-gray-100/10" : "sm:ring-gray-900/10"}`}
+          className={`fixed inset-y-0 right-0 z-50 w-full overflow-y-auto ${effectiveTheme === "dark" ? "bg-[#0A0A0A]" : "bg-white"} p-2 sm:max-w-sm sm:ring-1 ${effectiveTheme === "dark" ? "sm:ring-gray-100/10" : "sm:ring-gray-900/10"}`}
         >
           <div className="flex items-center justify-between">
             {finalBranding}
             <button
-              className={`-m-2.5 rounded-md p-2.5 ${theme === "dark" ? "text-white" : "text-black"}`}
+              className={`-m-2.5 rounded-md p-2.5 ${effectiveTheme === "dark" ? "text-white" : "text-black"}`}
               type="button"
               onClick={() => setMobileMenuOpen(false)}
             >
@@ -389,13 +436,11 @@ const Navbar = ({
                     itemCenter={false}
                   >
                     {shouldUseCustomActions &&
-                      customActions.map(
-                        (action: React.ReactNode, index: number) => (
-                          <div key={index} className="w-full">
-                            {action}
-                          </div>
-                        ),
-                      )}
+                      customActions.map((action: ReactNode, index: number) => (
+                        <div key={index} className="w-full">
+                          {action}
+                        </div>
+                      ))}
                     {/* Add Gamification and Notifications to Mobile Menu */}
                     {shouldUseCustomActions && (
                       <FlexContainer
@@ -434,7 +479,7 @@ const Navbar = ({
                         itemCenter={false}
                       >
                         <Link
-                          className={`text-base font-medium ${theme === "dark" ? "text-white" : "text-black"} hover:text-${accentColorClass}`}
+                          className={`text-base font-medium ${effectiveTheme === "dark" ? "text-white" : "text-black"} hover:text-${accentColorClass}`}
                           href={variantConfig.pricingNavLink.href}
                           onClick={handleCloseMobileMenu}
                         >
@@ -463,7 +508,7 @@ const Navbar = ({
                       justifyCenter={false}
                     >
                       <Text
-                        className={`pre-title ${theme === "dark" ? "text-gray-400" : "text-greyDark"}`}
+                        className={`pre-title ${effectiveTheme === "dark" ? "text-gray-400" : "text-greyDark"}`}
                         level="span"
                       >
                         Connect with us
@@ -476,7 +521,9 @@ const Navbar = ({
                         <Link href={LINKS.instagram} target="_blank">
                           <FaInstagram
                             className={
-                              theme === "dark" ? "text-white" : "text-black"
+                              effectiveTheme === "dark"
+                                ? "text-white"
+                                : "text-black"
                             }
                             size="2em"
                           />
@@ -484,7 +531,9 @@ const Navbar = ({
                         <Link href={LINKS.youtube} target="_blank">
                           <FaYoutube
                             className={
-                              theme === "dark" ? "text-white" : "text-black"
+                              effectiveTheme === "dark"
+                                ? "text-white"
+                                : "text-black"
                             }
                             size="2em"
                           />
@@ -492,7 +541,9 @@ const Navbar = ({
                         <Link href={LINKS.officialLinkedIn} target="_blank">
                           <FaLinkedin
                             className={
-                              theme === "dark" ? "text-white" : "text-black"
+                              effectiveTheme === "dark"
+                                ? "text-white"
+                                : "text-black"
                             }
                             size="2em"
                           />
@@ -540,7 +591,7 @@ const Navbar = ({
                   >
                     <Dialog.Panel
                       className={`pointer-events-auto w-80 max-w-sm ${
-                        theme === "dark"
+                        effectiveTheme === "dark"
                           ? "bg-[#111111] text-white"
                           : "bg-white text-gray-900"
                       }`}
@@ -549,7 +600,7 @@ const Navbar = ({
                         title={sidebarTitle}
                         totalItems={totalChapters}
                         completedItems={completedChapters}
-                        theme={theme}
+                        theme={effectiveTheme}
                         onClose={() => setLearningSidebarOpen(false)}
                       >
                         {sidebarContent}

--- a/packages/components/src/layout/Page.tsx
+++ b/packages/components/src/layout/Page.tsx
@@ -1,9 +1,12 @@
-import { Footer, Navbar } from "@tbe/components";
 import { routes } from "@tbe/constants";
 import type { PageLayoutProps } from "@tbe/interface";
 import { motion } from "framer-motion";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+
+import { ThemeToggle, useHasThemeProvider } from "../common/Theme";
+import Footer from "./Footer";
+import Navbar from "./Navbar";
 
 const PageLayout = ({ children }: PageLayoutProps) => {
   let router: any = null;
@@ -14,6 +17,7 @@ const PageLayout = ({ children }: PageLayoutProps) => {
     // App Router or RouterContext not mounted
   }
   const [isClient, setIsClient] = useState(false);
+  const hasThemeProvider = useHasThemeProvider();
 
   useEffect(() => {
     setIsClient(true);
@@ -33,23 +37,39 @@ const PageLayout = ({ children }: PageLayoutProps) => {
     };
   }, [isClient, router?.events]);
 
-  const isExcludedRoute =
-    router?.pathname === routes.checkout ||
-    router?.pathname === routes.paymentStatus ||
-    router?.pathname === routes.login ||
+  const isProfileRoute =
     router?.pathname === "/profile" ||
     router?.pathname === "/user/profile" ||
     Boolean(router?.pathname?.endsWith("/profile")) ||
     Boolean(router?.pathname?.includes("/profile"));
 
+  const isExcludedRoute =
+    router?.pathname === routes.checkout ||
+    router?.pathname === routes.paymentStatus ||
+    router?.pathname === routes.login ||
+    isProfileRoute;
+
+  const showFloatingThemeToggle =
+    hasThemeProvider &&
+    (router?.pathname === routes.checkout ||
+      router?.pathname === routes.paymentStatus ||
+      router?.pathname === routes.login);
+
   if (isExcludedRoute) {
     return (
-      <main className="bg-lightBG flex min-h-screen flex-col">{children}</main>
+      <main className="bg-background text-foreground flex min-h-screen flex-col">
+        {showFloatingThemeToggle && (
+          <div className="fixed top-4 right-4 z-50 rounded-md border border-border bg-card p-1 shadow-sm">
+            <ThemeToggle />
+          </div>
+        )}
+        {children}
+      </main>
     );
   }
 
   return (
-    <main className="bg-lightBG flex flex-col min-h-screen">
+    <main className="bg-background text-foreground flex flex-col min-h-screen">
       <Navbar />
       <motion.div
         animate={{ opacity: 1, scale: 1 }}

--- a/packages/components/src/learn/LearnDashboardContainer.tsx
+++ b/packages/components/src/learn/LearnDashboardContainer.tsx
@@ -417,7 +417,8 @@ const RECOMMENDED_DISCOVERY_ITEMS: RecommendedItem[] = [
     url: "https://resources.theboringeducation.com/resources/git-github-contributor-playbook",
     isExternal: true,
     category: "GIT PLAYBOOK",
-    categoryStyle: "bg-slate-100 text-slate-800 border-slate-200",
+    categoryStyle:
+      "bg-slate-100 dark:bg-muted text-slate-800 border-slate-200 dark:border-border",
     iconType: "code",
   },
   // 21
@@ -807,7 +808,7 @@ export const LearnDashboardContainer: React.FC<
   };
 
   return (
-    <div className="w-full min-h-screen bg-[#F8FAFC] flex relative font-sans">
+    <div className="w-full min-h-screen bg-[#F8FAFC] dark:bg-background flex relative font-sans">
       <div
         className={`w-full flex ${
           !showQuiz || isCookingQuiz || isSavingQuiz ? "flex" : "hidden"
@@ -819,7 +820,7 @@ export const LearnDashboardContainer: React.FC<
             isSidebarCollapsed
               ? "w-[56px] sm:w-[64px] px-1 sm:px-1.5"
               : "w-[220px] sm:w-[240px] px-2 sm:px-2.5"
-          } border-r border-[#E8ECF2] bg-white min-h-screen sticky top-0 flex flex-col justify-between py-3 shrink-0 transition-[width,padding] duration-300 ease-in-out select-none z-30 overflow-hidden`}
+          } border-r border-[#E8ECF2] dark:border-border bg-white dark:bg-card min-h-screen sticky top-0 flex flex-col justify-between py-3 shrink-0 transition-[width,padding] duration-300 ease-in-out select-none z-30 overflow-hidden`}
         >
           <div className="space-y-2">
             {/* Top Collapse Toggle Button */}
@@ -830,7 +831,7 @@ export const LearnDashboardContainer: React.FC<
             >
               <button
                 onClick={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
-                className="w-6 h-6 rounded-md flex items-center justify-center text-slate-400 hover:text-slate-700 hover:bg-slate-100 transition-colors cursor-pointer shrink-0"
+                className="w-6 h-6 rounded-md flex items-center justify-center text-slate-400 dark:text-muted-foreground hover:text-slate-700 hover:bg-slate-100 dark:hover:bg-muted dark:bg-muted transition-colors cursor-pointer shrink-0"
                 title={
                   isSidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"
                 }
@@ -854,7 +855,7 @@ export const LearnDashboardContainer: React.FC<
                   } py-1.5 rounded-lg text-[13px] transition-colors duration-200 cursor-pointer overflow-hidden ${
                     activeTab === "dashboard"
                       ? "bg-red-50/70 text-[#FF4D4D] font-medium shadow-2xs"
-                      : "text-slate-600 hover:bg-slate-50 hover:text-slate-900 font-normal"
+                      : "text-slate-600 dark:text-muted-foreground hover:bg-slate-50 dark:hover:bg-muted dark:bg-muted hover:text-slate-900 dark:text-foreground font-normal"
                   }`}
                 >
                   {activeTab === "dashboard" && (
@@ -865,7 +866,7 @@ export const LearnDashboardContainer: React.FC<
                       className={`w-[17px] h-[17px] ${
                         activeTab === "dashboard"
                           ? "text-[#FF4D4D]"
-                          : "text-slate-500"
+                          : "text-slate-500 dark:text-muted-foreground"
                       }`}
                     />
                   </div>
@@ -897,7 +898,7 @@ export const LearnDashboardContainer: React.FC<
               {/* LEARNING Section */}
               <div className="space-y-0.5">
                 <div
-                  className={`px-2 text-[10px] font-bold text-slate-400 tracking-wider uppercase whitespace-nowrap overflow-hidden transition-all duration-200 ${
+                  className={`px-2 text-[10px] font-bold text-slate-400 dark:text-muted-foreground tracking-wider uppercase whitespace-nowrap overflow-hidden transition-all duration-200 ${
                     isSidebarCollapsed
                       ? "opacity-0 h-0 my-0"
                       : "opacity-100 py-0.5"
@@ -916,7 +917,7 @@ export const LearnDashboardContainer: React.FC<
                     } py-1.5 rounded-lg text-[13px] transition-colors duration-200 cursor-pointer overflow-hidden ${
                       activeTab === "mylearning"
                         ? "bg-red-50/70 text-[#FF4D4D] font-medium shadow-2xs"
-                        : "text-slate-600 hover:bg-slate-50 hover:text-slate-900 font-normal"
+                        : "text-slate-600 dark:text-muted-foreground hover:bg-slate-50 dark:hover:bg-muted dark:bg-muted hover:text-slate-900 dark:text-foreground font-normal"
                     }`}
                   >
                     {activeTab === "mylearning" && (
@@ -927,7 +928,7 @@ export const LearnDashboardContainer: React.FC<
                         className={`w-[17px] h-[17px] ${
                           activeTab === "mylearning"
                             ? "text-[#FF4D4D]"
-                            : "text-slate-500"
+                            : "text-slate-500 dark:text-muted-foreground"
                         }`}
                       />
                     </div>
@@ -965,7 +966,7 @@ export const LearnDashboardContainer: React.FC<
                     } py-1.5 rounded-lg text-[13px] transition-colors duration-200 cursor-pointer overflow-hidden ${
                       activeTab === "explore"
                         ? "bg-red-50/70 text-[#FF4D4D] font-medium shadow-2xs"
-                        : "text-slate-600 hover:bg-slate-50 hover:text-slate-900 font-normal"
+                        : "text-slate-600 dark:text-muted-foreground hover:bg-slate-50 dark:hover:bg-muted dark:bg-muted hover:text-slate-900 dark:text-foreground font-normal"
                     }`}
                   >
                     {activeTab === "explore" && (
@@ -976,7 +977,7 @@ export const LearnDashboardContainer: React.FC<
                         className={`w-[17px] h-[17px] ${
                           activeTab === "explore"
                             ? "text-[#FF4D4D]"
-                            : "text-slate-500"
+                            : "text-slate-500 dark:text-muted-foreground"
                         }`}
                       />
                     </div>
@@ -1011,10 +1012,10 @@ export const LearnDashboardContainer: React.FC<
                       isSidebarCollapsed
                         ? "justify-center px-0"
                         : "px-2 gap-2.5"
-                    } py-1.5 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-slate-900 font-normal transition-colors overflow-hidden`}
+                    } py-1.5 rounded-lg text-[13px] text-slate-600 dark:text-muted-foreground hover:bg-slate-50 dark:hover:bg-muted dark:bg-muted hover:text-slate-900 dark:text-foreground font-normal transition-colors overflow-hidden`}
                   >
                     <div className="w-5 h-5 flex items-center justify-center shrink-0">
-                      <FiPlayCircle className="w-[17px] h-[17px] text-slate-500" />
+                      <FiPlayCircle className="w-[17px] h-[17px] text-slate-500 dark:text-muted-foreground" />
                     </div>
                     <span
                       className={`whitespace-nowrap flex-1 text-left truncate transition-opacity duration-200 ${
@@ -1035,7 +1036,7 @@ export const LearnDashboardContainer: React.FC<
                     } py-1.5 rounded-lg text-[13px] transition-colors duration-200 cursor-pointer overflow-hidden ${
                       activeTab === "ecosystem"
                         ? "bg-red-50/70 text-[#FF4D4D] font-medium shadow-2xs"
-                        : "text-slate-600 hover:bg-slate-50 hover:text-slate-900 font-normal"
+                        : "text-slate-600 dark:text-muted-foreground hover:bg-slate-50 dark:hover:bg-muted dark:bg-muted hover:text-slate-900 dark:text-foreground font-normal"
                     }`}
                   >
                     {activeTab === "ecosystem" && (
@@ -1046,7 +1047,7 @@ export const LearnDashboardContainer: React.FC<
                         className={`w-[17px] h-[17px] ${
                           activeTab === "ecosystem"
                             ? "text-[#FF4D4D]"
-                            : "text-slate-500"
+                            : "text-slate-500 dark:text-muted-foreground"
                         }`}
                       />
                     </div>
@@ -1082,7 +1083,7 @@ export const LearnDashboardContainer: React.FC<
               {/* PRACTICE Section */}
               <div className="space-y-0.5">
                 <div
-                  className={`px-2 text-[10px] font-bold text-slate-400 tracking-wider uppercase whitespace-nowrap overflow-hidden transition-all duration-200 ${
+                  className={`px-2 text-[10px] font-bold text-slate-400 dark:text-muted-foreground tracking-wider uppercase whitespace-nowrap overflow-hidden transition-all duration-200 ${
                     isSidebarCollapsed
                       ? "opacity-0 h-0 my-0"
                       : "opacity-100 py-0.5"
@@ -1100,10 +1101,10 @@ export const LearnDashboardContainer: React.FC<
                       isSidebarCollapsed
                         ? "justify-center px-0"
                         : "px-2 gap-2.5"
-                    } py-1.5 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-slate-900 font-normal transition-colors overflow-hidden`}
+                    } py-1.5 rounded-lg text-[13px] text-slate-600 dark:text-muted-foreground hover:bg-slate-50 dark:hover:bg-muted dark:bg-muted hover:text-slate-900 dark:text-foreground font-normal transition-colors overflow-hidden`}
                   >
                     <div className="w-5 h-5 flex items-center justify-center shrink-0">
-                      <FiCode className="w-[17px] h-[17px] text-slate-500" />
+                      <FiCode className="w-[17px] h-[17px] text-slate-500 dark:text-muted-foreground" />
                     </div>
                     <span
                       className={`whitespace-nowrap flex-1 text-left truncate transition-opacity duration-200 ${
@@ -1121,10 +1122,10 @@ export const LearnDashboardContainer: React.FC<
                       isSidebarCollapsed
                         ? "justify-center px-0"
                         : "px-2 gap-2.5"
-                    } py-1.5 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-slate-900 font-normal transition-colors overflow-hidden`}
+                    } py-1.5 rounded-lg text-[13px] text-slate-600 dark:text-muted-foreground hover:bg-slate-50 dark:hover:bg-muted dark:bg-muted hover:text-slate-900 dark:text-foreground font-normal transition-colors overflow-hidden`}
                   >
                     <div className="w-5 h-5 flex items-center justify-center shrink-0">
-                      <FiTarget className="w-[17px] h-[17px] text-slate-500" />
+                      <FiTarget className="w-[17px] h-[17px] text-slate-500 dark:text-muted-foreground" />
                     </div>
                     <span
                       className={`whitespace-nowrap flex-1 text-left truncate transition-opacity duration-200 ${
@@ -1144,10 +1145,10 @@ export const LearnDashboardContainer: React.FC<
                       isSidebarCollapsed
                         ? "justify-center px-0"
                         : "px-2 gap-2.5"
-                    } py-1.5 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-slate-900 font-normal transition-colors overflow-hidden`}
+                    } py-1.5 rounded-lg text-[13px] text-slate-600 dark:text-muted-foreground hover:bg-slate-50 dark:hover:bg-muted dark:bg-muted hover:text-slate-900 dark:text-foreground font-normal transition-colors overflow-hidden`}
                   >
                     <div className="w-5 h-5 flex items-center justify-center shrink-0">
-                      <FiBarChart2 className="w-[17px] h-[17px] text-slate-500" />
+                      <FiBarChart2 className="w-[17px] h-[17px] text-slate-500 dark:text-muted-foreground" />
                     </div>
                     <span
                       className={`whitespace-nowrap flex-1 text-left truncate transition-opacity duration-200 ${
@@ -1166,7 +1167,7 @@ export const LearnDashboardContainer: React.FC<
               {/* COMMUNITY Section */}
               <div className="space-y-0.5">
                 <div
-                  className={`px-2 text-[10px] font-bold text-slate-400 tracking-wider uppercase whitespace-nowrap overflow-hidden transition-all duration-200 ${
+                  className={`px-2 text-[10px] font-bold text-slate-400 dark:text-muted-foreground tracking-wider uppercase whitespace-nowrap overflow-hidden transition-all duration-200 ${
                     isSidebarCollapsed
                       ? "opacity-0 h-0 my-0"
                       : "opacity-100 py-0.5"
@@ -1184,10 +1185,10 @@ export const LearnDashboardContainer: React.FC<
                       isSidebarCollapsed
                         ? "justify-center px-0"
                         : "px-2 gap-2.5"
-                    } py-1.5 rounded-lg text-[13px] text-slate-600 hover:bg-slate-50 hover:text-slate-900 font-normal transition-colors overflow-hidden`}
+                    } py-1.5 rounded-lg text-[13px] text-slate-600 dark:text-muted-foreground hover:bg-slate-50 dark:hover:bg-muted dark:bg-muted hover:text-slate-900 dark:text-foreground font-normal transition-colors overflow-hidden`}
                   >
                     <div className="w-5 h-5 flex items-center justify-center shrink-0">
-                      <FiFileText className="w-[17px] h-[17px] text-slate-500" />
+                      <FiFileText className="w-[17px] h-[17px] text-slate-500 dark:text-muted-foreground" />
                     </div>
                     <span
                       className={`whitespace-nowrap flex-1 text-left truncate transition-opacity duration-200 ${
@@ -1207,12 +1208,12 @@ export const LearnDashboardContainer: React.FC<
             <Link
               href="/user/profile"
               title="Settings"
-              className={`w-full bg-slate-50/70 hover:bg-slate-100 text-slate-600 hover:text-slate-900 rounded-lg ${
+              className={`w-full bg-slate-50 dark:bg-muted/70 hover:bg-slate-100 dark:hover:bg-muted dark:bg-muted text-slate-600 dark:text-muted-foreground hover:text-slate-900 dark:text-foreground rounded-lg ${
                 isSidebarCollapsed ? "justify-center px-0" : "px-2 gap-2.5"
               } py-1.5 text-[13px] font-normal flex items-center border border-[#E8ECF2] transition-colors cursor-pointer overflow-hidden`}
             >
               <div className="w-5 h-5 flex items-center justify-center shrink-0">
-                <FiSettings className="w-[17px] h-[17px] text-slate-500" />
+                <FiSettings className="w-[17px] h-[17px] text-slate-500 dark:text-muted-foreground" />
               </div>
               <span
                 className={`whitespace-nowrap flex-1 text-left truncate transition-opacity duration-200 ${
@@ -1223,7 +1224,7 @@ export const LearnDashboardContainer: React.FC<
               </span>
               {!isSidebarCollapsed && (
                 <svg
-                  className="w-3.5 h-3.5 text-slate-400 shrink-0"
+                  className="w-3.5 h-3.5 text-slate-400 dark:text-muted-foreground shrink-0"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -1246,7 +1247,7 @@ export const LearnDashboardContainer: React.FC<
             /* Ecosystem Tab */
             <div className="space-y-4">
               <section className="space-y-3">
-                <h2 className="text-sm sm:text-base font-bold text-slate-900">
+                <h2 className="text-sm sm:text-base font-bold text-slate-900 dark:text-foreground">
                   Quick access to TBE Ecosystem
                 </h2>
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4">
@@ -1256,7 +1257,7 @@ export const LearnDashboardContainer: React.FC<
                       href={app.url}
                       target={app.isExternal ? "_blank" : undefined}
                       rel={app.isExternal ? "noopener noreferrer" : undefined}
-                      className={`group bg-white hover:bg-slate-50/80 border border-slate-200/80 hover:border-[#FF3B30]/50 transition-all hover:shadow-md rounded-2xl p-3.5 sm:p-4 flex min-w-0 overflow-hidden ${i % 2 === 0 ? "flex-col" : "flex-col-reverse"}`}
+                      className={`group bg-white dark:bg-card hover:bg-slate-50 dark:hover:bg-muted dark:bg-muted/80 border border-slate-200/80 dark:border-border hover:border-[#FF3B30]/50 transition-all hover:shadow-md rounded-2xl p-3.5 sm:p-4 flex min-w-0 overflow-hidden ${i % 2 === 0 ? "flex-col" : "flex-col-reverse"}`}
                     >
                       {/* Image */}
                       <div className="w-full h-32 sm:h-40 flex items-center justify-center py-2 sm:py-3">
@@ -1279,12 +1280,12 @@ export const LearnDashboardContainer: React.FC<
                         }
                       >
                         <div className="flex items-center justify-between gap-1">
-                          <h3 className="text-sm font-extrabold text-slate-900 group-hover:text-[#FF3B30] transition-colors leading-tight">
+                          <h3 className="text-sm font-extrabold text-slate-900 dark:text-foreground group-hover:text-[#FF3B30] transition-colors leading-tight">
                             {app.name}
                           </h3>
-                          <FiArrowUpRight className="w-3.5 h-3.5 text-slate-400 group-hover:text-[#FF3B30] shrink-0" />
+                          <FiArrowUpRight className="w-3.5 h-3.5 text-slate-400 dark:text-muted-foreground group-hover:text-[#FF3B30] shrink-0" />
                         </div>
-                        <p className="text-[11px] text-slate-500 font-medium leading-snug mt-0.5">
+                        <p className="text-[11px] text-slate-500 dark:text-muted-foreground font-medium leading-snug mt-0.5">
                           {app.desc}
                         </p>
                       </div>
@@ -1301,7 +1302,7 @@ export const LearnDashboardContainer: React.FC<
                 <h1 className="text-lg sm:text-xl md:text-2xl font-extrabold text-[#10162F] tracking-tight">
                   {getGreeting()}, {user?.name?.split(" ")[0] || "Nitin"} 👋
                 </h1>
-                <p className="text-xs text-slate-500 font-semibold">
+                <p className="text-xs text-slate-500 dark:text-muted-foreground font-semibold">
                   Keep learning, keep growing!
                 </p>
               </div>
@@ -1310,7 +1311,7 @@ export const LearnDashboardContainer: React.FC<
               <section className="space-y-2.5 sm:space-y-3">
                 <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-1 sm:gap-2">
                   <div className="flex items-center gap-2">
-                    <h2 className="text-sm sm:text-base font-bold text-slate-900">
+                    <h2 className="text-sm sm:text-base font-bold text-slate-900 dark:text-foreground">
                       Recommended for you
                     </h2>
                   </div>
@@ -1326,10 +1327,10 @@ export const LearnDashboardContainer: React.FC<
                 <div className="relative group overflow-x-clip">
                   <div
                     id="recommended-scroll-container"
-                    className="flex items-stretch gap-3 sm:gap-3.5 overflow-x-auto snap-x pb-2 pt-1 flex-nowrap scroll-smooth [&::-webkit-scrollbar]:h-[3px] [&::-webkit-scrollbar-track]:bg-slate-100 [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-300 [&::-webkit-scrollbar-thumb]:rounded-full hover:[&::-webkit-scrollbar-thumb]:bg-slate-400"
+                    className="flex items-stretch gap-3 sm:gap-3.5 overflow-x-auto snap-x pb-2 pt-1 flex-nowrap scroll-smooth [&::-webkit-scrollbar]:h-[3px] [&::-webkit-scrollbar-track]:bg-slate-100 dark:bg-muted [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-300 [&::-webkit-scrollbar-thumb]:rounded-full hover:[&::-webkit-scrollbar-thumb]:bg-slate-400"
                   >
                     {/* Bulb Card */}
-                    <div className="w-52 sm:w-60 md:w-64 shrink-0 bg-white border border-slate-200/80 rounded-2xl p-3.5 sm:p-4 flex flex-col justify-between text-center shadow-xs hover:border-slate-300 transition-all snap-start">
+                    <div className="w-52 sm:w-60 md:w-64 shrink-0 bg-white dark:bg-card border border-slate-200/80 dark:border-border rounded-2xl p-3.5 sm:p-4 flex flex-col justify-between text-center shadow-xs hover:border-slate-300 transition-all snap-start">
                       <div>
                         <div className="w-full flex items-center justify-center py-1 mb-2">
                           <img
@@ -1338,10 +1339,10 @@ export const LearnDashboardContainer: React.FC<
                             className="h-20 sm:h-24 md:h-28 object-contain mx-auto"
                           />
                         </div>
-                        <h3 className="text-xs sm:text-sm font-bold text-slate-900 leading-tight">
+                        <h3 className="text-xs sm:text-sm font-bold text-slate-900 dark:text-foreground leading-tight">
                           Explore courses & sheets
                         </h3>
-                        <p className="text-[11px] text-slate-500 mt-1.5 leading-snug">
+                        <p className="text-[11px] text-slate-500 dark:text-muted-foreground mt-1.5 leading-snug">
                           Browse all interview sheets, core CS subjects & free
                           roadmaps.
                         </p>
@@ -1400,7 +1401,7 @@ export const LearnDashboardContainer: React.FC<
                       return (
                         <div
                           key={item.id}
-                          className="w-52 sm:w-60 md:w-64 shrink-0 bg-white border border-slate-200/80 rounded-2xl overflow-hidden flex flex-col justify-between shadow-xs hover:border-slate-300 transition-all snap-start group"
+                          className="w-52 sm:w-60 md:w-64 shrink-0 bg-white dark:bg-card border border-slate-200/80 dark:border-border rounded-2xl overflow-hidden flex flex-col justify-between shadow-xs hover:border-slate-300 transition-all snap-start group"
                         >
                           <div>
                             <div
@@ -1409,15 +1410,15 @@ export const LearnDashboardContainer: React.FC<
                               {badgeText}
                             </div>
                             <div className="p-3 sm:p-3.5 space-y-1.5 sm:space-y-2">
-                              <h3 className="text-xs sm:text-sm font-bold text-slate-900 leading-snug group-hover:text-[#FF3B30] transition-colors">
+                              <h3 className="text-xs sm:text-sm font-bold text-slate-900 dark:text-foreground leading-snug group-hover:text-[#FF3B30] transition-colors">
                                 {item.title}
                               </h3>
-                              <p className="text-[11px] text-slate-600 leading-snug line-clamp-3">
+                              <p className="text-[11px] text-slate-600 dark:text-muted-foreground leading-snug line-clamp-3">
                                 {item.desc}
                               </p>
                               {isInProgress && (
                                 <div className="pt-1.5 space-y-1">
-                                  <div className="w-full bg-slate-100 rounded-full h-1.5">
+                                  <div className="w-full bg-slate-100 dark:bg-muted rounded-full h-1.5">
                                     <div
                                       className="bg-[#FF3B30] h-1.5 rounded-full"
                                       style={{
@@ -1432,7 +1433,7 @@ export const LearnDashboardContainer: React.FC<
                               )}
                             </div>
                           </div>
-                          <div className="px-3 sm:px-3.5 py-2 sm:py-2.5 border-t border-slate-100 flex items-center justify-between text-[10px] font-medium text-slate-400">
+                          <div className="px-3 sm:px-3.5 py-2 sm:py-2.5 border-t border-slate-100 flex items-center justify-between text-[10px] font-medium text-slate-400 dark:text-muted-foreground">
                             <span>
                               {item.type === "core-subject"
                                 ? "OnCampus"
@@ -1471,7 +1472,7 @@ export const LearnDashboardContainer: React.FC<
               {/* My learning section */}
               <section className="space-y-2.5 sm:space-y-3">
                 <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-1 sm:gap-2 border-b border-slate-100 pb-2">
-                  <h2 className="text-sm sm:text-base font-extrabold text-slate-900 tracking-tight">
+                  <h2 className="text-sm sm:text-base font-extrabold text-slate-900 dark:text-foreground tracking-tight">
                     My learning
                   </h2>
                   <Link
@@ -1482,9 +1483,9 @@ export const LearnDashboardContainer: React.FC<
                   </Link>
                 </div>
 
-                <div className="flex items-stretch gap-3 sm:gap-4 overflow-x-auto snap-x pb-3 pt-1 flex-nowrap scroll-smooth [&::-webkit-scrollbar]:h-[3px] [&::-webkit-scrollbar-track]:bg-slate-100 [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-300 [&::-webkit-scrollbar-thumb]:rounded-full hover:[&::-webkit-scrollbar-thumb]:bg-slate-400">
+                <div className="flex items-stretch gap-3 sm:gap-4 overflow-x-auto snap-x pb-3 pt-1 flex-nowrap scroll-smooth [&::-webkit-scrollbar]:h-[3px] [&::-webkit-scrollbar-track]:bg-slate-100 dark:bg-muted [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-300 [&::-webkit-scrollbar-thumb]:rounded-full hover:[&::-webkit-scrollbar-thumb]:bg-slate-400">
                   {loadingLearning ? (
-                    <div className="w-full py-8 flex items-center justify-center text-xs font-bold text-slate-400">
+                    <div className="w-full py-8 flex items-center justify-center text-xs font-bold text-slate-400 dark:text-muted-foreground">
                       Loading your learning sheets...
                     </div>
                   ) : activeSheetsWithProgress &&
@@ -1544,7 +1545,7 @@ export const LearnDashboardContainer: React.FC<
                       return (
                         <div
                           key={sheet.slug || sheet._id || index}
-                          className="w-[260px] sm:w-[290px] md:w-[320px] shrink-0 bg-white border border-slate-200/80 hover:border-slate-300 hover:shadow-md transition-all rounded-2xl overflow-hidden flex flex-col justify-between group snap-start"
+                          className="w-[260px] sm:w-[290px] md:w-[320px] shrink-0 bg-white dark:bg-card border border-slate-200/80 dark:border-border hover:border-slate-300 hover:shadow-md transition-all rounded-2xl overflow-hidden flex flex-col justify-between group snap-start"
                         >
                           {/* Top border badge strip */}
                           <div
@@ -1567,22 +1568,22 @@ export const LearnDashboardContainer: React.FC<
                                     <FiFileText className="w-7 h-7 sm:w-8 h-8 text-[#FF3B30] shrink-0" />
                                   )}
                                   <div className="min-w-0">
-                                    <h3 className="text-xs sm:text-sm md:text-[15px] font-extrabold text-slate-900 leading-snug truncate group-hover:text-[#FF3B30] transition-colors">
+                                    <h3 className="text-xs sm:text-sm md:text-[15px] font-extrabold text-slate-900 dark:text-foreground leading-snug truncate group-hover:text-[#FF3B30] transition-colors">
                                       {sheet.title}
                                     </h3>
                                   </div>
                                 </div>
                                 <div className="shrink-0 text-right">
-                                  <span className="text-xs font-black text-slate-900">
+                                  <span className="text-xs font-black text-slate-900 dark:text-foreground">
                                     {progressPercentage}%
                                   </span>
-                                  <div className="text-[9px] font-bold text-slate-400">
+                                  <div className="text-[9px] font-bold text-slate-400 dark:text-muted-foreground">
                                     Solved
                                   </div>
                                 </div>
                               </div>
 
-                              <p className="text-xs text-slate-500 leading-relaxed font-medium line-clamp-2 mt-2 sm:mt-3">
+                              <p className="text-xs text-slate-500 dark:text-muted-foreground leading-relaxed font-medium line-clamp-2 mt-2 sm:mt-3">
                                 {sheet.description ||
                                   "Curated list of topic-wise interview preparation problems."}
                               </p>
@@ -1590,13 +1591,13 @@ export const LearnDashboardContainer: React.FC<
 
                             <div className="mt-3.5 sm:mt-4 pt-3 sm:pt-3.5 border-t border-slate-100 space-y-2.5 sm:space-y-3">
                               <div className="space-y-1.5">
-                                <div className="w-full bg-slate-100 rounded-full h-1.5 overflow-hidden">
+                                <div className="w-full bg-slate-100 dark:bg-muted rounded-full h-1.5 overflow-hidden">
                                   <div
                                     className={`${progressColor} h-1.5 rounded-full`}
                                     style={{ width: `${progressPercentage}%` }}
                                   />
                                 </div>
-                                <div className="flex items-center justify-between text-[10px] sm:text-[11px] text-slate-400 font-semibold">
+                                <div className="flex items-center justify-between text-[10px] sm:text-[11px] text-slate-400 dark:text-muted-foreground font-semibold">
                                   <span>
                                     {completedCount} / {totalCount} Problems
                                     Solved
@@ -1627,14 +1628,14 @@ export const LearnDashboardContainer: React.FC<
                       );
                     })
                   ) : (
-                    <div className="w-full py-8 bg-white border border-slate-200/80 rounded-2xl flex flex-col items-center justify-center text-center space-y-2 p-4 sm:p-6">
-                      <div className="w-10 h-10 rounded-xl bg-slate-50 border border-slate-100 flex items-center justify-center text-slate-400">
+                    <div className="w-full py-8 bg-white dark:bg-card border border-slate-200/80 dark:border-border rounded-2xl flex flex-col items-center justify-center text-center space-y-2 p-4 sm:p-6">
+                      <div className="w-10 h-10 rounded-xl bg-slate-50 dark:bg-muted border border-slate-100 flex items-center justify-center text-slate-400 dark:text-muted-foreground">
                         <FiBookOpen className="w-5 h-5" />
                       </div>
                       <span className="text-xs font-bold text-slate-700">
                         No active sheets in progress yet
                       </span>
-                      <p className="text-[11px] text-slate-400 max-w-sm">
+                      <p className="text-[11px] text-slate-400 dark:text-muted-foreground max-w-sm">
                         Start solving questions in any interview sheet to see
                         your progress here.
                       </p>
@@ -1651,7 +1652,7 @@ export const LearnDashboardContainer: React.FC<
 
               {/* More features to explore */}
               <section className="space-y-2.5">
-                <h2 className="text-sm sm:text-base font-bold text-slate-900">
+                <h2 className="text-sm sm:text-base font-bold text-slate-900 dark:text-foreground">
                   More features to explore
                 </h2>
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2.5 sm:gap-3">
@@ -1659,66 +1660,66 @@ export const LearnDashboardContainer: React.FC<
                     href="https://quiz.theboringeducation.com"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="bg-white border border-slate-200/80 rounded-xl p-3 sm:p-3.5 flex items-center justify-between hover:border-slate-300 transition-all cursor-pointer group"
+                    className="bg-white dark:bg-card border border-slate-200/80 dark:border-border rounded-xl p-3 sm:p-3.5 flex items-center justify-between hover:border-slate-300 transition-all cursor-pointer group"
                   >
                     <div className="flex items-center gap-2.5 sm:gap-3 min-w-0">
                       <div className="w-7 h-7 sm:w-8 h-8 rounded-lg bg-amber-50 text-amber-600 flex items-center justify-center shrink-0 group-hover:scale-105 transition-transform">
                         <FiHelpCircle className="w-4 h-4" />
                       </div>
                       <div className="min-w-0">
-                        <h4 className="text-xs font-bold text-slate-900 group-hover:text-[#FF3B30] transition-colors truncate">
+                        <h4 className="text-xs font-bold text-slate-900 dark:text-foreground group-hover:text-[#FF3B30] transition-colors truncate">
                           Tech Quizzes
                         </h4>
-                        <p className="text-[10px] sm:text-[11px] text-slate-500 line-clamp-1">
+                        <p className="text-[10px] sm:text-[11px] text-slate-500 dark:text-muted-foreground line-clamp-1">
                           Topic-wise quizzes &amp; skill assessments.
                         </p>
                       </div>
                     </div>
-                    <FiExternalLink className="w-3.5 h-3.5 text-slate-400 group-hover:text-slate-600 shrink-0 ml-2" />
+                    <FiExternalLink className="w-3.5 h-3.5 text-slate-400 dark:text-muted-foreground group-hover:text-slate-600 dark:text-muted-foreground shrink-0 ml-2" />
                   </a>
 
                   <a
                     href="https://oncampus.theboringeducation.com/aptitude"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="bg-white border border-slate-200/80 rounded-xl p-3 sm:p-3.5 flex items-center justify-between hover:border-slate-300 transition-all cursor-pointer group"
+                    className="bg-white dark:bg-card border border-slate-200/80 dark:border-border rounded-xl p-3 sm:p-3.5 flex items-center justify-between hover:border-slate-300 transition-all cursor-pointer group"
                   >
                     <div className="flex items-center gap-2.5 sm:gap-3 min-w-0">
                       <div className="w-7 h-7 sm:w-8 h-8 rounded-lg bg-emerald-50 text-emerald-600 flex items-center justify-center shrink-0 group-hover:scale-105 transition-transform">
                         <FiBarChart2 className="w-4 h-4" />
                       </div>
                       <div className="min-w-0">
-                        <h4 className="text-xs font-bold text-slate-900 group-hover:text-[#FF3B30] transition-colors truncate">
+                        <h4 className="text-xs font-bold text-slate-900 dark:text-foreground group-hover:text-[#FF3B30] transition-colors truncate">
                           Aptitude Practice
                         </h4>
-                        <p className="text-[10px] sm:text-[11px] text-slate-500 line-clamp-1">
+                        <p className="text-[10px] sm:text-[11px] text-slate-500 dark:text-muted-foreground line-clamp-1">
                           Company mock tests &amp; placement questions.
                         </p>
                       </div>
                     </div>
-                    <FiExternalLink className="w-3.5 h-3.5 text-slate-400 group-hover:text-slate-600 shrink-0 ml-2" />
+                    <FiExternalLink className="w-3.5 h-3.5 text-slate-400 dark:text-muted-foreground group-hover:text-slate-600 dark:text-muted-foreground shrink-0 ml-2" />
                   </a>
 
                   <a
                     href="https://oncampus.theboringeducation.com/coresubjects"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="bg-white border border-slate-200/80 rounded-xl p-3 sm:p-3.5 flex items-center justify-between hover:border-slate-300 transition-all cursor-pointer group sm:col-span-2 lg:col-span-1"
+                    className="bg-white dark:bg-card border border-slate-200/80 dark:border-border rounded-xl p-3 sm:p-3.5 flex items-center justify-between hover:border-slate-300 transition-all cursor-pointer group sm:col-span-2 lg:col-span-1"
                   >
                     <div className="flex items-center gap-2.5 sm:gap-3 min-w-0">
                       <div className="w-7 h-7 sm:w-8 h-8 rounded-lg bg-blue-50 text-blue-600 flex items-center justify-center shrink-0 group-hover:scale-105 transition-transform">
                         <FiBookOpen className="w-4 h-4" />
                       </div>
                       <div className="min-w-0">
-                        <h4 className="text-xs font-bold text-slate-900 group-hover:text-[#FF3B30] transition-colors truncate">
+                        <h4 className="text-xs font-bold text-slate-900 dark:text-foreground group-hover:text-[#FF3B30] transition-colors truncate">
                           Core Subjects
                         </h4>
-                        <p className="text-[10px] sm:text-[11px] text-slate-500 line-clamp-1">
+                        <p className="text-[10px] sm:text-[11px] text-slate-500 dark:text-muted-foreground line-clamp-1">
                           Master OS, DBMS, CN &amp; OOPs for interviews.
                         </p>
                       </div>
                     </div>
-                    <FiExternalLink className="w-3.5 h-3.5 text-slate-400 group-hover:text-slate-600 shrink-0 ml-2" />
+                    <FiExternalLink className="w-3.5 h-3.5 text-slate-400 dark:text-muted-foreground group-hover:text-slate-600 dark:text-muted-foreground shrink-0 ml-2" />
                   </a>
                 </div>
               </section>
@@ -1728,17 +1729,17 @@ export const LearnDashboardContainer: React.FC<
             <div className="space-y-5 sm:space-y-6">
               {/* Header */}
               <div className="space-y-0.5 sm:space-y-1">
-                <h1 className="text-lg sm:text-xl md:text-2xl font-bold text-slate-900 tracking-tight">
+                <h1 className="text-lg sm:text-xl md:text-2xl font-bold text-slate-900 dark:text-foreground tracking-tight">
                   Explore Courses, Sheets &amp; Resources
                 </h1>
-                <p className="text-xs text-slate-500 font-normal">
+                <p className="text-xs text-slate-500 dark:text-muted-foreground font-normal">
                   Master interview questions, college core subjects &amp; full
                   stack engineering.
                 </p>
               </div>
 
               {/* Filters & Search Bar */}
-              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2.5 sm:gap-3 bg-white p-2.5 sm:p-3.5 rounded-2xl border border-slate-200/80 shadow-2xs">
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2.5 sm:gap-3 bg-white dark:bg-card p-2.5 sm:p-3.5 rounded-2xl border border-slate-200/80 dark:border-border shadow-2xs">
                 {/* Category Pills */}
                 <div className="flex items-center gap-1.5 overflow-x-auto pb-1 sm:pb-0 scrollbar-none flex-nowrap">
                   {[
@@ -1754,7 +1755,7 @@ export const LearnDashboardContainer: React.FC<
                       className={`px-2.5 sm:px-3 py-1.5 rounded-xl text-[11px] sm:text-xs font-bold transition-all shrink-0 cursor-pointer ${
                         exploreCategory === tab.id
                           ? "bg-[#FF3B30] text-white shadow-xs"
-                          : "bg-slate-50 text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                          : "bg-slate-50 dark:bg-muted text-slate-600 dark:text-muted-foreground hover:bg-slate-100 dark:hover:bg-muted dark:bg-muted hover:text-slate-900 dark:text-foreground"
                       }`}
                     >
                       {tab.label}
@@ -1764,13 +1765,13 @@ export const LearnDashboardContainer: React.FC<
 
                 {/* Search Input */}
                 <div className="relative w-full sm:w-56 md:w-64 shrink-0">
-                  <FiSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-400 w-3.5 h-3.5 pointer-events-none" />
+                  <FiSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-400 dark:text-muted-foreground w-3.5 h-3.5 pointer-events-none" />
                   <input
                     type="text"
                     placeholder="Search topics, languages..."
                     value={exploreSearchQuery}
                     onChange={(e) => setExploreSearchQuery(e.target.value)}
-                    className="w-full pl-8 pr-3 py-1.5 bg-slate-50 border border-slate-200 rounded-xl text-xs font-medium placeholder:text-slate-400 focus:outline-none focus:bg-white focus:border-[#FF3B30] transition-all"
+                    className="w-full pl-8 pr-3 py-1.5 bg-slate-50 dark:bg-muted border border-slate-200 dark:border-border rounded-xl text-xs font-medium placeholder:text-slate-400 dark:text-muted-foreground focus:outline-none focus:bg-white dark:bg-card focus:border-[#FF3B30] transition-all"
                   />
                 </div>
               </div>
@@ -1851,10 +1852,10 @@ export const LearnDashboardContainer: React.FC<
                   return (
                     <div
                       key={item.id}
-                      className={`bg-white border rounded-2xl flex flex-col shadow-xs hover:shadow-md transition-all group overflow-hidden ${
+                      className={`bg-white dark:bg-card border rounded-2xl flex flex-col shadow-xs hover:shadow-md transition-all group overflow-hidden ${
                         isInProgress
-                          ? "border-slate-200"
-                          : "border-slate-200/80 hover:border-slate-300"
+                          ? "border-slate-200 dark:border-border"
+                          : "border-slate-200/80 dark:border-border hover:border-slate-300"
                       }`}
                     >
                       {/* Full-width top badge strip */}
@@ -1879,12 +1880,12 @@ export const LearnDashboardContainer: React.FC<
                       {/* Title + Description */}
                       <div className="px-3.5 sm:px-5 pt-2 pb-3.5 sm:pb-4 flex-1 flex flex-col gap-1.5 sm:gap-2">
                         <h3
-                          className="text-sm sm:text-[15px] font-bold text-slate-900 leading-snug"
+                          className="text-sm sm:text-[15px] font-bold text-slate-900 dark:text-foreground leading-snug"
                           title={item.title}
                         >
                           {item.title}
                         </h3>
-                        <p className="text-xs text-slate-500 leading-relaxed line-clamp-3 sm:line-clamp-none">
+                        <p className="text-xs text-slate-500 dark:text-muted-foreground leading-relaxed line-clamp-3 sm:line-clamp-none">
                           {item.desc}
                         </p>
 
@@ -1893,13 +1894,13 @@ export const LearnDashboardContainer: React.FC<
                           {isInProgress ? (
                             <div className="space-y-1.5">
                               {/* Thin colored bar */}
-                              <div className="w-full bg-slate-100 rounded-full h-1 overflow-hidden">
+                              <div className="w-full bg-slate-100 dark:bg-muted rounded-full h-1 overflow-hidden">
                                 <div
                                   className="h-1 rounded-full bg-[#FF3B30]"
                                   style={{ width: `${progressPercentage}%` }}
                                 />
                               </div>
-                              <div className="flex items-center justify-between text-[10px] sm:text-[11px] text-slate-500">
+                              <div className="flex items-center justify-between text-[10px] sm:text-[11px] text-slate-500 dark:text-muted-foreground">
                                 <span className="font-bold text-slate-700">
                                   {progressPercentage}% Solved
                                 </span>
@@ -1910,7 +1911,7 @@ export const LearnDashboardContainer: React.FC<
                             </div>
                           ) : (
                             /* Gray pill */
-                            <div className="inline-flex items-center gap-1.5 px-2.5 sm:px-3 py-1 sm:py-1.5 bg-slate-50 border border-slate-200 rounded-lg text-[10px] sm:text-[11px] font-semibold text-slate-500">
+                            <div className="inline-flex items-center gap-1.5 px-2.5 sm:px-3 py-1 sm:py-1.5 bg-slate-50 dark:bg-muted border border-slate-200 dark:border-border rounded-lg text-[10px] sm:text-[11px] font-semibold text-slate-500 dark:text-muted-foreground">
                               <FiCheckCircle className="w-3.5 h-3.5 text-emerald-500 shrink-0" />
                               {item.type === "core-subject"
                                 ? "Core CS Subject"
@@ -1926,7 +1927,7 @@ export const LearnDashboardContainer: React.FC<
 
                       {/* Footer */}
                       <div className="px-3.5 sm:px-5 py-2.5 sm:py-3 border-t border-slate-100 flex items-center justify-between text-[11px]">
-                        <span className="flex items-center gap-1.5 text-slate-400 font-medium">
+                        <span className="flex items-center gap-1.5 text-slate-400 dark:text-muted-foreground font-medium">
                           {item.type === "course" ? (
                             <FiPlayCircle className="w-3.5 h-3.5" />
                           ) : (
@@ -1970,7 +1971,7 @@ export const LearnDashboardContainer: React.FC<
             /* My Learning Tab */
             <div className="space-y-4 sm:space-y-5">
               <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-1 sm:gap-2 border-b border-slate-100 pb-2.5">
-                <h2 className="text-sm sm:text-base font-extrabold text-slate-900 tracking-tight">
+                <h2 className="text-sm sm:text-base font-extrabold text-slate-900 dark:text-foreground tracking-tight">
                   My Active Learning
                 </h2>
                 <Link
@@ -1983,7 +1984,7 @@ export const LearnDashboardContainer: React.FC<
 
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4">
                 {loadingLearning ? (
-                  <div className="col-span-full py-12 flex items-center justify-center text-xs font-bold text-slate-400">
+                  <div className="col-span-full py-12 flex items-center justify-center text-xs font-bold text-slate-400 dark:text-muted-foreground">
                     Loading your enrolled sheets...
                   </div>
                 ) : activeSheetsWithProgress &&
@@ -2041,7 +2042,7 @@ export const LearnDashboardContainer: React.FC<
                     return (
                       <div
                         key={sheet.slug || sheet._id || index}
-                        className="bg-white border border-slate-200/80 hover:border-slate-300 hover:shadow-md transition-all rounded-2xl overflow-hidden flex flex-col justify-between group"
+                        className="bg-white dark:bg-card border border-slate-200/80 dark:border-border hover:border-slate-300 hover:shadow-md transition-all rounded-2xl overflow-hidden flex flex-col justify-between group"
                       >
                         {/* Top border badge strip */}
                         <div
@@ -2064,22 +2065,22 @@ export const LearnDashboardContainer: React.FC<
                                   <FiFileText className="w-7 h-7 sm:w-8 h-8 text-[#FF3B30] shrink-0" />
                                 )}
                                 <div className="min-w-0">
-                                  <h3 className="text-xs sm:text-sm md:text-[15px] font-extrabold text-slate-900 leading-snug truncate group-hover:text-[#FF3B30] transition-colors">
+                                  <h3 className="text-xs sm:text-sm md:text-[15px] font-extrabold text-slate-900 dark:text-foreground leading-snug truncate group-hover:text-[#FF3B30] transition-colors">
                                     {sheet.title}
                                   </h3>
                                 </div>
                               </div>
                               <div className="shrink-0 text-right">
-                                <span className="text-xs font-black text-slate-900">
+                                <span className="text-xs font-black text-slate-900 dark:text-foreground">
                                   {progressPercentage}%
                                 </span>
-                                <div className="text-[9px] font-bold text-slate-400">
+                                <div className="text-[9px] font-bold text-slate-400 dark:text-muted-foreground">
                                   Solved
                                 </div>
                               </div>
                             </div>
 
-                            <p className="text-xs text-slate-500 leading-relaxed font-medium line-clamp-2 mt-2 sm:mt-3">
+                            <p className="text-xs text-slate-500 dark:text-muted-foreground leading-relaxed font-medium line-clamp-2 mt-2 sm:mt-3">
                               {sheet.description ||
                                 "Curated list of topic-wise interview preparation problems."}
                             </p>
@@ -2087,13 +2088,13 @@ export const LearnDashboardContainer: React.FC<
 
                           <div className="mt-3.5 sm:mt-4 pt-3 sm:pt-3.5 border-t border-slate-100 space-y-2.5 sm:space-y-3">
                             <div className="space-y-1.5">
-                              <div className="w-full bg-slate-100 rounded-full h-1.5 overflow-hidden">
+                              <div className="w-full bg-slate-100 dark:bg-muted rounded-full h-1.5 overflow-hidden">
                                 <div
                                   className={`${progressColor} h-1.5 rounded-full`}
                                   style={{ width: `${progressPercentage}%` }}
                                 />
                               </div>
-                              <div className="flex items-center justify-between text-[10px] sm:text-[11px] text-slate-400 font-semibold">
+                              <div className="flex items-center justify-between text-[10px] sm:text-[11px] text-slate-400 dark:text-muted-foreground font-semibold">
                                 <span>
                                   {completedCount} / {totalCount} Problems
                                   Solved
@@ -2143,7 +2144,7 @@ export const LearnDashboardContainer: React.FC<
                     return (
                       <div
                         key={course.slug || course._id || index}
-                        className="bg-white border border-slate-200/80 hover:border-[#FF3B30]/30 hover:shadow-md transition-all rounded-2xl overflow-hidden flex flex-col justify-between group"
+                        className="bg-white dark:bg-card border border-slate-200/80 dark:border-border hover:border-[#FF3B30]/30 hover:shadow-md transition-all rounded-2xl overflow-hidden flex flex-col justify-between group"
                       >
                         <div className="px-3 sm:px-3.5 py-1.5 text-[10px] font-extrabold tracking-wider uppercase bg-[#FF3B30] text-white">
                           SHIKSHA COURSE
@@ -2161,20 +2162,20 @@ export const LearnDashboardContainer: React.FC<
                                 ) : (
                                   <FiPlayCircle className="w-7 h-7 sm:w-8 h-8 text-[#FF3B30] shrink-0" />
                                 )}
-                                <h3 className="text-xs sm:text-sm md:text-[15px] font-extrabold text-slate-900 leading-snug truncate group-hover:text-[#FF3B30] transition-colors">
+                                <h3 className="text-xs sm:text-sm md:text-[15px] font-extrabold text-slate-900 dark:text-foreground leading-snug truncate group-hover:text-[#FF3B30] transition-colors">
                                   {course.title}
                                 </h3>
                               </div>
                               <div className="shrink-0 text-right">
-                                <span className="text-xs font-black text-slate-900">
+                                <span className="text-xs font-black text-slate-900 dark:text-foreground">
                                   {progressPct}%
                                 </span>
-                                <div className="text-[9px] font-bold text-slate-400">
+                                <div className="text-[9px] font-bold text-slate-400 dark:text-muted-foreground">
                                   Done
                                 </div>
                               </div>
                             </div>
-                            <p className="text-xs text-slate-500 leading-relaxed font-medium line-clamp-2 mt-2 sm:mt-3">
+                            <p className="text-xs text-slate-500 dark:text-muted-foreground leading-relaxed font-medium line-clamp-2 mt-2 sm:mt-3">
                               {course.description ||
                                 courseDef?.desc ||
                                 "Full-stack course on Shiksha."}
@@ -2182,13 +2183,13 @@ export const LearnDashboardContainer: React.FC<
                           </div>
                           <div className="mt-3.5 sm:mt-4 pt-3 sm:pt-3.5 border-t border-slate-100 space-y-2.5 sm:space-y-3">
                             <div className="space-y-1.5">
-                              <div className="w-full bg-slate-100 rounded-full h-1.5 overflow-hidden">
+                              <div className="w-full bg-slate-100 dark:bg-muted rounded-full h-1.5 overflow-hidden">
                                 <div
                                   className="bg-[#FF3B30] h-1.5 rounded-full"
                                   style={{ width: `${progressPct}%` }}
                                 />
                               </div>
-                              <div className="flex items-center justify-between text-[10px] sm:text-[11px] text-slate-400 font-semibold">
+                              <div className="flex items-center justify-between text-[10px] sm:text-[11px] text-slate-400 dark:text-muted-foreground font-semibold">
                                 <span>
                                   {completedChapters} / {totalChapters} Chapters
                                   Done
@@ -2217,14 +2218,14 @@ export const LearnDashboardContainer: React.FC<
                   (!activeSheetsWithProgress ||
                     activeSheetsWithProgress.length === 0) &&
                   (!enrolledCourses || enrolledCourses.length === 0) && (
-                    <div className="col-span-full py-8 bg-white border border-slate-200/80 rounded-2xl flex flex-col items-center justify-center text-center space-y-2 p-4 sm:p-6">
-                      <div className="w-10 h-10 rounded-xl bg-slate-50 border border-slate-100 flex items-center justify-center text-slate-400">
+                    <div className="col-span-full py-8 bg-white dark:bg-card border border-slate-200/80 dark:border-border rounded-2xl flex flex-col items-center justify-center text-center space-y-2 p-4 sm:p-6">
+                      <div className="w-10 h-10 rounded-xl bg-slate-50 dark:bg-muted border border-slate-100 flex items-center justify-center text-slate-400 dark:text-muted-foreground">
                         <FiBookOpen className="w-5 h-5" />
                       </div>
                       <span className="text-xs font-bold text-slate-700">
                         No active learning in progress yet
                       </span>
-                      <p className="text-[11px] text-slate-400 max-w-sm">
+                      <p className="text-[11px] text-slate-400 dark:text-muted-foreground max-w-sm">
                         Start solving questions in any interview sheet or course
                         to track your progress here.
                       </p>

--- a/packages/components/src/profile/UnifiedProfilePage.tsx
+++ b/packages/components/src/profile/UnifiedProfilePage.tsx
@@ -14,6 +14,7 @@ import { sendRequest } from "@tbe/utils";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
 
+import { useColorTheme, useHasThemeProvider } from "../common/Theme";
 import Toast from "../common/Toast";
 import Navbar from "../layout/Navbar";
 import SEO from "../layout/SEO";
@@ -52,9 +53,12 @@ export const UnifiedProfilePage: React.FC<UnifiedProfilePageProps> = ({
   const queryClient = useQueryClient();
   const { signOut } = useAuth();
   const { user, isAuth, loading: loadingUser, updateSession } = useUser();
+  const hasThemeProvider = useHasThemeProvider();
+  const colorTheme = useColorTheme();
 
-  const isDark =
-    theme !== undefined
+  const isDark = hasThemeProvider
+    ? colorTheme === "dark"
+    : theme !== undefined
       ? theme === "dark"
       : navbarVariant === "dsayatra" || navbarVariant === "oncampus";
 

--- a/packages/constants/src/component.tsx
+++ b/packages/constants/src/component.tsx
@@ -48,7 +48,7 @@ const socialLinks = [
 const productLinks = [
   {
     name: "The Boring Education",
-    href: "https://www.theboringeducation.com/",
+    href: toPlatformUrl("/"),
   },
 ];
 
@@ -66,7 +66,7 @@ const links: NavbarDropdownLink[] = [
   {
     id: "explore-courses",
     name: "Explore Courses",
-    href: "https://www.theboringeducation.com/shiksha",
+    href: toPlatformUrl(routes.shiksha),
     description: "Learn Tech with Courses",
   },
   {
@@ -341,7 +341,7 @@ export const getFooterVariantConfig = (
   Logo: ComponentType<any>,
 ): Record<string, FooterVariantConfig> => ({
   default: {
-    branding: <Logo />,
+    branding: <Logo isDark />,
     subtitle:
       "Making tech education accessible for everyone. Learn, build, and grow with our comprehensive platform designed for students and professionals.",
   },

--- a/packages/interface/src/Components.ts
+++ b/packages/interface/src/Components.ts
@@ -1284,3 +1284,23 @@ export interface PatternQuizBannerProps {
   className?: string;
   compact?: boolean;
 }
+
+export interface ThemeProviderProps {
+  /** App tree that should receive theme context */
+  children: ReactNode;
+  /** Initial theme before user preference is read. Defaults to `"light"`. */
+  defaultTheme?: "light" | "dark";
+  /** Persist preference and apply as `class` on `<html>`. */
+  attribute?: "class" | "data-theme";
+  /** Whether to follow OS preference. Defaults to `false` for light-first apps. */
+  enableSystem?: boolean;
+  /** Disable CSS transitions while theme is applying */
+  disableTransitionOnChange?: boolean;
+}
+
+export interface ThemeToggleProps {
+  /** Extra classes for the toggle control */
+  className?: string;
+  /** Visual style when the shell is dark-themed */
+  theme?: "light" | "dark";
+}


### PR DESCRIPTION
Closes #1234

## What this does
Adds a dark/light mode toggle to the platform site. Preference is saved and sticks when you move between pages.

## Changes
- Shared `ThemeProvider` + navbar toggle in `@tbe/components` (via `next-themes`)
- Wired into platform `_app`, Tailwind `class` dark mode, and CSS variables
- Toggle shows across normal pages, profile, learning layouts, and login/checkout
- Updated key surfaces (home, learn dashboard, course/sheet content, etc.) so they follow the theme
- Platform-internal nav links use `toPlatformUrl` so local env doesn’t bounce you to production

## How to test
1. Copy `apps/platform/.env.example` → `.env.local` (or keep the local one you already have)
2. `pnpm --filter @tbe/platform dev`
3. Hard refresh `http://localhost:3000`
4. Hit the sun/moon control in the navbar
5. Open `/shiksha`, `/interview-prep`, `/learn`, `/profile` and confirm theme + toggle still work
6. Refresh once — preference should stick

## Notes
- Only platform is wrapped with `ThemeProvider`; other apps keep their existing fixed themes
- Some product cards still link to live satellite apps (DSA Yatra, PrepYatra, etc.) unless those apps are running locally too