### PR TITLE
fix: consolidate USER_LEVELS to single source in @tbe/constants

### DIFF
--- a/apps/quizes/src/contexts/GamificationContext.tsx
+++ b/apps/quizes/src/contexts/GamificationContext.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { USER_LEVELS } from "@tbe/constants";
 import { gamificationApi } from "@tbe/services";
 import React, {
   createContext,
@@ -8,20 +9,6 @@ import React, {
   useEffect,
   useState,
 } from "react";
-
-// User levels configuration
-const USER_LEVELS = [
-  { name: "Noob", value: "NOOB", minPoints: 0, level: 1 },
-  { name: "Coder", value: "CODER", minPoints: 500, level: 2 },
-  { name: "Debugger", value: "DEBUGGER", minPoints: 1000, level: 3 },
-  { name: "Ninja", value: "NINJA", minPoints: 2000, level: 4 },
-  { name: "Squasher", value: "SQUASHER", minPoints: 3000, level: 5 },
-  { name: "Hacker", value: "HACKER", minPoints: 4500, level: 6 },
-  { name: "Wizard", value: "WIZARD", minPoints: 6000, level: 7 },
-  { name: "Guru", value: "GURU", minPoints: 7500, level: 8 },
-  { name: "Architect", value: "ARCHITECT", minPoints: 9000, level: 9 },
-  { name: "Legend", value: "LEGEND", minPoints: 10000, level: 10 },
-];
 
 interface GamificationContextType {
   points: number;

--- a/packages/components/src/quizes/GamificationCard.tsx
+++ b/packages/components/src/quizes/GamificationCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { USER_LEVELS } from "@tbe/constants";
+
 import { useGamificationContext } from "./context/GamificationContext";
 
 interface GamificationCardProps {
@@ -7,20 +9,6 @@ interface GamificationCardProps {
   onClose: () => void;
   variant?: "popup" | "dashboard";
 }
-
-// User levels configuration
-const USER_LEVELS = [
-  { name: "Noob", value: "NOOB", minPoints: 0, level: 1 },
-  { name: "Coder", value: "CODER", minPoints: 500, level: 2 },
-  { name: "Debugger", value: "DEBUGGER", minPoints: 1000, level: 3 },
-  { name: "Ninja", value: "NINJA", minPoints: 2000, level: 4 },
-  { name: "Squasher", value: "SQUASHER", minPoints: 3000, level: 5 },
-  { name: "Hacker", value: "HACKER", minPoints: 4500, level: 6 },
-  { name: "Wizard", value: "WIZARD", minPoints: 6000, level: 7 },
-  { name: "Guru", value: "GURU", minPoints: 7500, level: 8 },
-  { name: "Architect", value: "ARCHITECT", minPoints: 9000, level: 9 },
-  { name: "Legend", value: "LEGEND", minPoints: 10000, level: 10 },
-];
 
 export function GamificationCard({
   isOpen,

--- a/packages/components/src/quizes/context/GamificationContext.tsx
+++ b/packages/components/src/quizes/context/GamificationContext.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { USER_LEVELS } from "@tbe/constants";
 import { gamificationApi } from "@tbe/services";
 import React, {
   createContext,
@@ -8,20 +9,6 @@ import React, {
   useEffect,
   useState,
 } from "react";
-
-// User levels configuration
-const USER_LEVELS = [
-  { name: "Noob", value: "NOOB", minPoints: 0, level: 1 },
-  { name: "Coder", value: "CODER", minPoints: 500, level: 2 },
-  { name: "Debugger", value: "DEBUGGER", minPoints: 1000, level: 3 },
-  { name: "Ninja", value: "NINJA", minPoints: 2000, level: 4 },
-  { name: "Squasher", value: "SQUASHER", minPoints: 3000, level: 5 },
-  { name: "Hacker", value: "HACKER", minPoints: 4500, level: 6 },
-  { name: "Wizard", value: "WIZARD", minPoints: 6000, level: 7 },
-  { name: "Guru", value: "GURU", minPoints: 7500, level: 8 },
-  { name: "Architect", value: "ARCHITECT", minPoints: 9000, level: 9 },
-  { name: "Legend", value: "LEGEND", minPoints: 10000, level: 10 },
-];
 
 interface GamificationContextType {
   points: number;


### PR DESCRIPTION
Fixes #1108

Removes duplicate `USER_LEVELS` definitions from quiz gamification files and imports from `@tbe/constants` (canonical source: `packages/constants/src/global.ts`).

## Files changed
- `packages/components/src/quizes/context/GamificationContext.tsx`
- `packages/components/src/quizes/GamificationCard.tsx`
- `apps/quizes/src/contexts/GamificationContext.tsx`

No behavior change — refactor only.